### PR TITLE
[Reformat code] Add trailing commas to multiline function calls

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -20,3 +20,4 @@ newlines.alwaysBeforeElseAfterCurlyIf = false
 newlines.alwaysBeforeTopLevelStatements = true
 binPack.literalArgumentLists = false
 runner.optimizer.forceConfigStyleMinArgCount = 1
+trailingCommas = always

--- a/src/it/scala/temple/containers/DockerPostgresService.scala
+++ b/src/it/scala/temple/containers/DockerPostgresService.scala
@@ -5,8 +5,8 @@ import java.sql.DriverManager
 import com.whisk.docker.{DockerCommandExecutor, DockerContainer, DockerContainerState, DockerKit, DockerReadyChecker}
 import temple.containers.DockerPostgresService.PostgresReadyChecker
 
-import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future}
 
 /** DockerPostgresService configures a docker container for Postgres */
 trait DockerPostgresService extends DockerKit {
@@ -15,10 +15,10 @@ trait DockerPostgresService extends DockerKit {
     .withPorts(DockerPostgresService.internalPort -> Some(DockerPostgresService.externalPort))
     .withEnv(
       s"POSTGRES_USER=${DockerPostgresService.databaseUsername}",
-      s"POSTGRES_PASSWORD=${DockerPostgresService.databasePassword}"
+      s"POSTGRES_PASSWORD=${DockerPostgresService.databasePassword}",
     )
     .withReadyChecker(
-      new PostgresReadyChecker().looped(5, 10.seconds)
+      new PostgresReadyChecker().looped(5, 10.seconds),
     )
 
   abstract override def dockerContainers: List[DockerContainer] =
@@ -39,7 +39,7 @@ object DockerPostgresService {
 
     // Called by the ready checker, will only succeed when container has started
     override def apply(
-      container: DockerContainerState
+      container: DockerContainerState,
     )(implicit docker: DockerCommandExecutor, ec: ExecutionContext): Future[Boolean] = {
       val url = s"jdbc:postgresql://${docker.host}:$externalPort/"
       Future {

--- a/src/it/scala/temple/containers/PostgresSpec.scala
+++ b/src/it/scala/temple/containers/PostgresSpec.scala
@@ -21,8 +21,8 @@ trait PostgresSpec extends FlatSpec with DockerTestKit with DockerPostgresServic
       DriverManager.getConnection(
         DockerPostgresService.externalUrl,
         DockerPostgresService.databaseUsername,
-        DockerPostgresService.databasePassword
-      )
+        DockerPostgresService.databasePassword,
+      ),
     ) map { conn =>
       try fn(conn)
       finally conn.close()

--- a/src/it/scala/temple/generate/database/PostgresGeneratorIntegrationTest.scala
+++ b/src/it/scala/temple/generate/database/PostgresGeneratorIntegrationTest.scala
@@ -33,7 +33,7 @@ class PostgresGeneratorIntegrationTest extends PostgresSpec with Matchers with B
     val createStatement = PostgresGenerator.generate(TestData.createStatement)
     executeWithoutResults(createStatement)
     val result = executeWithResults(
-      "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'users');"
+      "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'users');",
     ).getOrElse(fail("Database connection could not be established"))
     result.next()
     result.getBoolean("exists") shouldBe true
@@ -67,13 +67,13 @@ class PostgresGeneratorIntegrationTest extends PostgresSpec with Matchers with B
   "Users table" should "be dropped successfully" in {
     executeWithoutResults(PostgresGenerator.generate(TestData.createStatement))
     var result = executeWithResults(
-      "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'users');"
+      "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'users');",
     ).getOrElse(fail("Database connection could not be established"))
     result.next()
     result.getBoolean("exists") shouldBe true
     executeWithoutResults(PostgresGenerator.generate(TestData.dropStatement))
     result = executeWithResults(
-      "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'users');"
+      "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'users');",
     ).getOrElse(fail("Database connection could not be established"))
     result.next()
     result.getBoolean("exists") shouldBe false

--- a/src/it/scala/temple/generate/database/TestData.scala
+++ b/src/it/scala/temple/generate/database/TestData.scala
@@ -22,8 +22,8 @@ object TestData {
       ColumnDef("isStudent", BoolCol),
       ColumnDef("dateOfBirth", DateCol),
       ColumnDef("timeOfDay", TimeCol),
-      ColumnDef("expiry", DateTimeTzCol)
-    )
+      ColumnDef("expiry", DateTimeTzCol),
+    ),
   )
 
   val createStatementWithConstraints = Create(
@@ -32,8 +32,8 @@ object TestData {
       ColumnDef("itemID", IntCol, Seq(NonNull, PrimaryKey)),
       ColumnDef("createdAt", DateTimeTzCol, Seq(Unique)),
       ColumnDef("bookingTime", TimeCol, Seq(References("Bookings", "bookingTime"))),
-      ColumnDef("value", IntCol, Seq(Check("value", GreaterEqual, "1"), Null))
-    )
+      ColumnDef("value", IntCol, Seq(Check("value", GreaterEqual, "1"), Null)),
+    ),
   )
 
   val readStatement = Read(
@@ -45,8 +45,8 @@ object TestData {
       Column("isStudent"),
       Column("dateOfBirth"),
       Column("timeOfDay"),
-      Column("expiry")
-    )
+      Column("expiry"),
+    ),
   )
 
   val readStatementWithWhere = Read(
@@ -58,11 +58,11 @@ object TestData {
       Column("isStudent"),
       Column("dateOfBirth"),
       Column("timeOfDay"),
-      Column("expiry")
+      Column("expiry"),
     ),
     Some(
-      Comparison("Users.id", Equal, "123456")
-    )
+      Comparison("Users.id", Equal, "123456"),
+    ),
   )
 
   val readStatementWithWhereConjunction = Read(
@@ -74,14 +74,14 @@ object TestData {
       Column("isStudent"),
       Column("dateOfBirth"),
       Column("timeOfDay"),
-      Column("expiry")
+      Column("expiry"),
     ),
     Some(
       Conjunction(
         Comparison("Users.id", Equal, "123456"),
-        Comparison("Users.expiry", LessEqual, "2")
-      )
-    )
+        Comparison("Users.expiry", LessEqual, "2"),
+      ),
+    ),
   )
 
   val readStatementWithWhereDisjunction = Read(
@@ -93,14 +93,14 @@ object TestData {
       Column("isStudent"),
       Column("dateOfBirth"),
       Column("timeOfDay"),
-      Column("expiry")
+      Column("expiry"),
     ),
     Some(
       Disjunction(
         Comparison("Users.id", NotEqual, "123456"),
-        Comparison("Users.expiry", Greater, "2")
-      )
-    )
+        Comparison("Users.expiry", Greater, "2"),
+      ),
+    ),
   )
 
   val readStatementWithWhereInverse = Read(
@@ -112,13 +112,13 @@ object TestData {
       Column("isStudent"),
       Column("dateOfBirth"),
       Column("timeOfDay"),
-      Column("expiry")
+      Column("expiry"),
     ),
     Some(
       Inverse(
-        Comparison("Users.id", Less, "123456")
-      )
-    )
+        Comparison("Users.id", Less, "123456"),
+      ),
+    ),
   )
 
   val readStatementComplex = Read(
@@ -130,20 +130,20 @@ object TestData {
       Column("isStudent"),
       Column("dateOfBirth"),
       Column("timeOfDay"),
-      Column("expiry")
+      Column("expiry"),
     ),
     Some(
       Conjunction(
         Disjunction(
           IsNull(Column("isStudent")),
-          Comparison("Users.id", GreaterEqual, "1")
+          Comparison("Users.id", GreaterEqual, "1"),
         ),
         Disjunction(
           Inverse(IsNull(Column("isStudent"))),
-          Inverse(Comparison("Users.expiry", Less, "TIMESTAMP '2020-02-03 00:00:00+00'"))
-        )
-      )
-    )
+          Inverse(Comparison("Users.expiry", Less, "TIMESTAMP '2020-02-03 00:00:00+00'")),
+        ),
+      ),
+    ),
   )
 
   val insertStatement = Insert(
@@ -155,47 +155,47 @@ object TestData {
       Column("isStudent"),
       Column("dateOfBirth"),
       Column("timeOfDay"),
-      Column("expiry")
-    )
+      Column("expiry"),
+    ),
   )
 
   val deleteStatement = Delete(
-    "Users"
+    "Users",
   )
 
   val deleteStatementWithWhere = Delete(
     "Users",
     Some(
-      Comparison("Users.id", Equal, "123456")
-    )
+      Comparison("Users.id", Equal, "123456"),
+    ),
   )
 
   val dropStatement = Drop(
     "Users",
-    ifExists = false
+    ifExists = false,
   )
 
   val dropStatementIfExists = Drop(
-    "Users"
+    "Users",
   )
 
   val updateStatement = Update(
     "Users",
     Seq(
       Assignment(Column("bankBalance"), Value("123.456")),
-      Assignment(Column("name"), Value("'Will'"))
-    )
+      Assignment(Column("name"), Value("'Will'")),
+    ),
   )
 
   val updateStatementWithWhere = Update(
     "Users",
     Seq(
       Assignment(Column("bankBalance"), Value("123.456")),
-      Assignment(Column("name"), Value("'Will'"))
+      Assignment(Column("name"), Value("'Will'")),
     ),
     Some(
-      Comparison("Users.id", Equal, "123456")
-    )
+      Comparison("Users.id", Equal, "123456"),
+    ),
   )
 
   val insertDataA: Seq[PreparedVariable] = Seq(
@@ -205,7 +205,7 @@ object TestData {
     PreparedVariable.BoolVariable(true),
     PreparedVariable.DateVariable(Date.valueOf("1998-03-05")),
     PreparedVariable.TimeVariable(Time.valueOf("12:00:00")),
-    PreparedVariable.DateTimeTzVariable(Timestamp.valueOf("2020-01-01 00:00:00.0"))
+    PreparedVariable.DateTimeTzVariable(Timestamp.valueOf("2020-01-01 00:00:00.0")),
   )
 
   val insertDataB: Seq[PreparedVariable] = Seq(
@@ -215,7 +215,7 @@ object TestData {
     PreparedVariable.BoolVariable(false),
     PreparedVariable.DateVariable(Date.valueOf("1998-03-05")),
     PreparedVariable.TimeVariable(Time.valueOf("12:00:00")),
-    PreparedVariable.DateTimeTzVariable(Timestamp.valueOf("2019-02-03 02:23:50.0"))
+    PreparedVariable.DateTimeTzVariable(Timestamp.valueOf("2019-02-03 02:23:50.0")),
   )
 
 }

--- a/src/main/scala/temple/DSL/parser/DSLParser.scala
+++ b/src/main/scala/temple/DSL/parser/DSLParser.scala
@@ -1,7 +1,6 @@
 package temple.DSL.parser
 
 import temple.DSL.syntax._
-import temple.DSL._
 
 import scala.util.parsing.combinator.JavaTokenParsers
 

--- a/src/main/scala/temple/TempleConfig.scala
+++ b/src/main/scala/temple/TempleConfig.scala
@@ -1,7 +1,8 @@
 package temple
 
-import scala.collection.{Seq => CSeq}
 import org.rogach.scallop.{ScallopConf, ScallopOption, Subcommand}
+
+import scala.collection.{Seq => CSeq}
 
 /** TempleConfig produces the application configuration from command line arguments */
 class TempleConfig(arguments: CSeq[String]) extends ScallopConf(arguments) {

--- a/src/main/scala/temple/generate/database/PostgresGenerator.scala
+++ b/src/main/scala/temple/generate/database/PostgresGenerator.scala
@@ -4,8 +4,8 @@ import temple.generate.database.ast.ColType._
 import temple.generate.database.ast.ColumnConstraint._
 import temple.generate.database.ast.ComparisonOperator._
 import temple.generate.database.ast.Condition._
-import temple.generate.database.ast.Statement._
 import temple.generate.database.ast.Expression._
+import temple.generate.database.ast.Statement._
 import temple.generate.database.ast._
 import temple.utils.StringUtils._
 
@@ -89,7 +89,7 @@ object PostgresGenerator extends DatabaseGenerator[PostgresContext] {
         context.preparedType match {
           case PreparedType.DollarNumbers => s"$$$i"
           case PreparedType.QuestionMarks => "?"
-        }
+        },
       )
       .mkString(", ")
 

--- a/src/test/scala/temple/DSL/parser/DSLParserTest.scala
+++ b/src/test/scala/temple/DSL/parser/DSLParserTest.scala
@@ -2,8 +2,8 @@ package temple.DSL.parser
 
 import org.scalatest.{FlatSpec, Matchers}
 import temple.DSL.DSLProcessor
-import temple.DSL.syntax.{Arg, Args, AttributeType, DSLRootItem}
 import temple.DSL.syntax.Entry.{Attribute, Metadata}
+import temple.DSL.syntax.{Arg, Args, AttributeType, DSLRootItem}
 import temple.utils.FileUtils._
 import temple.utils.MonadUtils.FromEither
 
@@ -38,15 +38,15 @@ class DSLParserTest extends FlatSpec with Matchers {
           Attribute("yeets", AttributeType("bool")),
           Attribute(
             "currentBankBalance",
-            AttributeType("float", Args(kwargs = Seq("min" -> Arg.FloatingArg(0), "precision" -> Arg.IntArg(2))))
+            AttributeType("float", Args(kwargs = Seq("min" -> Arg.FloatingArg(0), "precision" -> Arg.IntArg(2)))),
           ),
           Attribute("birthDate", AttributeType("date")),
           Attribute("breakfastTime", AttributeType("time")),
           DSLRootItem("Fred", "struct", Seq(Attribute("field", AttributeType("string")))),
           Metadata("auth", Args(kwargs = Seq("login" -> Arg.TokenArg("username")))),
-          Metadata("uses", Args(Seq(Arg.ListArg(Seq(Arg.TokenArg("Booking"), Arg.TokenArg("Events"))))))
-        )
-      )
+          Metadata("uses", Args(Seq(Arg.ListArg(Seq(Arg.TokenArg("Booking"), Arg.TokenArg("Events")))))),
+        ),
+      ),
     )
   }
 

