### PR TITLE
[SQL-Gen] Add simple update statement gen

### DIFF
--- a/src/main/scala/temple/generate/database/PostgresGenerator.scala
+++ b/src/main/scala/temple/generate/database/PostgresGenerator.scala
@@ -5,6 +5,7 @@ import temple.generate.database.ast.ColumnConstraint._
 import temple.generate.database.ast.ComparisonOperator._
 import temple.generate.database.ast.Condition._
 import temple.generate.database.ast.Statement._
+import temple.generate.database.ast.Expression._
 import temple.generate.database.ast._
 import temple.utils.StringUtils._
 
@@ -13,8 +14,18 @@ import scala.util.chaining._
 /** Implementation of [[DatabaseGenerator]] for generating PostgreSQL */
 object PostgresGenerator extends DatabaseGenerator {
 
+  /** Given an expression, parse it into the Postgres format */
+  private def generateExpression(expression: Expression): String =
+    expression match {
+      case Value(value) => value
+    }
+
+  /** Given an assignment, parse it into the Postgres format */
+  private def generateAssignment(assignment: Assignment): String =
+    s"${assignment.column.name} = ${generateExpression(assignment.expression)}"
+
   /** Given a comparison, parse it into the Postgres format */
-  private def generateComparison(comparison: ComparisonOperator) =
+  private def generateComparison(comparison: ComparisonOperator): String =
     comparison match {
       case GreaterEqual => ">="
       case Greater      => ">"
@@ -46,6 +57,13 @@ object PostgresGenerator extends DatabaseGenerator {
       case IsNull(column)                => s"${column.name} IS NULL"
     }
 
+  /** Given conditions, generate a Postgres WHERE clause  */
+  private def generateConditionString(conditions: Option[Condition]): List[String] =
+    conditions.map(generateCondition) match {
+      case Some(conditionsString) => List(s"WHERE $conditionsString")
+      case None                   => List()
+    }
+
   /** Given a column type, parse it into the type required by PostgreSQL */
   private def generateColumnType(columnType: ColType): String =
     columnType match {
@@ -75,15 +93,16 @@ object PostgresGenerator extends DatabaseGenerator {
             .pipe(indent(_))
         s"CREATE TABLE $tableName (\n$stringColumns\n);"
       case Read(tableName, columns, condition) =>
-        val stringColumns = columns.map(_.name).mkString(", ")
-        val stringCondition = condition.map(generateCondition) match {
-          case Some(conditionString) => List(s"WHERE $conditionString")
-          case None                  => List()
-        }
+        val stringColumns   = columns.map(_.name).mkString(", ")
+        val stringCondition = generateConditionString(condition)
         (s"SELECT $stringColumns FROM $tableName" +: stringCondition).mkString("", " ", ";")
       case Insert(tableName, columns) =>
         val stringColumns = columns.map(_.name).mkString(", ")
         val values        = (1 to columns.length).map(i => s"$$$i").mkString(", ")
         s"INSERT INTO $tableName ($stringColumns)\nVALUES ($values);"
+      case Update(tableName, assignments, conditions) =>
+        val stringAssignments = assignments.map(generateAssignment).mkString(", ")
+        val stringConditions  = generateConditionString(conditions)
+        (s"UPDATE $tableName SET ${stringAssignments}" +: stringConditions).mkString("", " ", ";")
     }
 }

--- a/src/main/scala/temple/generate/database/ast/Assignment.scala
+++ b/src/main/scala/temple/generate/database/ast/Assignment.scala
@@ -1,0 +1,4 @@
+package temple.generate.database.ast
+
+/** AST representation for assignments */
+sealed case class Assignment(column: Column, expression: Expression)

--- a/src/main/scala/temple/generate/database/ast/Column.scala
+++ b/src/main/scala/temple/generate/database/ast/Column.scala
@@ -1,3 +1,4 @@
 package temple.generate.database.ast
 
+/** AST representation for database columns */
 sealed case class Column(name: String)

--- a/src/main/scala/temple/generate/database/ast/ColumnDef.scala
+++ b/src/main/scala/temple/generate/database/ast/ColumnDef.scala
@@ -1,6 +1,6 @@
 package temple.generate.database.ast
 
-/** AST implementation of database columns for all data types supported in Templefile */
+/** AST implementation of database column definitions for all data types supported in Templefile */
 sealed case class ColumnDef(name: String, colType: ColType, constraints: List[ColumnConstraint] = List())
 
 sealed trait ColType

--- a/src/main/scala/temple/generate/database/ast/Expression.scala
+++ b/src/main/scala/temple/generate/database/ast/Expression.scala
@@ -1,0 +1,8 @@
+package temple.generate.database.ast
+
+/** AST representation for expressions */
+sealed trait Expression
+
+object Expression {
+  case class Value(value: String) extends Expression
+}

--- a/src/main/scala/temple/generate/database/ast/Statement.scala
+++ b/src/main/scala/temple/generate/database/ast/Statement.scala
@@ -7,4 +7,7 @@ object Statement {
   case class Create(tableName: String, columns: List[ColumnDef])                                 extends Statement
   case class Read(tableName: String, columns: List[Column], condition: Option[Condition] = None) extends Statement
   case class Insert(tableName: String, columns: List[Column])                                    extends Statement
+
+  case class Update(tableName: String, assignments: List[Assignment], condition: Option[Condition] = None)
+      extends Statement
 }

--- a/src/test/scala/temple/generate/database/PostgresGeneratorTest.scala
+++ b/src/test/scala/temple/generate/database/PostgresGeneratorTest.scala
@@ -28,4 +28,10 @@ class PostgresGeneratorTest extends FlatSpec with Matchers {
   "PostgresGenerator" should "handle inverse in WHERE correctly" in {
     PostgresGenerator.generate(TestData.readStatementWithWhereInverse) shouldBe TestData.postgresSelectStringWithWhereInverse
   }
+  "PostgresGenerator" should "generate correct UPDATE statements" in {
+    PostgresGenerator.generate(TestData.updateStatement) shouldBe TestData.postgresUpdateString
+  }
+  "PostgresGenerator" should "handle updates with WHERE correctly" in {
+    PostgresGenerator.generate(TestData.updateStatementWithWhere) shouldBe TestData.postgresUpdateStringWithWhere
+  }
 }

--- a/src/test/scala/temple/generate/database/package.scala
+++ b/src/test/scala/temple/generate/database/package.scala
@@ -5,6 +5,7 @@ import temple.generate.database.ast.ColumnConstraint._
 import temple.generate.database.ast.ComparisonOperator._
 import temple.generate.database.ast.Condition.{Comparison, Conjunction, Disjunction, Inverse}
 import temple.generate.database.ast.Statement._
+import temple.generate.database.ast.Expression._
 import temple.generate.database.ast._
 
 package object database {
@@ -170,5 +171,30 @@ package object database {
     val postgresInsertString: String =
       """INSERT INTO Users (id, bankBalance, name, isStudent, dateOfBirth, timeOfDay, expiry)
         |VALUES ($1, $2, $3, $4, $5, $6, $7);""".stripMargin
+
+    val updateStatement = Update(
+      "Users",
+      List(
+        Assignment(Column("bankBalance"), Value("123.456")),
+        Assignment(Column("name"), Value("Will"))
+      )
+    )
+
+    val postgresUpdateString: String =
+      """UPDATE Users SET bankBalance = 123.456, name = Will;"""
+
+    val updateStatementWithWhere = Update(
+      "Users",
+      List(
+        Assignment(Column("bankBalance"), Value("123.456")),
+        Assignment(Column("name"), Value("Will"))
+      ),
+      Some(
+        Comparison("Users.id", Equal, "123456")
+      )
+    )
+
+    val postgresUpdateStringWithWhere: String =
+      """UPDATE Users SET bankBalance = 123.456, name = Will WHERE Users.id = 123456;"""
   }
 }

--- a/src/test/scala/temple/generate/database/package.scala
+++ b/src/test/scala/temple/generate/database/package.scala
@@ -188,6 +188,9 @@ package object database {
       List(
         Assignment(Column("bankBalance"), Value("123.456")),
         Assignment(Column("name"), Value("Will"))
+      ),
+      Some(
+        Comparison("Users.id", Equal, "123456")
       )
     )
 

--- a/src/test/scala/temple/generate/database/package.scala
+++ b/src/test/scala/temple/generate/database/package.scala
@@ -176,18 +176,18 @@ package object database {
       "Users",
       List(
         Assignment(Column("bankBalance"), Value("123.456")),
-        Assignment(Column("name"), Value("Will"))
+        Assignment(Column("name"), Value("'Will'"))
       )
     )
 
     val postgresUpdateString: String =
-      """UPDATE Users SET bankBalance = 123.456, name = Will;"""
+      """UPDATE Users SET bankBalance = 123.456, name = 'Will';"""
 
     val updateStatementWithWhere = Update(
       "Users",
       List(
         Assignment(Column("bankBalance"), Value("123.456")),
-        Assignment(Column("name"), Value("Will"))
+        Assignment(Column("name"), Value("'Will'"))
       ),
       Some(
         Comparison("Users.id", Equal, "123456")
@@ -195,7 +195,7 @@ package object database {
     )
 
     val postgresUpdateStringWithWhere: String =
-      """UPDATE Users SET bankBalance = 123.456, name = Will WHERE Users.id = 123456;"""
+      """UPDATE Users SET bankBalance = 123.456, name = 'Will' WHERE Users.id = 123456;"""
 
     val deleteStatement = Delete(
       "Users"


### PR DESCRIPTION
* Add simple update statement generation
  * Update all rows in table: `UPDATE Users SET bankBalance = 123.456, name = 'Will';`
  * Update based on condition: `UPDATE Users SET bankBalance = 123.456, name = 'Will' WHERE Users.id = 123456;`
* Add basic unit tests

Expressions are currently just simple string values, but have been written to be extended later as we see need.