### PR TITLE
Test naming

### DIFF
--- a/src/it/scala/temple/generate/database/PostgresGeneratorIntegrationTest.scala
+++ b/src/it/scala/temple/generate/database/PostgresGeneratorIntegrationTest.scala
@@ -15,11 +15,12 @@ class PostgresGeneratorIntegrationTest extends PostgresSpec with Matchers with B
     executeWithoutResults("DROP TABLE IF EXISTS Users;")
   }
 
-  "Users table" should "not exist" in {
+  behavior of "PostgresService"
+  it should "not contain a users table" in {
     a[PSQLException] should be thrownBy executeWithResults("SELECT * FROM Users;")
   }
 
-  "Users table" should "be created, insert values, and return results" in {
+  it should "create a users table, insert values, and return these values later" in {
     executeWithoutResults("CREATE TABLE Users (id INT);")
     executeWithoutResults("INSERT INTO Users (id) VALUES (1);")
     val result =
@@ -29,7 +30,7 @@ class PostgresGeneratorIntegrationTest extends PostgresSpec with Matchers with B
     result.isLast shouldBe true
   }
 
-  "Users table" should "be created correctly" in {
+  it should "create a users table correctly" in {
     val createStatement = PostgresGenerator.generate(TestData.createStatement)
     executeWithoutResults(createStatement)
     val result = executeWithResults(
@@ -39,7 +40,8 @@ class PostgresGeneratorIntegrationTest extends PostgresSpec with Matchers with B
     result.getBoolean("exists") shouldBe true
   }
 
-  "Insert statement" should "be executed correctly" in {
+  behavior of "InsertStatements"
+  it should "be executed correctly" in {
     executeWithoutResults(PostgresGenerator.generate(TestData.createStatement))
     executeWithoutResultsPrepared(PostgresGenerator.generate(TestData.insertStatement), TestData.insertDataA)
     val result =
@@ -55,7 +57,8 @@ class PostgresGeneratorIntegrationTest extends PostgresSpec with Matchers with B
     result.isLast shouldBe true
   }
 
-  "Users table" should "be empty after delete following insert" in {
+  behavior of "DeleteStatements"
+  it should "clear the table following an insert" in {
     executeWithoutResults(PostgresGenerator.generate(TestData.createStatement))
     executeWithoutResultsPrepared(PostgresGenerator.generate(TestData.insertStatement), TestData.insertDataA)
     executeWithoutResults(PostgresGenerator.generate(TestData.deleteStatement))
@@ -64,7 +67,8 @@ class PostgresGeneratorIntegrationTest extends PostgresSpec with Matchers with B
     result.isBeforeFirst shouldBe false
   }
 
-  "Users table" should "be dropped successfully" in {
+  behavior of "DropStatements"
+  it should "remove the table from the database" in {
     executeWithoutResults(PostgresGenerator.generate(TestData.createStatement))
     var result = executeWithResults(
       "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'users');",
@@ -79,7 +83,8 @@ class PostgresGeneratorIntegrationTest extends PostgresSpec with Matchers with B
     result.getBoolean("exists") shouldBe false
   }
 
-  "Complex select statements" should "be executed correctly" in {
+  behavior of "SelectStatements"
+  it should "be executed correctly" in {
     executeWithoutResults(PostgresGenerator.generate(TestData.createStatement))
     //The query should select both
     executeWithoutResultsPrepared(PostgresGenerator.generate(TestData.insertStatement), TestData.insertDataA)
@@ -106,7 +111,8 @@ class PostgresGeneratorIntegrationTest extends PostgresSpec with Matchers with B
     result.isLast shouldBe true
   }
 
-  "Update statements" can "update all rows in a table" in {
+  behavior of "UpdateStatements"
+  it should "update all rows in a table" in {
     executeWithoutResults(PostgresGenerator.generate(TestData.createStatement))
     executeWithoutResultsPrepared(PostgresGenerator.generate(TestData.insertStatement), TestData.insertDataA)
     executeWithoutResultsPrepared(PostgresGenerator.generate(TestData.insertStatement), TestData.insertDataB)
@@ -133,7 +139,7 @@ class PostgresGeneratorIntegrationTest extends PostgresSpec with Matchers with B
     result.isLast shouldBe true
   }
 
-  "Update statements" can "update some rows in a table using WHERE" in {
+  it should "update some rows in a table using WHERE" in {
     executeWithoutResults(PostgresGenerator.generate(TestData.createStatement))
     executeWithoutResultsPrepared(PostgresGenerator.generate(TestData.insertStatement), TestData.insertDataA)
     executeWithoutResultsPrepared(PostgresGenerator.generate(TestData.insertStatement), TestData.insertDataB)

--- a/src/test/scala/temple/DSL/parser/DSLParserTest.scala
+++ b/src/test/scala/temple/DSL/parser/DSLParserTest.scala
@@ -8,19 +8,21 @@ import temple.utils.FileUtils._
 import temple.utils.MonadUtils.FromEither
 
 class DSLParserTest extends FlatSpec with Matchers {
-  "Empty string" should "parse" in {
+  behavior of "DSLParser"
+
+  it should "parse an empty string" in {
     DSLProcessor.parse("").isRight shouldBe true
   }
 
-  "Empty service" should "parse" in {
+  it should "parse an empty service" in {
     DSLProcessor.parse("Test: service { }").isRight shouldBe true
   }
 
-  "Annotations" should "not parse at the top level" in {
+  it should "not parse annotation at the top level" in {
     DSLProcessor.parse("@server Test: service { }").isLeft shouldBe true
   }
 
-  "simple.temple" should "parse to the correct result" in {
+  it should "parse to the correct result for simple.temple" in {
     val source      = readFile("src/test/scala/temple/testfiles/simple.temple")
     val parseResult = DSLProcessor.parse(source).fromEither(msg => fail(s"simple.temple did not parse, $msg"))
 
@@ -51,7 +53,7 @@ class DSLParserTest extends FlatSpec with Matchers {
     )
   }
 
-  "Exporting a parsed structure to string" should "re-parse to the same result" in {
+  it should "re-parse to the same result if a parsed structure is exported to string" in {
     val source      = readFile("src/test/scala/temple/testfiles/simple.temple")
     val parseResult = DSLProcessor.parse(source).fromEither(msg => fail(s"first parse failed, $msg"))
     val reSourced   = parseResult.mkString("\n\n")

--- a/src/test/scala/temple/DSL/semantics/SemanticAnalyserTest.scala
+++ b/src/test/scala/temple/DSL/semantics/SemanticAnalyserTest.scala
@@ -23,7 +23,9 @@ class SemanticAnalyserTest extends FlatSpec with Matchers {
   private def mkTemplefileSemanticsWithUserService(serviceBlock: ServiceBlock): Templefile =
     Templefile("test", Nil, Map.empty, Map("User" -> serviceBlock))
 
-  "Semantic Analyser" should "complain that there is no project block when parsing an Empty AST" in {
+  behavior of "Semantic Analyser"
+
+  it should "complain that there is no project block when parsing an Empty AST" in {
     a[SemanticParsingException] should be thrownBy { parseSemantics(Nil) }
   }
 

--- a/src/test/scala/temple/TempleConfigTest.scala
+++ b/src/test/scala/temple/TempleConfigTest.scala
@@ -3,26 +3,28 @@ package temple
 import org.scalatest.{FlatSpec, Matchers}
 
 class TempleConfigTest extends FlatSpec with Matchers {
-  "Generate" should "not correctly parse without a filename" in {
+  behavior of "TempleConfig"
+
+  it should "not parse the generate command correctly without a filename" in {
     a[RuntimeException] should be thrownBy new TempleConfig(Seq("generate"))
   }
 
-  "Generate" should "correctly parse with a filename" in {
+  it should "parse the generate command correctly with a filename" in {
     val config = new TempleConfig(Seq("generate", "foo.temple"))
     config.subcommand shouldBe Some(config.Generate)
     config.Generate.filename.toOption shouldBe Some("foo.temple")
   }
 
-  "Empty arguments" should "have no sub commands" in {
+  it should "have no sub commands if none were provided" in {
     val config = new TempleConfig(Seq())
     config.subcommand shouldBe None
   }
 
-  "Unknown subcommand" should "throw an exception" in {
+  it should "throw an exception if an unknown subcommand is used" in {
     an[IllegalArgumentException] should be thrownBy new TempleConfig(Seq("foobarbaz"))
   }
 
-  "Unknown flag" should "throw an exception" in {
+  it should "throw an exception if an unknown flag is used" in {
     an[IllegalArgumentException] should be thrownBy new TempleConfig(Seq("-z"))
   }
 }

--- a/src/test/scala/temple/collection/enumeration/EnumTest.scala
+++ b/src/test/scala/temple/collection/enumeration/EnumTest.scala
@@ -14,7 +14,9 @@ class EnumTest extends FlatSpec with Matchers {
     case object Case2 extends MyEnum("other")
   }
 
-  "Enums" should "have the correct values" in {
+  behavior of "Enums"
+
+  it should "have the correct values" in {
     MyEnum.values shouldBe IndexedSeq(MyEnum.Case1, MyEnum.Case2)
   }
 

--- a/src/test/scala/temple/generate/database/PostgresGeneratorTest.scala
+++ b/src/test/scala/temple/generate/database/PostgresGeneratorTest.scala
@@ -12,49 +12,64 @@ class PostgresGeneratorTest extends FlatSpec with Matchers {
   it should "generate correct CREATE statements" in {
     PostgresGenerator.generate(TestData.createStatement) shouldBe TestData.postgresCreateString
   }
+
   it should "generate correct SELECT statements" in {
     PostgresGenerator.generate(TestData.readStatement) shouldBe TestData.postgresSelectString
   }
+
   it should "handle column constraints correctly" in {
     PostgresGenerator.generate(TestData.createStatementWithConstraints) shouldBe TestData.postgresCreateStringWithConstraints
   }
+
   it should "handle selects with WHERE correctly" in {
     PostgresGenerator.generate(TestData.readStatementWithWhere) shouldBe TestData.postgresSelectStringWithWhere
   }
+
   it should "generate correct INSERT statements" in {
     PostgresGenerator.generate(TestData.insertStatement) shouldBe TestData.postgresInsertString
   }
+
   it should "generate correct INSERT statements with question marks" in {
     val questionMarkContext: PostgresContext = PostgresContext(PreparedType.QuestionMarks)
     PostgresGenerator.generate(TestData.insertStatement)(questionMarkContext) shouldBe TestData.postgresInsertStringWithQuestionMarks
   }
+
   it should "handle conjunctions in WHERE correctly" in {
     PostgresGenerator.generate(TestData.readStatementWithWhereConjunction) shouldBe TestData.postgresSelectStringWithWhereConjunction
   }
+
   it should "handle disjunctions in WHERE correctly" in {
     PostgresGenerator.generate(TestData.readStatementWithWhereDisjunction) shouldBe TestData.postgresSelectStringWithWhereDisjunction
   }
+
   it should "handle inverse in WHERE correctly" in {
     PostgresGenerator.generate(TestData.readStatementWithWhereInverse) shouldBe TestData.postgresSelectStringWithWhereInverse
   }
+
   it should "generate correct UPDATE statements" in {
     PostgresGenerator.generate(TestData.updateStatement) shouldBe TestData.postgresUpdateString
   }
+
   it should "handle updates with WHERE correctly" in {
     PostgresGenerator.generate(TestData.updateStatementWithWhere) shouldBe TestData.postgresUpdateStringWithWhere
   }
+
   it should "generate correct DELETE statements" in {
     PostgresGenerator.generate(TestData.deleteStatement) shouldBe TestData.postgresDeleteString
   }
+
   it should "handle deletes with WHERE correctly" in {
     PostgresGenerator.generate(TestData.deleteStatementWithWhere) shouldBe TestData.postgresDeleteStringWithWhere
   }
+
   it should "handle DROP TABLEs correctly" in {
     PostgresGenerator.generate(TestData.dropStatement) shouldBe TestData.postgresDropString
   }
+
   it should "handle DROP TABLE IF EXISTS correctly" in {
     PostgresGenerator.generate(TestData.dropStatementIfExists) shouldBe TestData.postgresDropStringIfExists
   }
+
   it should "handle complex SELECT statements" in {
     PostgresGenerator.generate(TestData.readStatementComplex) shouldBe TestData.postgresSelectStringComplex
   }

--- a/src/test/scala/temple/generate/database/PostgresGeneratorTest.scala
+++ b/src/test/scala/temple/generate/database/PostgresGeneratorTest.scala
@@ -7,53 +7,55 @@ class PostgresGeneratorTest extends FlatSpec with Matchers {
 
   implicit val context: PostgresContext = PostgresContext(PreparedType.DollarNumbers)
 
-  "PostgresGenerator" should "generate correct CREATE statements" in {
+  behavior of "PostgresGenerator"
+
+  it should "generate correct CREATE statements" in {
     PostgresGenerator.generate(TestData.createStatement) shouldBe TestData.postgresCreateString
   }
-  "PostgresGenerator" should "generate correct SELECT statements" in {
+  it should "generate correct SELECT statements" in {
     PostgresGenerator.generate(TestData.readStatement) shouldBe TestData.postgresSelectString
   }
-  "PostgresGenerator" should "handle column constraints correctly" in {
+  it should "handle column constraints correctly" in {
     PostgresGenerator.generate(TestData.createStatementWithConstraints) shouldBe TestData.postgresCreateStringWithConstraints
   }
-  "PostgresGenerator" should "handle selects with WHERE correctly" in {
+  it should "handle selects with WHERE correctly" in {
     PostgresGenerator.generate(TestData.readStatementWithWhere) shouldBe TestData.postgresSelectStringWithWhere
   }
-  "PostgresGenerator" should "generate correct INSERT statements" in {
+  it should "generate correct INSERT statements" in {
     PostgresGenerator.generate(TestData.insertStatement) shouldBe TestData.postgresInsertString
   }
-  "PostgresGenerator" should "generate correct INSERT statements with question marks" in {
+  it should "generate correct INSERT statements with question marks" in {
     val questionMarkContext: PostgresContext = PostgresContext(PreparedType.QuestionMarks)
     PostgresGenerator.generate(TestData.insertStatement)(questionMarkContext) shouldBe TestData.postgresInsertStringWithQuestionMarks
   }
-  "PostgresGenerator" should "handle conjunctions in WHERE correctly" in {
+  it should "handle conjunctions in WHERE correctly" in {
     PostgresGenerator.generate(TestData.readStatementWithWhereConjunction) shouldBe TestData.postgresSelectStringWithWhereConjunction
   }
-  "PostgresGenerator" should "handle disjunctions in WHERE correctly" in {
+  it should "handle disjunctions in WHERE correctly" in {
     PostgresGenerator.generate(TestData.readStatementWithWhereDisjunction) shouldBe TestData.postgresSelectStringWithWhereDisjunction
   }
-  "PostgresGenerator" should "handle inverse in WHERE correctly" in {
+  it should "handle inverse in WHERE correctly" in {
     PostgresGenerator.generate(TestData.readStatementWithWhereInverse) shouldBe TestData.postgresSelectStringWithWhereInverse
   }
-  "PostgresGenerator" should "generate correct UPDATE statements" in {
+  it should "generate correct UPDATE statements" in {
     PostgresGenerator.generate(TestData.updateStatement) shouldBe TestData.postgresUpdateString
   }
-  "PostgresGenerator" should "handle updates with WHERE correctly" in {
+  it should "handle updates with WHERE correctly" in {
     PostgresGenerator.generate(TestData.updateStatementWithWhere) shouldBe TestData.postgresUpdateStringWithWhere
   }
-  "PostgresGenerator" should "generate correct DELETE statements" in {
+  it should "generate correct DELETE statements" in {
     PostgresGenerator.generate(TestData.deleteStatement) shouldBe TestData.postgresDeleteString
   }
-  "PostgresGenerator" should "handle deletes with WHERE correctly" in {
+  it should "handle deletes with WHERE correctly" in {
     PostgresGenerator.generate(TestData.deleteStatementWithWhere) shouldBe TestData.postgresDeleteStringWithWhere
   }
-  "PostgresGenerator" should "handle DROP TABLEs correctly" in {
+  it should "handle DROP TABLEs correctly" in {
     PostgresGenerator.generate(TestData.dropStatement) shouldBe TestData.postgresDropString
   }
-  "PostgresGenerator" should "handle DROP TABLE IF EXISTS correctly" in {
+  it should "handle DROP TABLE IF EXISTS correctly" in {
     PostgresGenerator.generate(TestData.dropStatementIfExists) shouldBe TestData.postgresDropStringIfExists
   }
-  "PostgresGenerator" should "handle complex SELECT statements" in {
+  it should "handle complex SELECT statements" in {
     PostgresGenerator.generate(TestData.readStatementComplex) shouldBe TestData.postgresSelectStringComplex
   }
 }

--- a/src/test/scala/temple/utils/FileUtilsTest.scala
+++ b/src/test/scala/temple/utils/FileUtilsTest.scala
@@ -10,16 +10,18 @@ class FileUtilsTest extends FlatSpec with Matchers {
 
   def randomString(length: Int): String = new Random().alphanumeric.take(length).mkString
 
-  "Creating a folder that already exists" should "not throw an exception" in {
+  behavior of "FileUtils"
+
+  it should "not throw an exception when creating a folder that already exists" in {
     FileUtils.createDirectory("src")
     noException should be thrownBy FileUtils.createDirectory("src")
   }
 
-  "Creating a folder where a file with that name already exists" should "throw an exception" in {
+  it should "throw an exception when creating a folder where a file with that name already exists" in {
     a[FileAlreadyExistsException] should be thrownBy FileUtils.createDirectory("build.sbt")
   }
 
-  "Creating a file" should "succeed" in {
+  it should "create a file successfully in" in {
     // Generate a filename randomly, retrying if the file name already exists
     val filename = Iterator.continually(s"/tmp/test-${randomString(10)}").find(x => !Files.exists(Paths.get(x))).get
 

--- a/src/test/scala/temple/utils/MapUtilsTest.scala
+++ b/src/test/scala/temple/utils/MapUtilsTest.scala
@@ -7,20 +7,22 @@ import scala.collection.mutable
 
 class MapUtilsTest extends FlatSpec with Matchers {
 
-  "SafeInsertMap" should "allow any insertion into an empty map" in {
+  behavior of "SafeInsertMap"
+
+  it should "allow any insertion into an empty map" in {
     val map: mutable.Map[Int, Boolean] = mutable.HashMap()
 
     map.safeInsert(1 -> true, fail("Conflict incorrectly found in map"))
   }
 
-  "SafeInsertMap" should "allow non-colliding insertions into a map" in {
+  it should "allow non-colliding insertions into a map" in {
     val map: mutable.Map[Int, Boolean] = mutable.HashMap(1 -> true, 2 -> false)
 
     map.safeInsert(3 -> true, fail("Conflict incorrectly found in map"))
     map.safeInsert(0 -> false, fail("Conflict incorrectly found in map"))
   }
 
-  "SafeInsertMap" should "fail on duplicate insertions into a map" in {
+  it should "fail on duplicate insertions into a map" in {
     var callbackCalled = 0
 
     val map: mutable.Map[Int, Boolean] = mutable.HashMap()
@@ -31,7 +33,7 @@ class MapUtilsTest extends FlatSpec with Matchers {
     callbackCalled shouldBe 1
   }
 
-  "SafeInsertMap" should "fail on conflicting insertions into a map" in {
+  it should "fail on conflicting insertions into a map" in {
     var callbackCalled = 0
 
     val map: mutable.Map[Int, Boolean] = mutable.HashMap(3 -> true)
@@ -41,7 +43,7 @@ class MapUtilsTest extends FlatSpec with Matchers {
     callbackCalled shouldBe 1
   }
 
-  "SafeInsertMap" should "fail using an implicit fail handler" in {
+  it should "fail using an implicit fail handler" in {
     var callbackCalled = 0
 
     val map: mutable.Map[Int, Boolean] = mutable.HashMap(3 -> true)

--- a/src/test/scala/temple/utils/SeqUtilsTest.scala
+++ b/src/test/scala/temple/utils/SeqUtilsTest.scala
@@ -5,23 +5,25 @@ import org.scalatest.{FlatSpec, Matchers}
 class SeqUtilsTest extends FlatSpec with Matchers {
   import SeqUtils.SeqOptionExtras
 
-  "sequence" should "successfully return an empty list" in {
+  behavior of "sequence"
+
+  it should "successfully return an empty list" in {
     List().sequence shouldBe Some(List())
   }
 
-  "sequence" should "successfully return a list of Some" in {
+  it should "successfully return a list of Some" in {
     List(Some(1)).sequence shouldBe Some(List(1))
 
     List(Some(1), Some(2)).sequence shouldBe Some(List(1, 2))
   }
 
-  "sequence" should "return None for a list of Nones" in {
+  it should "return None for a list of Nones" in {
     List(None).sequence shouldBe None
 
     List(None, None).sequence shouldBe None
   }
 
-  "sequence" should "return None for a mixed list" in {
+  it should "return None for a mixed list" in {
     List(None, Some(1)).sequence shouldBe None
 
     List(Some(1), Some(2), None).sequence shouldBe None

--- a/src/test/scala/temple/utils/StringUtilsTest.scala
+++ b/src/test/scala/temple/utils/StringUtilsTest.scala
@@ -4,18 +4,19 @@ import org.scalatest.{FlatSpec, Matchers}
 import temple.utils.StringUtils.indent
 
 class StringUtilsTest extends FlatSpec with Matchers {
-  "indent" should "add spaces to an empty string" in {
+  behavior of "indent"
+  it should "add spaces to an empty string" in {
     indent("") shouldEqual "  "
   }
-  "indent" should "add n spaces to an empty string" in {
+  it should "add n spaces to an empty string" in {
     indent("", 1) shouldEqual " "
     indent("", 3) shouldEqual "   "
   }
-  "indent" should "add spaces to a single line" in {
+  it should "add spaces to a single line" in {
     indent("abcd") shouldEqual "  abcd"
     indent("efgh", 4) shouldEqual "    efgh"
   }
-  "indent" should "add spaces on each line" in {
+  it should "add spaces on each line" in {
     indent("abcd\nefg", 1) shouldEqual " abcd\n efg"
     indent("abcd\nefg\n", 1) shouldEqual " abcd\n efg\n "
   }

--- a/src/test/scala/temple/utils/StringUtilsTest.scala
+++ b/src/test/scala/temple/utils/StringUtilsTest.scala
@@ -5,17 +5,21 @@ import temple.utils.StringUtils.indent
 
 class StringUtilsTest extends FlatSpec with Matchers {
   behavior of "indent"
+
   it should "add spaces to an empty string" in {
     indent("") shouldEqual "  "
   }
+
   it should "add n spaces to an empty string" in {
     indent("", 1) shouldEqual " "
     indent("", 3) shouldEqual "   "
   }
+
   it should "add spaces to a single line" in {
     indent("abcd") shouldEqual "  abcd"
     indent("efgh", 4) shouldEqual "    efgh"
   }
+
   it should "add spaces on each line" in {
     indent("abcd\nefg", 1) shouldEqual " abcd\n efg"
     indent("abcd\nefg\n", 1) shouldEqual " abcd\n efg\n "


### PR DESCRIPTION
To improve the output of `sbt test`, tests for the same functionality can be grouped together using `behavior of ...`.

This works well when the tests in the same file test the same behaviour, but not when there's multiple behaviours being tested (see the integration tests) - are we happy to stick with this, or should I rename the tests to contain the behaviour in the right side of the `should`, so that the left side can always remain the same?