--- a/src/test/scala/temple/TempleConfigTest.scala
+++ b/src/test/scala/temple/TempleConfigTest.scala
@@ -1,7 +1,6 @@
 package temple
 
 import org.scalatest.{FlatSpec, Matchers}
-import org.rogach.scallop.ScallopOption
 
 class TempleConfigTest extends FlatSpec with Matchers {
   "Generate" should "not correctly parse without a filename" in {

--- a/src/test/scala/temple/generate/database/PostgresGeneratorTest.scala
+++ b/src/test/scala/temple/generate/database/PostgresGeneratorTest.scala
@@ -1,7 +1,6 @@
 package temple.generate.database
 
 import org.scalatest.{FlatSpec, Matchers}
-
 import temple.generate.database.{IntegrationTestData => TestData}
 
 class PostgresGeneratorTest extends FlatSpec with Matchers {

--- a/src/test/scala/temple/generate/database/TestData.scala
+++ b/src/test/scala/temple/generate/database/TestData.scala
@@ -20,8 +20,8 @@ object IntegrationTestData {
       ColumnDef("isStudent", BoolCol),
       ColumnDef("dateOfBirth", DateCol),
       ColumnDef("timeOfDay", TimeCol),
-      ColumnDef("expiry", DateTimeTzCol)
-    )
+      ColumnDef("expiry", DateTimeTzCol),
+    ),
   )
 
   val postgresCreateString: String =
@@ -41,8 +41,8 @@ object IntegrationTestData {
       ColumnDef("item_id", IntCol, Seq(NonNull, PrimaryKey)),
       ColumnDef("createdAt", DateTimeTzCol, Seq(Unique)),
       ColumnDef("bookingTime", TimeCol, Seq(References("Bookings", "bookingTime"))),
-      ColumnDef("value", IntCol, Seq(Check("value", GreaterEqual, "1"), Null))
-    )
+      ColumnDef("value", IntCol, Seq(Check("value", GreaterEqual, "1"), Null)),
+    ),
   )
 
   val postgresCreateStringWithConstraints: String =
