### PR TITLE
[List to Seq] Replace instances of List with superclass Seq

### DIFF
--- a/src/main/scala/temple/DSL/DSLProcessor.scala
+++ b/src/main/scala/temple/DSL/DSLProcessor.scala
@@ -16,7 +16,7 @@ object DSLProcessor extends DSLParser {
     * @param contents the contents of a Templefile as a string
     * @return Right of the the parsed list of root elements, or Left of a string representing the error
     */
-  def parse(contents: String): Either[String, List[DSLRootItem]] =
+  def parse(contents: String): Either[String, Seq[DSLRootItem]] =
     parseAll(templeFile, contents) match {
       case Success(result, _)    => Right(result)
       case NoSuccess(str, input) => Left(str + '\n' + printError(input))

--- a/src/main/scala/temple/DSL/package.scala
+++ b/src/main/scala/temple/DSL/package.scala
@@ -6,7 +6,7 @@ import temple.utils.StringUtils._
 package object DSL {
 
   /** The type of a struct’s attribute, complete with parameters */
-  case class AttributeType(typeName: String, args: List[Arg] = List(), kwargs: List[(String, Arg)] = List()) {
+  case class AttributeType(typeName: String, args: Seq[Arg] = Nil, kwargs: Seq[(String, Arg)] = Nil) {
 
     override def toString: String = {
       val kwargsStr = kwargs.map { case (str, arg) => s"$str: $arg" }
@@ -18,7 +18,7 @@ package object DSL {
 // TODO: move to the next step
 
 //  object FieldType {
-//    case class FieldType(typeName: String, args: List[Arg], kwargs: List[(String, Arg)]) extends FieldType
+//    case class FieldType(typeName: String, args: Seq[Arg], kwargs: Seq[(String, Arg)]) extends FieldType
 //    //    case object BoolType extends FieldType
 ////
 ////    case class IntType(max: Long, min: Long)                                        extends FieldType
@@ -44,7 +44,7 @@ package object DSL {
     case class TokenArg(name: String)     extends Arg { override def toString: String = name                           }
     case class IntArg(value: scala.Int)   extends Arg { override def toString: String = value.toString                 }
     case class FloatingArg(value: Double) extends Arg { override def toString: String = value.toString                 }
-    case class ListArg(elems: List[Arg])  extends Arg { override def toString: String = elems.mkString("[", ", ", "]") }
+    case class ListArg(elems: Seq[Arg])   extends Arg { override def toString: String = elems.mkString("[", ", ", "]") }
   }
 
   /** Any element of a service/struct */
@@ -52,11 +52,11 @@ package object DSL {
 
   object Entry {
 
-    case class Attribute(key: String, dataType: AttributeType, annotations: List[Annotation]) extends Entry {
+    case class Attribute(key: String, dataType: AttributeType, annotations: Seq[Annotation]) extends Entry {
       override def toString: String = s"$key: $dataType${annotations.map(" " + _).mkString};"
     }
 
-    case class Metadata(function: String, args: List[Arg], kwargs: List[(String, Arg)]) extends Entry {
+    case class Metadata(function: String, args: Seq[Arg], kwargs: Seq[(String, Arg)]) extends Entry {
 
       override def toString: String = {
         val kwargsStr = kwargs.map { case (str, arg) => s"$str: $arg" }
@@ -66,7 +66,7 @@ package object DSL {
   }
 
   /** An item at the root of the Templefile, e.g. services and targets */
-  case class DSLRootItem(key: String, tag: String, entries: List[Entry]) extends Entry {
+  case class DSLRootItem(key: String, tag: String, entries: Seq[Entry]) extends Entry {
 
     override def toString: String = {
       val contents = indent(entries.mkString("\n"))

--- a/src/main/scala/temple/DSL/parser/DSLParser.scala
+++ b/src/main/scala/temple/DSL/parser/DSLParser.scala
@@ -8,7 +8,7 @@ import scala.util.parsing.combinator.JavaTokenParsers
 class DSLParser extends JavaTokenParsers with UtilParsers {
 
   /** A parser generator for an entire Templefile */
-  def templeFile: Parser[List[DSLRootItem]] = repAll(rootItem)
+  def templeFile: Parser[Seq[DSLRootItem]] = repAll(rootItem)
 
   /** A parser generator for each item at the root level, i.e. a name, tag and block */
   def rootItem: Parser[DSLRootItem] = (ident <~ ":") ~ (ident <~ "{") ~ repUntil(entry, "}") ^^ {
@@ -36,7 +36,7 @@ class DSLParser extends JavaTokenParsers with UtilParsers {
   def listArg: Parser[Arg] = "[" ~> repUntil(arg <~ argsListSeparator, "]") ^^ (elems => Arg.ListArg(elems))
 
   /** A parser generator for a list of arguments in square brackets, when used in shorthand to replace the brackets */
-  def shorthandListArg[T]: Parser[List[Arg] ~ List[T]] = (listArg ^^ (list => List(list))) ~ success(List())
+  def shorthandListArg[T]: Parser[Seq[Arg] ~ Seq[T]] = (listArg ^^ (list => Seq(list))) ~ success(Nil)
 
   /**
     * A parser generator for any argument passed to a type or metadata
@@ -51,7 +51,7 @@ class DSLParser extends JavaTokenParsers with UtilParsers {
   def kwarg: Parser[(String, Arg)] = ((ident <~ ":") ~ arg) ^^ { case ident ~ arg => (ident, arg) }
 
   /** A parser generator for a sequence of arguments, starting positionally and subsequently keyed */
-  def allArgs: Parser[List[Arg] ~ List[(String, Arg)]] =
+  def allArgs: Parser[Seq[Arg] ~ Seq[(String, Arg)]] =
     "(" ~> (rep(arg <~ argsListSeparator) ~ repUntil(kwarg <~ argsListSeparator, ")"))
 
   /** A parser generator for the type of an attribute */

--- a/src/main/scala/temple/DSL/parser/UtilParsers.scala
+++ b/src/main/scala/temple/DSL/parser/UtilParsers.scala
@@ -15,22 +15,22 @@ trait UtilParsers extends RegexParsers {
     * @param q0 The parser marking the end of the sequence. Use `guard` to avoid consuming this input
     * @return A parser that returns a list of the successful parses of `p0`
     */
-  def repUntil[T](p0: => Parser[T], q0: => Parser[Any] = ""): Parser[List[T]] = Parser { in =>
+  def repUntil[T](p0: => Parser[T], q0: => Parser[Any] = ""): Parser[Seq[T]] = Parser { in =>
     lazy val p = p0
     lazy val q = q0
     val elems  = new ListBuffer[T]
 
     // run `p0` repeatedly
-    @tailrec def applyP(in0: Input): ParseResult[List[T]] = p(in0) match {
+    @tailrec def applyP(in0: Input): ParseResult[Seq[T]] = p(in0) match {
       case Success(x, rest) => elems += x; applyP(rest)
       case e: Error         => e // still have to propagate `p`’s parser error
       case Failure(str, input) =>
         q(in0) match {
-          case Success(_, next) => Success(elems.toList, next) // allow `q` to consume (use guard to avoid)
-          case _: Failure       => Failure(str, input)         // If both fail, propagate `p0`’s failure.
-          case e: Error         => e                           // still have to propagate `q0`’s parser error
+          case Success(_, next) => Success(elems.toSeq, next) // allow `q` to consume (use guard to avoid)
+          case _: Failure       => Failure(str, input)        // If both fail, propagate `p0`’s failure.
+          case e: Error         => e                          // still have to propagate `q0`’s parser error
         }
-      case _ => Success(elems.toList, in0)
+      case _ => Success(elems.toSeq, in0)
     }
 
     applyP(in)
@@ -45,5 +45,5 @@ trait UtilParsers extends RegexParsers {
     * @param p0 The parser that is repeated
     * @return A parser that returns a list of the successful parses of `p0`
     */
-  def repAll[T](p0: => Parser[T]): Parser[List[T]] = repUntil(p0, "$".r)
+  def repAll[T](p0: => Parser[T]): Parser[Seq[T]] = repUntil(p0, "$".r)
 }

--- a/src/main/scala/temple/generate/database/PostgresGenerator.scala
+++ b/src/main/scala/temple/generate/database/PostgresGenerator.scala
@@ -58,10 +58,10 @@ object PostgresGenerator extends DatabaseGenerator {
     }
 
   /** Given conditions, generate a Postgres WHERE clause  */
-  private def generateConditionString(conditions: Option[Condition]): List[String] =
+  private def generateConditionString(conditions: Option[Condition]): Seq[String] =
     conditions.map(generateCondition) match {
-      case Some(conditionsString) => List(s"WHERE $conditionsString")
-      case None                   => List()
+      case Some(conditionsString) => Seq(s"WHERE $conditionsString")
+      case None                   => Nil
     }
 
   /** Given a column type, parse it into the type required by PostgreSQL */

--- a/src/main/scala/temple/generate/database/ast/ColumnDef.scala
+++ b/src/main/scala/temple/generate/database/ast/ColumnDef.scala
@@ -1,7 +1,7 @@
 package temple.generate.database.ast
 
 /** AST implementation of database column definitions for all data types supported in Templefile */
-sealed case class ColumnDef(name: String, colType: ColType, constraints: List[ColumnConstraint] = List())
+sealed case class ColumnDef(name: String, colType: ColType, constraints: Seq[ColumnConstraint] = Nil)
 
 sealed trait ColType
 

--- a/src/main/scala/temple/generate/database/ast/Statement.scala
+++ b/src/main/scala/temple/generate/database/ast/Statement.scala
@@ -4,11 +4,11 @@ package temple.generate.database.ast
 sealed trait Statement
 
 object Statement {
-  case class Create(tableName: String, columns: List[ColumnDef])                                 extends Statement
-  case class Read(tableName: String, columns: List[Column], condition: Option[Condition] = None) extends Statement
-  case class Insert(tableName: String, columns: List[Column])                                    extends Statement
+  case class Create(tableName: String, columns: Seq[ColumnDef])                                 extends Statement
+  case class Read(tableName: String, columns: Seq[Column], condition: Option[Condition] = None) extends Statement
+  case class Insert(tableName: String, columns: Seq[Column])                                    extends Statement
 
-  case class Update(tableName: String, assignments: List[Assignment], condition: Option[Condition] = None)
+  case class Update(tableName: String, assignments: Seq[Assignment], condition: Option[Condition] = None)
       extends Statement
   case class Delete(tableName: String, condition: Option[Condition] = None) extends Statement
   case class Drop(tableName: String, ifExists: Boolean = true)              extends Statement

--- a/src/test/scala/temple/TempleConfigTest.scala
+++ b/src/test/scala/temple/TempleConfigTest.scala
@@ -5,25 +5,25 @@ import org.rogach.scallop.ScallopOption
 
 class TempleConfigTest extends FlatSpec with Matchers {
   "Generate" should "not correctly parse without a filename" in {
-    a[RuntimeException] should be thrownBy new TempleConfig(List("generate"))
+    a[RuntimeException] should be thrownBy new TempleConfig(Seq("generate"))
   }
 
   "Generate" should "correctly parse with a filename" in {
-    val config = new TempleConfig(List("generate", "foo.temple"))
+    val config = new TempleConfig(Seq("generate", "foo.temple"))
     config.subcommand shouldBe Some(config.Generate)
     config.Generate.filename.toOption shouldBe Some("foo.temple")
   }
 
   "Empty arguments" should "have no sub commands" in {
-    val config = new TempleConfig(List())
+    val config = new TempleConfig(Seq())
     config.subcommand shouldBe None
   }
 
   "Unknown subcommand" should "throw an exception" in {
-    an[IllegalArgumentException] should be thrownBy new TempleConfig(List("foobarbaz"))
+    an[IllegalArgumentException] should be thrownBy new TempleConfig(Seq("foobarbaz"))
   }
 
   "Unknown flag" should "throw an exception" in {
-    an[IllegalArgumentException] should be thrownBy new TempleConfig(List("-z"))
+    an[IllegalArgumentException] should be thrownBy new TempleConfig(Seq("-z"))
   }
 }

--- a/src/test/scala/temple/generate/database/package.scala
+++ b/src/test/scala/temple/generate/database/package.scala
@@ -13,9 +13,9 @@ package object database {
   /** Static testing assets for DB generation */
   object TestData {
 
-    val createStatement = Create(
+    val createStatement: Create = Create(
       "Users",
-      List(
+      Seq(
         ColumnDef("id", IntCol),
         ColumnDef("bankBalance", FloatCol),
         ColumnDef("name", StringCol),
@@ -37,13 +37,13 @@ package object database {
         |  expiry TIMESTAMPTZ
         |);""".stripMargin
 
-    val createStatementWithConstraints = Create(
+    val createStatementWithConstraints: Create = Create(
       "Test",
-      List(
-        ColumnDef("item_id", IntCol, List(NonNull, PrimaryKey)),
-        ColumnDef("createdAt", DateTimeTzCol, List(Unique)),
-        ColumnDef("bookingTime", TimeCol, List(References("Bookings", "bookingTime"))),
-        ColumnDef("value", IntCol, List(Check("value", GreaterEqual, "1"), Null))
+      Seq(
+        ColumnDef("item_id", IntCol, Seq(NonNull, PrimaryKey)),
+        ColumnDef("createdAt", DateTimeTzCol, Seq(Unique)),
+        ColumnDef("bookingTime", TimeCol, Seq(References("Bookings", "bookingTime"))),
+        ColumnDef("value", IntCol, Seq(Check("value", GreaterEqual, "1"), Null))
       )
     )
 
@@ -55,9 +55,9 @@ package object database {
         |  value INT CHECK (value >= 1) NULL
         |);""".stripMargin
 
-    val readStatement = Read(
+    val readStatement: Read = Read(
       "Users",
-      List(
+      Seq(
         Column("id"),
         Column("bankBalance"),
         Column("name"),
@@ -71,9 +71,9 @@ package object database {
     val postgresSelectString: String =
       """SELECT id, bankBalance, name, isStudent, dateOfBirth, timeOfDay, expiry FROM Users;"""
 
-    val readStatementWithWhere = Read(
+    val readStatementWithWhere: Read = Read(
       "Users",
-      List(
+      Seq(
         Column("id"),
         Column("bankBalance"),
         Column("name"),
@@ -90,9 +90,9 @@ package object database {
     val postgresSelectStringWithWhere: String =
       """SELECT id, bankBalance, name, isStudent, dateOfBirth, timeOfDay, expiry FROM Users WHERE Users.id = 123456;"""
 
-    val readStatementWithWhereConjunction = Read(
+    val readStatementWithWhereConjunction: Read = Read(
       "Users",
-      List(
+      Seq(
         Column("id"),
         Column("bankBalance"),
         Column("name"),
@@ -112,9 +112,9 @@ package object database {
     val postgresSelectStringWithWhereConjunction: String =
       """SELECT id, bankBalance, name, isStudent, dateOfBirth, timeOfDay, expiry FROM Users WHERE (Users.id = 123456) AND (Users.expiry <= 2);"""
 
-    val readStatementWithWhereDisjunction = Read(
+    val readStatementWithWhereDisjunction: Read = Read(
       "Users",
-      List(
+      Seq(
         Column("id"),
         Column("bankBalance"),
         Column("name"),
@@ -134,9 +134,9 @@ package object database {
     val postgresSelectStringWithWhereDisjunction: String =
       """SELECT id, bankBalance, name, isStudent, dateOfBirth, timeOfDay, expiry FROM Users WHERE (Users.id <> 123456) OR (Users.expiry > 2);"""
 
-    val readStatementWithWhereInverse = Read(
+    val readStatementWithWhereInverse: Read = Read(
       "Users",
-      List(
+      Seq(
         Column("id"),
         Column("bankBalance"),
         Column("name"),
@@ -155,9 +155,9 @@ package object database {
     val postgresSelectStringWithWhereInverse: String =
       """SELECT id, bankBalance, name, isStudent, dateOfBirth, timeOfDay, expiry FROM Users WHERE NOT (Users.id < 123456);"""
 
-    val readStatementComplex = Read(
+    val readStatementComplex: Read = Read(
       "Users",
-      List(
+      Seq(
         Column("id"),
         Column("bankBalance"),
         Column("name"),
@@ -183,9 +183,9 @@ package object database {
     val postgresSelectStringComplex: String =
       """SELECT id, bankBalance, name, isStudent, dateOfBirth, timeOfDay, expiry FROM Users WHERE ((isStudent IS NULL) OR (Users.id >= 1)) AND ((isStudent IS NOT NULL) OR (NOT (Users.expiry < 2020-02-03 00:00:00+00)));"""
 
-    val insertStatement = Insert(
+    val insertStatement: Insert = Insert(
       "Users",
-      List(
+      Seq(
         Column("id"),
         Column("bankBalance"),
         Column("name"),
@@ -200,9 +200,9 @@ package object database {
       """INSERT INTO Users (id, bankBalance, name, isStudent, dateOfBirth, timeOfDay, expiry)
         |VALUES ($1, $2, $3, $4, $5, $6, $7);""".stripMargin
 
-    val updateStatement = Update(
+    val updateStatement: Update = Update(
       "Users",
-      List(
+      Seq(
         Assignment(Column("bankBalance"), Value("123.456")),
         Assignment(Column("name"), Value("'Will'"))
       )
@@ -211,9 +211,9 @@ package object database {
     val postgresUpdateString: String =
       """UPDATE Users SET bankBalance = 123.456, name = 'Will';"""
 
-    val updateStatementWithWhere = Update(
+    val updateStatementWithWhere: Update = Update(
       "Users",
-      List(
+      Seq(
         Assignment(Column("bankBalance"), Value("123.456")),
         Assignment(Column("name"), Value("'Will'"))
       ),
@@ -225,14 +225,14 @@ package object database {
     val postgresUpdateStringWithWhere: String =
       """UPDATE Users SET bankBalance = 123.456, name = 'Will' WHERE Users.id = 123456;"""
 
-    val deleteStatement = Delete(
+    val deleteStatement: Delete = Delete(
       "Users"
     )
 
     val postgresDeleteString: String =
       """DELETE FROM Users;"""
 
-    val deleteStatementWithWhere = Delete(
+    val deleteStatementWithWhere: Delete = Delete(
       "Users",
       Some(
         Comparison("Users.id", Equal, "123456")
@@ -242,7 +242,7 @@ package object database {
     val postgresDeleteStringWithWhere: String =
       """DELETE FROM Users WHERE Users.id = 123456;"""
 
-    val dropStatement = Drop(
+    val dropStatement: Drop = Drop(
       "Users",
       ifExists = false
     )
@@ -250,7 +250,7 @@ package object database {
     val postgresDropString: String =
       """DROP TABLE Users;"""
 
-    val dropStatementIfExists = Drop(
+    val dropStatementIfExists: Drop = Drop(
       "Users"
     )
 


### PR DESCRIPTION
List is a linked list, and converting into this data structure seems a
bit pointless in many cases when they can just be left in the Seq
(immutable ordered collection) that they are already in/can be converted
to most efficiently.