### PR TITLE
[Docker-Gen] Implement RUN, CMD and EXPOSE commands

### DIFF
--- a/src/main/scala/temple/generate/docker/DockerfileGenerator.scala
+++ b/src/main/scala/temple/generate/docker/DockerfileGenerator.scala
@@ -19,6 +19,7 @@ object DockerfileGenerator {
       case From(image, tag)        => mkCode("FROM", image, tag.map(":" + _))
       case Run(executable, params) => mkCode("RUN", buildArrayString(executable +: params))
       case Cmd(executable, params) => mkCode("CMD", buildArrayString(executable +: params))
+      case Expose(port)            => mkCode("EXPOSE", port.toString)
     }
 
   /** Given a [[temple.generate.docker.ast.DockerfileRoot]] object, build a valid Dockerfile string */

--- a/src/main/scala/temple/generate/docker/DockerfileGenerator.scala
+++ b/src/main/scala/temple/generate/docker/DockerfileGenerator.scala
@@ -18,6 +18,7 @@ object DockerfileGenerator {
     statement match {
       case From(image, tag)        => mkCode("FROM", image, tag.map(":" + _))
       case Run(executable, params) => mkCode("RUN", buildArrayString(executable +: params))
+      case Cmd(executable, params) => mkCode("CMD", buildArrayString(executable +: params))
     }
 
   /** Given a [[temple.generate.docker.ast.DockerfileRoot]] object, build a valid Dockerfile string */

--- a/src/main/scala/temple/generate/docker/DockerfileGenerator.scala
+++ b/src/main/scala/temple/generate/docker/DockerfileGenerator.scala
@@ -16,9 +16,8 @@ object DockerfileGenerator {
   /** Given a [[temple.generate.docker.ast.Statement]], generate a valid string */
   private def generateStatement(statement: Statement): String =
     statement match {
-      case From(image, tag)            => mkCode("FROM", image, tag.map(":" + _))
-      case RunCmd(command)             => mkCode("RUN", command)
-      case RunExec(executable, params) => mkCode("RUN", buildArrayString(executable +: params))
+      case From(image, tag)        => mkCode("FROM", image, tag.map(":" + _))
+      case Run(executable, params) => mkCode("RUN", buildArrayString(executable +: params))
     }
 
   /** Given a [[temple.generate.docker.ast.DockerfileRoot]] object, build a valid Dockerfile string */

--- a/src/main/scala/temple/generate/docker/ast/Statement.scala
+++ b/src/main/scala/temple/generate/docker/ast/Statement.scala
@@ -3,7 +3,6 @@ package temple.generate.docker.ast
 sealed trait Statement
 
 object Statement {
-  case class From(image: String, tag: Option[String])         extends Statement
-  case class RunCmd(command: String)                          extends Statement
-  case class RunExec(executable: String, params: Seq[String]) extends Statement
+  case class From(image: String, tag: Option[String])     extends Statement
+  case class Run(executable: String, params: Seq[String]) extends Statement
 }

--- a/src/main/scala/temple/generate/docker/ast/Statement.scala
+++ b/src/main/scala/temple/generate/docker/ast/Statement.scala
@@ -5,4 +5,5 @@ sealed trait Statement
 object Statement {
   case class From(image: String, tag: Option[String])     extends Statement
   case class Run(executable: String, params: Seq[String]) extends Statement
+  case class Cmd(executable: String, params: Seq[String]) extends Statement
 }

--- a/src/main/scala/temple/generate/docker/ast/Statement.scala
+++ b/src/main/scala/temple/generate/docker/ast/Statement.scala
@@ -9,7 +9,7 @@ object Statement {
 
   case class Expose(port: Int) extends Statement {
     {
-      val MAX_PORT = 65500
+      val MAX_PORT = 65535
       if (!(0 to MAX_PORT contains port)) throw new IllegalArgumentException("EXPOSE requires a valid port")
     }
   }

--- a/src/main/scala/temple/generate/docker/ast/Statement.scala
+++ b/src/main/scala/temple/generate/docker/ast/Statement.scala
@@ -6,4 +6,11 @@ object Statement {
   case class From(image: String, tag: Option[String])     extends Statement
   case class Run(executable: String, params: Seq[String]) extends Statement
   case class Cmd(executable: String, params: Seq[String]) extends Statement
+
+  case class Expose(port: Int) extends Statement {
+    {
+      val MAX_PORT = 65500
+      if (!(0 to MAX_PORT contains port)) throw new IllegalArgumentException("EXPOSE requires a valid port")
+    }
+  }
 }

--- a/src/test/scala/temple/generate/docker/DockerfileGeneratorTest.scala
+++ b/src/test/scala/temple/generate/docker/DockerfileGeneratorTest.scala
@@ -4,7 +4,9 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class DockerfileGeneratorTest extends FlatSpec with Matchers {
 
-  "DockerfileGenerator" should "generate correct base statements" in {
+  behavior of "DockerfileGenerator"
+
+  it should "generate correct base statements" in {
     DockerfileGenerator.generate(UnitTestData.basicDockerfileRoot) shouldBe UnitTestData.basicDockerfileString
   }
 

--- a/src/test/scala/temple/generate/docker/UnitTestData.scala
+++ b/src/test/scala/temple/generate/docker/UnitTestData.scala
@@ -9,6 +9,7 @@ object UnitTestData {
     From("temple/base", Some("1.2.3")),
     Seq(
       Run("/bin/python3", Seq("src/main.py", "--help")),
+      Cmd("/bin/bash", Seq("/app/start.sh")),
     ),
   )
 
@@ -16,5 +17,7 @@ object UnitTestData {
     """|FROM temple/base:1.2.3
        |
        |RUN ["/bin/python3", "src/main.py", "--help"]
+       |
+       |CMD ["/bin/bash", "/app/start.sh"]
        |""".stripMargin
 }

--- a/src/test/scala/temple/generate/docker/UnitTestData.scala
+++ b/src/test/scala/temple/generate/docker/UnitTestData.scala
@@ -10,6 +10,7 @@ object UnitTestData {
     Seq(
       Run("/bin/python3", Seq("src/main.py", "--help")),
       Cmd("/bin/bash", Seq("/app/start.sh")),
+      Expose(1234),
     ),
   )
 
@@ -19,5 +20,7 @@ object UnitTestData {
        |RUN ["/bin/python3", "src/main.py", "--help"]
        |
        |CMD ["/bin/bash", "/app/start.sh"]
+       |
+       |EXPOSE 1234
        |""".stripMargin
 }

--- a/src/test/scala/temple/generate/docker/UnitTestData.scala
+++ b/src/test/scala/temple/generate/docker/UnitTestData.scala
@@ -8,15 +8,12 @@ object UnitTestData {
   val basicDockerfileRoot: DockerfileRoot = DockerfileRoot(
     From("temple/base", Some("1.2.3")),
     Seq(
-      RunCmd("/bin/bash"),
-      RunExec("/bin/python3", Seq("src/main.py", "--help")),
+      Run("/bin/python3", Seq("src/main.py", "--help")),
     ),
   )
 
   val basicDockerfileString: String =
     """|FROM temple/base:1.2.3
-       |
-       |RUN /bin/bash
        |
        |RUN ["/bin/python3", "src/main.py", "--help"]
        |""".stripMargin

--- a/src/test/scala/temple/generate/docker/ast/StatementTest.scala
+++ b/src/test/scala/temple/generate/docker/ast/StatementTest.scala
@@ -1,0 +1,22 @@
+package temple.generate.docker.ast
+
+import org.scalatest.{FlatSpec, Matchers}
+import temple.generate.docker.ast.Statement.Expose
+
+class StatementTest extends FlatSpec with Matchers {
+
+  behavior of "Statement"
+
+  it should "Throw on negative port numbers" in {
+    a[IllegalArgumentException] should be thrownBy Expose(-1)
+  }
+
+  it should "Throw on large port numbers" in {
+    a[IllegalArgumentException] should be thrownBy Expose(1234567)
+  }
+
+  it should "Allow valid port numbers" in {
+    noException should be thrownBy Expose(1234)
+  }
+
+}


### PR DESCRIPTION
Add support for generation of `RUN`, `CMD` and `EXPOSE` commands in Dockerfile. 

Agreed that we're only going to support one variant of commands with multiple options, as they're all mostly equal anyway.

Unit tests included