@@ -62,8 +62,8 @@ object IntegrationTestData {
       Column("isStudent"),
       Column("dateOfBirth"),
       Column("timeOfDay"),
-      Column("expiry")
-    )
+      Column("expiry"),
+    ),
   )
 
   val postgresSelectString: String =
@@ -78,11 +78,11 @@ object IntegrationTestData {
       Column("isStudent"),
       Column("dateOfBirth"),
       Column("timeOfDay"),
-      Column("expiry")
+      Column("expiry"),
     ),
     Some(
-      Comparison("Users.id", Equal, "123456")
-    )
+      Comparison("Users.id", Equal, "123456"),
+    ),
   )
 
   val postgresSelectStringWithWhere: String =
@@ -97,14 +97,14 @@ object IntegrationTestData {
       Column("isStudent"),
       Column("dateOfBirth"),
       Column("timeOfDay"),
-      Column("expiry")
+      Column("expiry"),
     ),
     Some(
       Conjunction(
         Comparison("Users.id", Equal, "123456"),
-        Comparison("Users.expiry", LessEqual, "2")
-      )
-    )
+        Comparison("Users.expiry", LessEqual, "2"),
+      ),
+    ),
   )
 
   val postgresSelectStringWithWhereConjunction: String =
@@ -119,14 +119,14 @@ object IntegrationTestData {
       Column("isStudent"),
       Column("dateOfBirth"),
       Column("timeOfDay"),
-      Column("expiry")
+      Column("expiry"),
     ),
     Some(
       Disjunction(
         Comparison("Users.id", NotEqual, "123456"),
-        Comparison("Users.expiry", Greater, "2")
-      )
-    )
+        Comparison("Users.expiry", Greater, "2"),
+      ),
+    ),
   )
 
   val postgresSelectStringWithWhereDisjunction: String =
