### PR TITLE
[SQL-Gen] Move ColType to its own file

### DIFF
--- a/src/main/scala/temple/generate/database/ast/ColType.scala
+++ b/src/main/scala/temple/generate/database/ast/ColType.scala
@@ -1,0 +1,13 @@
+package temple.generate.database.ast
+
+sealed trait ColType
+
+object ColType {
+  case object IntCol        extends ColType
+  case object FloatCol      extends ColType
+  case object StringCol     extends ColType
+  case object BoolCol       extends ColType
+  case object DateCol       extends ColType
+  case object TimeCol       extends ColType
+  case object DateTimeTzCol extends ColType
+}

--- a/src/main/scala/temple/generate/database/ast/ColumnDef.scala
+++ b/src/main/scala/temple/generate/database/ast/ColumnDef.scala
@@ -2,15 +2,3 @@ package temple.generate.database.ast
 
 /** AST implementation of database column definitions for all data types supported in Templefile */
 sealed case class ColumnDef(name: String, colType: ColType, constraints: Seq[ColumnConstraint] = Nil)
-
-sealed trait ColType
-
-object ColType {
-  case object IntCol        extends ColType
-  case object FloatCol      extends ColType
-  case object StringCol     extends ColType
-  case object BoolCol       extends ColType
-  case object DateCol       extends ColType
-  case object TimeCol       extends ColType
-  case object DateTimeTzCol extends ColType
-}


### PR DESCRIPTION
Scala files should have only one class/trait/object and optional
companion object