### PR TITLE
[Floating point parsing] Fix floating point parsing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ lazy val root = (project in file("."))
       "org.scalatest" %% "scalatest" % "3.0.8" % "it,test",
       "org.rogach" %% "scallop" % "3.3.2",
       "org.postgresql" % "postgresql" % "42.2.9",
-      "com.sun.activation" % "javax.activation" % "1.2.0",
+      "com.sun.activation" % "javax.activaddSbtPlugination" % "1.2.0",
       "com.spotify" % "docker-client" % "8.9.1",
       "com.whisk" %% "docker-testkit-scalatest" % "0.9.9" % "it,test",
       "com.whisk" %% "docker-testkit-impl-spotify" % "0.9.9" % "it,test",

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ lazy val root = (project in file("."))
       "org.scalatest" %% "scalatest" % "3.0.8" % "it,test",
       "org.rogach" %% "scallop" % "3.3.2",
       "org.postgresql" % "postgresql" % "42.2.9",
-      "com.sun.activation" % "javax.activaddSbtPlugination" % "1.2.0",
+      "com.sun.activation" % "javax.activation" % "1.2.0",
       "com.spotify" % "docker-client" % "8.9.1",
       "com.whisk" %% "docker-testkit-scalatest" % "0.9.9" % "it,test",
       "com.whisk" %% "docker-testkit-impl-spotify" % "0.9.9" % "it,test",

--- a/src/main/scala/temple/DSL/parser/DSLParser.scala
+++ b/src/main/scala/temple/DSL/parser/DSLParser.scala
@@ -53,7 +53,7 @@ class DSLParser extends JavaTokenParsers with UtilParsers {
   /** A parser generator for a sequence of arguments, starting positionally and subsequently keyed.
     * If the parser fails after parsing the open bracket, commit is called to protect against being confused with nested
     * rootitems */
-  def allArgs: Parser[Seq[Arg] ~ Seq[(String, Arg)]] =
+  def allArgs: Parser[List[Arg] ~ List[(String, Arg)]] =
     "(" ~> commit(rep(arg <~ argsListSeparator) ~ repUntil(kwarg <~ argsListSeparator, ")"))
 
   /** A parser generator for the type of an attribute */

--- a/src/main/scala/temple/DSL/parser/DSLParser.scala
+++ b/src/main/scala/temple/DSL/parser/DSLParser.scala
@@ -30,7 +30,7 @@ class DSLParser extends JavaTokenParsers with UtilParsers {
     }
 
   /** A parser generator for a comma or the end of the argument list */
-  def argsListSeparator: Parser[Unit] = ("," | guard("]" | ")" | "}")) ^^^ ()
+  def argsListSeparator: Parser[Unit] = (guard("]" | ")" | "}") | ",") ^^^ ()
 
   /** A parser generator for a list of arguments in square brackets */
   def listArg: Parser[Arg] = "[" ~> repUntil(arg <~ argsListSeparator, "]") ^^ (elems => Arg.ListArg(elems))
@@ -43,16 +43,18 @@ class DSLParser extends JavaTokenParsers with UtilParsers {
     */
   def arg: Parser[Arg] =
     ident ^^ Arg.TokenArg |
-    wholeNumber ^^ (str => Arg.IntArg(str.toInt)) |
     floatingPointNumber ^^ (str => Arg.FloatingArg(str.toDouble)) |
+    wholeNumber ^^ (str => Arg.IntArg(str.toInt)) |
     listArg
 
   /** A parser generator for an argument keyed by a keyword */
   def kwarg: Parser[(String, Arg)] = ((ident <~ ":") ~ arg) ^^ { case ident ~ arg => (ident, arg) }
 
-  /** A parser generator for a sequence of arguments, starting positionally and subsequently keyed */
-  def allArgs: Parser[List[Arg] ~ List[(String, Arg)]] =
-    "(" ~> (rep(arg <~ argsListSeparator) ~ repUntil(kwarg <~ argsListSeparator, ")"))
+  /** A parser generator for a sequence of arguments, starting positionally and subsequently keyed.
+    * If the parser fails after parsing the open bracket, commit is called to protect against being confused with nested
+    * rootitems */
+  def allArgs: Parser[Seq[Arg] ~ Seq[(String, Arg)]] =
+    "(" ~> commit(rep(arg <~ argsListSeparator) ~ repUntil(kwarg <~ argsListSeparator, ")"))
 
   /** A parser generator for the type of an attribute */
   def attributeType: Parser[AttributeType] = ident ~ allArgs.? ^^ {

--- a/src/test/scala/temple/testfiles/simple.temple
+++ b/src/test/scala/temple/testfiles/simple.temple
@@ -6,7 +6,7 @@ User: service {
   createdAt: datetimetz;
   numberOfDogs: int;
   yeets: bool;
-  currentBankBalance: fixed(places: 2);
+  currentBankBalance: float(min: 0.0, precision: 2);
   birthDate: date;
   breakfastTime: time;
 


### PR DESCRIPTION
I miss Yoda, turns out the implicit `try` only wraps the alternation, so
`wholeNumber | floatingPointNumber` will parse `0.0` as `0`, with `.0`
left over.