@@ -141,13 +141,13 @@ object IntegrationTestData {
       Column("isStudent"),
       Column("dateOfBirth"),
       Column("timeOfDay"),
-      Column("expiry")
+      Column("expiry"),
     ),
     Some(
       Inverse(
-        Comparison("Users.id", Less, "123456")
-      )
-    )
+        Comparison("Users.id", Less, "123456"),
+      ),
+    ),
   )
 
   val postgresSelectStringWithWhereInverse: String =
@@ -162,20 +162,20 @@ object IntegrationTestData {
       Column("isStudent"),
       Column("dateOfBirth"),
       Column("timeOfDay"),
-      Column("expiry")
+      Column("expiry"),
     ),
     Some(
       Conjunction(
         Disjunction(
           IsNull(Column("isStudent")),
-          Comparison("Users.id", GreaterEqual, "1")
+          Comparison("Users.id", GreaterEqual, "1"),
         ),
         Disjunction(
           Inverse(IsNull(Column("isStudent"))),
-          Inverse(Comparison("Users.expiry", Less, "TIMESTAMP '2020-02-03 00:00:00+00'"))
-        )
-      )
-    )
+          Inverse(Comparison("Users.expiry", Less, "TIMESTAMP '2020-02-03 00:00:00+00'")),
+        ),
+      ),
+    ),
   )
 
   val postgresSelectStringComplex: String =
