### PR TITLE
[SQL-Gen] Add simple delete statement gen

### DIFF
--- a/src/main/scala/temple/generate/database/PostgresGenerator.scala
+++ b/src/main/scala/temple/generate/database/PostgresGenerator.scala
@@ -85,5 +85,11 @@ object PostgresGenerator extends DatabaseGenerator {
         val stringColumns = columns.map(_.name).mkString(", ")
         val values        = (1 to columns.length).map(i => s"$$$i").mkString(", ")
         s"INSERT INTO $tableName ($stringColumns)\nVALUES ($values);"
+      case Delete(tableName, condition) =>
+        val stringCondition = condition.map(generateCondition) match {
+          case Some(conditionString) => List(s"WHERE $conditionString")
+          case None                  => List()
+        }
+        (s"DELETE FROM $tableName" +: stringCondition).mkString("", " ", ";")
     }
 }

--- a/src/main/scala/temple/generate/database/PostgresGenerator.scala
+++ b/src/main/scala/temple/generate/database/PostgresGenerator.scala
@@ -74,22 +74,22 @@ object PostgresGenerator extends DatabaseGenerator {
             .mkString(",\n")
             .pipe(indent(_))
         s"CREATE TABLE $tableName (\n$stringColumns\n);"
-      case Read(tableName, columns, condition) =>
+      case Read(tableName, columns, conditions) =>
         val stringColumns = columns.map(_.name).mkString(", ")
-        val stringCondition = condition.map(generateCondition) match {
-          case Some(conditionString) => List(s"WHERE $conditionString")
-          case None                  => List()
+        val stringConditions = conditions.map(generateCondition) match {
+          case Some(conditionsString) => List(s"WHERE $conditionsString")
+          case None                   => List()
         }
-        (s"SELECT $stringColumns FROM $tableName" +: stringCondition).mkString("", " ", ";")
+        (s"SELECT $stringColumns FROM $tableName" +: stringConditions).mkString("", " ", ";")
       case Insert(tableName, columns) =>
         val stringColumns = columns.map(_.name).mkString(", ")
         val values        = (1 to columns.length).map(i => s"$$$i").mkString(", ")
         s"INSERT INTO $tableName ($stringColumns)\nVALUES ($values);"
-      case Delete(tableName, condition) =>
-        val stringCondition = condition.map(generateCondition) match {
-          case Some(conditionString) => List(s"WHERE $conditionString")
-          case None                  => List()
+      case Delete(tableName, conditions) =>
+        val stringConditions = conditions.map(generateCondition) match {
+          case Some(conditionsString) => List(s"WHERE $conditionsString")
+          case None                   => List()
         }
-        (s"DELETE FROM $tableName" +: stringCondition).mkString("", " ", ";")
+        (s"DELETE FROM $tableName" +: stringConditions).mkString("", " ", ";")
     }
 }

--- a/src/main/scala/temple/generate/database/ast/Statement.scala
+++ b/src/main/scala/temple/generate/database/ast/Statement.scala
@@ -7,4 +7,5 @@ object Statement {
   case class Create(tableName: String, columns: List[ColumnDef])                                 extends Statement
   case class Read(tableName: String, columns: List[Column], condition: Option[Condition] = None) extends Statement
   case class Insert(tableName: String, columns: List[Column])                                    extends Statement
+  case class Delete(tableName: String, condition: Option[Condition] = None)                      extends Statement
 }

--- a/src/test/scala/temple/generate/database/PostgresGeneratorTest.scala
+++ b/src/test/scala/temple/generate/database/PostgresGeneratorTest.scala
@@ -28,4 +28,7 @@ class PostgresGeneratorTest extends FlatSpec with Matchers {
   "PostgresGenerator" should "handle inverse in WHERE correctly" in {
     PostgresGenerator.generate(TestData.readStatementWithWhereInverse) shouldBe TestData.postgresSelectStringWithWhereInverse
   }
+  "PostgresGenerator" should "generate correct DELETE statements" in {
+    PostgresGenerator.generate(TestData.deleteStatement) shouldBe TestData.postgresDeleteString
+  }
 }

--- a/src/test/scala/temple/generate/database/PostgresGeneratorTest.scala
+++ b/src/test/scala/temple/generate/database/PostgresGeneratorTest.scala
@@ -31,4 +31,7 @@ class PostgresGeneratorTest extends FlatSpec with Matchers {
   "PostgresGenerator" should "generate correct DELETE statements" in {
     PostgresGenerator.generate(TestData.deleteStatement) shouldBe TestData.postgresDeleteString
   }
+  "PostgresGenerator" should "handle deletes with WHERE correctly" in {
+    PostgresGenerator.generate(TestData.deleteStatementWithWhere) shouldBe TestData.postgresDeleteStringWithWhere
+  }
 }

--- a/src/test/scala/temple/generate/database/package.scala
+++ b/src/test/scala/temple/generate/database/package.scala
@@ -185,7 +185,7 @@ package object database {
       )
     )
 
-    val deleteStringWithWhere: String =
+    val postgresDeleteStringWithWhere: String =
       """DELETE FROM Users WHERE Users.id = 123456;"""
   }
 }

--- a/src/test/scala/temple/generate/database/package.scala
+++ b/src/test/scala/temple/generate/database/package.scala
@@ -170,5 +170,22 @@ package object database {
     val postgresInsertString: String =
       """INSERT INTO Users (id, bankBalance, name, isStudent, dateOfBirth, timeOfDay, expiry)
         |VALUES ($1, $2, $3, $4, $5, $6, $7);""".stripMargin
+
+    val deleteStatement = Delete(
+      "Users"
+    )
+
+    val postgresDeleteString: String =
+      """DELETE FROM Users;"""
+
+    val deleteStatementWithWhere = Delete(
+      "Users",
+      Some(
+        Comparison("Users.id", Equal, "123456")
+      )
+    )
+
+    val deleteStringWithWhere: String =
+      """DELETE FROM Users WHERE Users.id = 123456;"""
   }
 }


### PR DESCRIPTION
* Add simple delete statement generation
  * Delete everything from table: `DELETE FROM Users;`
  * Delete based on condition: `DELETE FROM Users WHERE User.id = 123456;`
* Add basic unit tests

While adding this I was looking at what had changed on Friday, currently the conditions AST has Strings as their leaf node types. Do we want to add some semantics to restrict this?

`case class Comparison(left: String, comparison: ComparisonOperator, right: String) extends Condition`

In which case, which conditions do we want to support?
