### PR TITLE
[Semantics] Make all attribute type parameters optional

### DIFF
--- a/src/main/scala/temple/DSL/semantics/Analyser.scala
+++ b/src/main/scala/temple/DSL/semantics/Analyser.scala
@@ -81,27 +81,27 @@ object Analyser {
         AttributeType.IntType(
           argMap.getOptionArg("min", IntArgType),
           argMap.getOptionArg("max", IntArgType),
-          argMap.getArg("precision", IntArgType).toShort,
+          argMap.getArg("precision", IntArgType).toByte,
         )
       case "string" =>
         val argMap = parseParameters(
           "maxLength" -> Some(Arg.NoArg),
-          "minLength" -> Some(Arg.IntArg(0)),
+          "minLength" -> Some(Arg.NoArg),
         )(args)
         AttributeType.StringType(
           argMap.getOptionArg("maxLength", IntArgType),
-          argMap.getArg("minLength", IntArgType).toInt,
+          argMap.getOptionArg("minLength", IntArgType).map(_.toInt),
         )
       case "float" =>
         val argMap = parseParameters(
-          "max"       -> Some(Arg.FloatingArg(Double.MaxValue)),
-          "min"       -> Some(Arg.FloatingArg(Double.MinValue)),
+          "max"       -> Some(Arg.NoArg),
+          "min"       -> Some(Arg.NoArg),
           "precision" -> Some(Arg.IntArg(8)),
         )(args)
         AttributeType.FloatType(
-          argMap.getArg("max", FloatingArgType),
-          argMap.getArg("min", FloatingArgType),
-          argMap.getArg("precision", FloatingArgType).toShort,
+          argMap.getOptionArg("max", FloatingArgType),
+          argMap.getOptionArg("min", FloatingArgType),
+          argMap.getArg("precision", FloatingArgType).toByte,
         )
       case "data" =>
         val argMap = parseParameters("maxSize" -> Some(Arg.NoArg))(args)

--- a/src/main/scala/temple/DSL/semantics/AttributeType.scala
+++ b/src/main/scala/temple/DSL/semantics/AttributeType.scala
@@ -10,11 +10,11 @@ object AttributeType {
   case object DateTimeType extends AttributeType
   case object TimeType     extends AttributeType
 
-  case class BlobType(size: Option[Long] = None)                extends AttributeType
-  case class StringType(max: Option[Long] = None, min: Int = 0) extends AttributeType
+  case class BlobType(size: Option[Long] = None)                           extends AttributeType
+  case class StringType(max: Option[Long] = None, min: Option[Int] = None) extends AttributeType
 
-  case class IntType(max: Option[Long] = None, min: Option[Long] = None, precision: Short = 4) extends AttributeType
+  case class IntType(max: Option[Long] = None, min: Option[Long] = None, precision: Byte = 4) extends AttributeType
 
-  case class FloatType(max: Double = Double.MaxValue, min: Double = Double.MinValue, precision: Short = 8)
+  case class FloatType(max: Option[Double] = None, min: Option[Double] = None, precision: Byte = 8)
       extends AttributeType
 }


### PR DESCRIPTION
At @jaylees14’s request, string `minLength` and float `min` and `max` now have None as a default value, rather than `0`/`MinValue`/`MaxValue` respectively