### PR TITLE
[cli] Add base CLI args parser

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,3 +6,4 @@ scalaVersion := "2.13.1"
 
 libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.8" % "test"
+libraryDependencies += "org.rogach" %% "scallop" % "3.3.2"

--- a/src/main/scala/temple/Main.scala
+++ b/src/main/scala/temple/Main.scala
@@ -3,11 +3,13 @@ package temple
 import temple.DSL.DSLProcessor
 import temple.utils.FileUtils
 
+/** Main entry point into the application */
 object Main extends App {
   val config = new TempleConfig(args)
   config.subcommand match {
     case Some(config.generate) => generate(config)
-    case _                     => config.printHelp()
+    case Some(_)               => throw new TempleConfig.UnhandledArgumentException
+    case None                  => config.printHelp()
   }
 
   def generate(config: TempleConfig): Unit = {

--- a/src/main/scala/temple/Main.scala
+++ b/src/main/scala/temple/Main.scala
@@ -13,10 +13,9 @@ object Main extends App {
       case None                  => config.printHelp()
     }
   } catch {
-    case error: IllegalArgumentException => {
+    case error: IllegalArgumentException =>
       System.err.println(error.getMessage)
       sys.exit(1)
-    }
   }
 
   def generate(config: TempleConfig): Unit = {

--- a/src/main/scala/temple/Main.scala
+++ b/src/main/scala/temple/Main.scala
@@ -5,11 +5,18 @@ import temple.utils.FileUtils
 
 /** Main entry point into the application */
 object Main extends App {
-  val config = new TempleConfig(args)
-  config.subcommand match {
-    case Some(config.generate) => generate(config)
-    case Some(_)               => throw new TempleConfig.UnhandledArgumentException
-    case None                  => config.printHelp()
+  try {
+    val config = new TempleConfig(args)
+    config.subcommand match {
+      case Some(config.generate) => generate(config)
+      case Some(_)               => throw new TempleConfig.UnhandledArgumentException
+      case None                  => config.printHelp()
+    }
+  } catch {
+    case error: IllegalArgumentException => {
+      System.err.println(error.getMessage)
+      sys.exit(1)
+    }
   }
 
   def generate(config: TempleConfig): Unit = {

--- a/src/main/scala/temple/Main.scala
+++ b/src/main/scala/temple/Main.scala
@@ -1,3 +1,18 @@
 package temple
 
-object Main extends App {}
+import temple.DSL.DSLProcessor
+import temple.utils.FileUtils
+
+object Main extends App {
+  val config = new TempleConfig(args)
+  config.subcommand match {
+    case Some(config.generate) => generate(config)
+    case _                     => config.printHelp()
+  }
+
+  def generate(config: TempleConfig): Unit = {
+    val fileContents = FileUtils.readFile(config.generate.filename())
+    val result       = DSLProcessor.parse(fileContents)
+    println(s"Generated... ${result}")
+  }
+}

--- a/src/main/scala/temple/TempleConfig.scala
+++ b/src/main/scala/temple/TempleConfig.scala
@@ -11,7 +11,7 @@ class TempleConfig(arguments: Seq[String]) extends ScallopConf(arguments) {
   shortSubcommandsHelp(true)
 
   val generate = new Subcommand("generate") {
-    var filename = trailArg[String]("filenames", "Templefiles to generate from")
+    var filename = trailArg[String]("filename", "Templefile to generate from")
   }
   addSubcommand(generate)
   verify()

--- a/src/main/scala/temple/TempleConfig.scala
+++ b/src/main/scala/temple/TempleConfig.scala
@@ -2,6 +2,7 @@ package temple
 
 import org.rogach.scallop.{ScallopConf, ScallopOption, Subcommand}
 
+/** TempleConfig produces the application configuration from command line arguments */
 class TempleConfig(arguments: Seq[String]) extends ScallopConf(arguments) {
   version("temple 0.1 (c) 2020 TempleEight")
   banner("Usage:\ttemple [OPTIONS] SUBCOMMAND")
@@ -15,4 +16,8 @@ class TempleConfig(arguments: Seq[String]) extends ScallopConf(arguments) {
   }
   addSubcommand(generate)
   verify()
+}
+
+object TempleConfig {
+  class UnhandledArgumentException extends RuntimeException
 }

--- a/src/main/scala/temple/TempleConfig.scala
+++ b/src/main/scala/temple/TempleConfig.scala
@@ -1,0 +1,18 @@
+package temple
+
+import org.rogach.scallop.{ScallopConf, ScallopOption, Subcommand}
+
+class TempleConfig(arguments: Seq[String]) extends ScallopConf(arguments) {
+  version("temple 0.1 (c) 2020 TempleEight")
+  banner("Usage:\ttemple [OPTIONS] SUBCOMMAND")
+  footer("Run 'temple SUBCOMMAND --help' for more information on a command.")
+
+  // Simplify output at the top level
+  shortSubcommandsHelp(true)
+
+  val generate = new Subcommand("generate") {
+    var filename = trailArg[String]("filenames", "Templefiles to generate from")
+  }
+  addSubcommand(generate)
+  verify()
+}

--- a/src/main/scala/temple/TempleConfig.scala
+++ b/src/main/scala/temple/TempleConfig.scala
@@ -4,6 +4,10 @@ import org.rogach.scallop.{ScallopConf, ScallopOption, Subcommand}
 
 /** TempleConfig produces the application configuration from command line arguments */
 class TempleConfig(arguments: Seq[String]) extends ScallopConf(arguments) {
+  errorMessageHandler = { error =>
+    throw new IllegalArgumentException(error)
+  }
+
   version("temple 0.1 (c) 2020 TempleEight")
   banner("Usage:\ttemple [OPTIONS] SUBCOMMAND")
   footer("Run 'temple SUBCOMMAND --help' for more information on a command.")

--- a/src/test/scala/temple/TempleConfigTest.scala
+++ b/src/test/scala/temple/TempleConfigTest.scala
@@ -1,0 +1,29 @@
+package temple
+
+import org.scalatest.{FlatSpec, Matchers}
+import org.rogach.scallop.ScallopOption
+
+class TempleConfigTest extends FlatSpec with Matchers {
+  "Generate" should "not correctly parse without a filename" in {
+    a[RuntimeException] should be thrownBy new TempleConfig(List("generate"))
+  }
+
+  "Generate" should "correctly parse with a filename" in {
+    val config = new TempleConfig(List("generate", "foo.temple"))
+    config.subcommand shouldBe Some(config.generate)
+    config.generate.filename.toOption shouldBe Some("foo.temple")
+  }
+
+  "Empty arguments" should "have no sub commands" in {
+    val config = new TempleConfig(List())
+    config.subcommand shouldBe None
+  }
+
+  "Unknown subcommand" should "throw an exception" in {
+    an[IllegalArgumentException] should be thrownBy new TempleConfig(List("foobarbaz"))
+  }
+
+  "Unknown flag" should "throw an exception" in {
+    an[IllegalArgumentException] should be thrownBy new TempleConfig(List("-z"))
+  }
+}


### PR DESCRIPTION
- Add base CLI args parser for `generate`
- Process generate requests by reading file and passing through parser - imagine this will change once we have some semantics attached to the AST