### PR TITLE
[SQL-Gen] Isolate whitespace interpolation to one function

### DIFF
--- a/src/main/scala/temple/generate/database/PostgresGenerator.scala
+++ b/src/main/scala/temple/generate/database/PostgresGenerator.scala
@@ -6,6 +6,7 @@ import temple.generate.database.ast.Comparison._
 import temple.generate.database.ast.Statement._
 import temple.generate.database.ast._
 import temple.utils.StringUtils._
+import scala.util.chaining._
 
 /** Implementation of [[DatabaseGenerator]] for generating PostgreSQL */
 object PostgresGenerator extends DatabaseGenerator {
@@ -32,8 +33,8 @@ object PostgresGenerator extends DatabaseGenerator {
       case References(table, colName) => s"REFERENCES $table($colName)"
     }
 
-  @inline private def generateColumnConstraints(constraints: List[ColumnConstraint]): String =
-    constraints.map(generateConstraint).map(" " + _).mkString
+  @inline private def generateColumnConstraints(constraints: List[ColumnConstraint]): List[String] =
+    constraints.map(generateConstraint)
 
   /** Given a column type, parse it into the type required by PostgreSQL */
   private def generateColumnType(columnType: ColType): String =
@@ -48,24 +49,26 @@ object PostgresGenerator extends DatabaseGenerator {
     }
 
   /** Parse a given column into PostgreSQL syntax */
-  private def generateColumnDef(column: ColumnDef) =
-    indent(s"${column.name} ${generateColumnType(column.colType)}${generateColumnConstraints(column.constraints)}")
+  private def generateColumnDef(column: ColumnDef): List[String] = {
+    val columnConstraints = generateColumnConstraints(column.constraints)
+    List(column.name, generateColumnType(column.colType)) concat columnConstraints
+  }
 
   /** Given a statement, parse it into a valid PostgreSQL statement */
-  override def generate(statement: Statement): String = {
-    val sb = new StringBuilder()
+  override def generate(statement: Statement): String =
     statement match {
       case Create(tableName, columns) =>
-        sb.append(s"CREATE TABLE $tableName ")
-        val stringColumns = columns.map(generateColumnDef)
-        sb.append(stringColumns.mkString("(\n", ",\n", "\n)"))
+        val stringColumns =
+          columns
+            .map(generateColumnDef)
+            .foldLeft(List[String]()) { (acc, elem) =>
+              acc :+ elem.mkString(" ")
+            }
+            .mkString(",\n")
+            .pipe(indent(_))
+        s"CREATE TABLE $tableName (\n$stringColumns\n);\n"
       case Read(tableName, columns) =>
-        sb.append("SELECT ")
-        val stringColumns = columns.map(_.name)
-        sb.append(stringColumns.mkString(", "))
-        sb.append(s" FROM $tableName")
+        val stringColumns = columns.map(_.name).mkString(", ")
+        s"SELECT $stringColumns FROM $tableName;\n"
     }
-    sb.append(";\n")
-    sb.mkString
-  }
 }

--- a/src/main/scala/temple/generate/database/PostgresGenerator.scala
+++ b/src/main/scala/temple/generate/database/PostgresGenerator.scala
@@ -60,9 +60,9 @@ object PostgresGenerator extends DatabaseGenerator {
             .map(generateColumnDef)
             .mkString(",\n")
             .pipe(indent(_))
-        s"CREATE TABLE $tableName (\n$stringColumns\n);\n"
+        s"CREATE TABLE $tableName (\n$stringColumns\n);"
       case Read(tableName, columns) =>
         val stringColumns = columns.map(_.name).mkString(", ")
-        s"SELECT $stringColumns FROM $tableName;\n"
+        s"SELECT $stringColumns FROM $tableName;"
     }
 }

--- a/src/test/scala/temple/generate/database/PostgresGeneratorTest.scala
+++ b/src/test/scala/temple/generate/database/PostgresGeneratorTest.scala
@@ -1,6 +1,5 @@
 package temple.generate.database
 
-import generate.database.TestData
 import org.scalatest.{FlatSpec, Matchers}
 
 class PostgresGeneratorTest extends FlatSpec with Matchers {

--- a/src/test/scala/temple/generate/database/package.scala
+++ b/src/test/scala/temple/generate/database/package.scala
@@ -1,4 +1,4 @@
-package generate
+package temple.generate
 
 import temple.generate.database.ast.ColType._
 import temple.generate.database.ast.ColumnConstraint._
@@ -33,8 +33,7 @@ package object database {
         |  dateOfBirth DATE,
         |  timeOfDay TIME,
         |  expiry TIMESTAMPTZ
-        |);
-        |""".stripMargin
+        |);""".stripMargin
 
     val createStatementWithConstraints = Create(
       "Test",
@@ -52,8 +51,7 @@ package object database {
         |  createdAt TIMESTAMPTZ UNIQUE,
         |  bookingTime TIME REFERENCES Bookings(bookingTime),
         |  value INT CHECK (value >= 1) NULL
-        |);
-        |""".stripMargin
+        |);""".stripMargin
 
     val readStatement = Read(
       "Users",
@@ -69,7 +67,6 @@ package object database {
     )
 
     val postgresSelectString: String =
-      """SELECT id, bankBalance, name, isStudent, dateOfBirth, timeOfDay, expiry FROM Users;
-        |""".stripMargin
+      """SELECT id, bankBalance, name, isStudent, dateOfBirth, timeOfDay, expiry FROM Users;""".stripMargin
   }
 }


### PR DESCRIPTION
Rather than adding white space in each individual generator, make them return lists of items and perform the interpolation in one single place for all queries. 

Should hopefully make it easier to add unit tests without depending too much on the formatting