@@ -190,8 +190,8 @@ object IntegrationTestData {
       Column("isStudent"),
       Column("dateOfBirth"),
       Column("timeOfDay"),
-      Column("expiry")
-    )
+      Column("expiry"),
+    ),
   )
 
   val postgresInsertString: String =
@@ -202,8 +202,8 @@ object IntegrationTestData {
     "Users",
     Seq(
       Assignment(Column("bankBalance"), Value("123.456")),
-      Assignment(Column("name"), Value("'Will'"))
-    )
+      Assignment(Column("name"), Value("'Will'")),
+    ),
   )
 
   val postgresUpdateString: String =
@@ -213,18 +213,18 @@ object IntegrationTestData {
     "Users",
     Seq(
       Assignment(Column("bankBalance"), Value("123.456")),
-      Assignment(Column("name"), Value("'Will'"))
+      Assignment(Column("name"), Value("'Will'")),
     ),
     Some(
-      Comparison("Users.id", Equal, "123456")
-    )
+      Comparison("Users.id", Equal, "123456"),
+    ),
   )
 
   val postgresUpdateStringWithWhere: String =
     """UPDATE Users SET bankBalance = 123.456, name = 'Will' WHERE Users.id = 123456;"""
 
   val deleteStatement: Delete = Delete(
-    "Users"
+    "Users",
   )
 
   val postgresDeleteString: String =
@@ -233,8 +233,8 @@ object IntegrationTestData {
   val deleteStatementWithWhere: Delete = Delete(
     "Users",
     Some(
-      Comparison("Users.id", Equal, "123456")
-    )
+      Comparison("Users.id", Equal, "123456"),
+    ),
   )
 
   val postgresDeleteStringWithWhere: String =
@@ -242,14 +242,14 @@ object IntegrationTestData {
 
   val dropStatement: Drop = Drop(
     "Users",
-    ifExists = false
+    ifExists = false,
   )
 
   val postgresDropString: String =
     """DROP TABLE Users;"""
 
   val dropStatementIfExists: Drop = Drop(
-    "Users"
+    "Users",
   )
 
   val postgresDropStringIfExists: String =

--- a/src/test/scala/temple/utils/StringUtilsTest.scala
+++ b/src/test/scala/temple/utils/StringUtilsTest.scala
@@ -1,7 +1,7 @@
 package temple.utils
 
 import org.scalatest.{FlatSpec, Matchers}
-import StringUtils.indent
+import temple.utils.StringUtils.indent
 
 class StringUtilsTest extends FlatSpec with Matchers {
   "indent" should "add spaces to an empty string" in {


### PR DESCRIPTION
Also run IntelliJ’s “reformat code” on everything, which cleans up some imports.