### PR TITLE
[SQL-Gen] Map from semantic types into database creation types

### DIFF
--- a/src/main/scala/temple/builder/DatabaseBuilder.scala
+++ b/src/main/scala/temple/builder/DatabaseBuilder.scala
@@ -18,7 +18,7 @@ object DatabaseBuilder {
       case Annotation.Unique => ColumnConstraint.Unique
     }.toSeq
 
-    val (colType, constraints) = attribute.attributeType match {
+    val (colType, typeConstraints) = attribute.attributeType match {
       case AttributeType.BoolType     => (ColType.BoolCol, Nil)
       case AttributeType.DateType     => (ColType.DateCol, Nil)
       case AttributeType.DateTimeType => (ColType.DateTimeTzCol, Nil)
@@ -34,7 +34,7 @@ object DatabaseBuilder {
         val colType = if (max.isDefined) ColType.BoundedStringCol(max.get) else ColType.StringCol
         (colType, generateMaxMinConstraints(s"length($name)", None, min))
     }
-    ColumnDef(name, colType, valueConstraints ++ constraints)
+    ColumnDef(name, colType, valueConstraints ++ typeConstraints)
   }
 
   /**

--- a/src/main/scala/temple/builder/DatabaseBuilder.scala
+++ b/src/main/scala/temple/builder/DatabaseBuilder.scala
@@ -1,0 +1,57 @@
+package temple.builder
+
+import temple.DSL.semantics.{Annotation, Attribute, AttributeType, ServiceBlock}
+import temple.generate.database.ast.ColumnConstraint.Check
+import temple.generate.database.ast._
+
+/** Construct database queries from a Templefile structure */
+object DatabaseBuilder {
+
+  private def generateMaxMinConstraints[T](name: String, max: Option[T], min: Option[T]): Seq[ColumnConstraint] = {
+    val maxCondition = max.map(v => Check(name, ComparisonOperator.LessEqual, v.toString))
+    val minCondition = min.map(v => Check(name, ComparisonOperator.GreaterEqual, v.toString))
+    Seq(maxCondition, minCondition).flatten
+  }
+
+  private def toColDef(name: String, attribute: Attribute): ColumnDef = {
+    val valueConstraints = attribute.valueAnnotations.map {
+      case Annotation.Unique => ColumnConstraint.Unique
+    }.toSeq
+
+    val (colType, constraints) = attribute.attributeType match {
+      case AttributeType.BoolType     => (ColType.BoolCol, valueConstraints)
+      case AttributeType.DateType     => (ColType.DateCol, valueConstraints)
+      case AttributeType.DateTimeType => (ColType.DateTimeTzCol, valueConstraints)
+      case AttributeType.TimeType     => (ColType.TimeCol, valueConstraints)
+      case AttributeType.ForeignKey   => (ColType.IntCol(4), valueConstraints)
+      case AttributeType.BlobType(_)  => (ColType.BlobCol, valueConstraints)
+      case AttributeType.IntType(max, min, precision) =>
+        (ColType.IntCol(precision), valueConstraints ++ generateMaxMinConstraints(name, max, min))
+      case AttributeType.FloatType(max, min, precision) =>
+        (ColType.FloatCol(precision), valueConstraints ++ generateMaxMinConstraints(name, max, min))
+      case AttributeType.StringType(max, min) =>
+        val colType = if (max.isDefined) ColType.BoundedStringCol(max.get) else ColType.StringCol
+        (colType, valueConstraints ++ generateMaxMinConstraints(s"length($name)", None, min))
+    }
+    ColumnDef(name, colType, constraints)
+  }
+
+  /**
+    * Converts a service block to an associated list of database table create statement
+    * @param serviceName The service name
+    * @param service The ServiceBlock to generate
+    * @return the associated create statement
+    */
+  def createServiceTables(serviceName: String, service: ServiceBlock): Seq[Statement.Create] = {
+    // Create a list of all tables to be created, using top level attributes and nested structs
+    val allTables = service.structs.map(s => (s._1, s._2.attributes)).toSeq :+ (serviceName, service.attributes)
+
+    // Generate the create statement for each table
+    allTables
+      .map {
+        case (tableName, attributes) =>
+          val columns = attributes.map(a => toColDef(a._1, a._2))
+          Statement.Create(tableName, columns.toSeq)
+      }
+  }
+}

--- a/src/main/scala/temple/generate/database/ast/ColType.scala
+++ b/src/main/scala/temple/generate/database/ast/ColType.scala
@@ -3,13 +3,13 @@ package temple.generate.database.ast
 sealed trait ColType
 
 object ColType {
-  case class IntCol(precision: Short)     extends ColType
-  case class FloatCol(precision: Short)   extends ColType
-  case class BoundedStringCol(max: Short) extends ColType
-  case object StringCol                   extends ColType
-  case object BoolCol                     extends ColType
-  case object DateCol                     extends ColType
-  case object TimeCol                     extends ColType
-  case object DateTimeTzCol               extends ColType
-  case object BlobCol                     extends ColType
+  case class IntCol(precision: Short)    extends ColType
+  case class FloatCol(precision: Short)  extends ColType
+  case class BoundedStringCol(max: Long) extends ColType
+  case object StringCol                  extends ColType
+  case object BoolCol                    extends ColType
+  case object DateCol                    extends ColType
+  case object TimeCol                    extends ColType
+  case object DateTimeTzCol              extends ColType
+  case object BlobCol                    extends ColType
 }

--- a/src/test/scala/temple/builder/DatabaseBuilderTest.scala
+++ b/src/test/scala/temple/builder/DatabaseBuilderTest.scala
@@ -1,0 +1,17 @@
+package temple.builder
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class DatabaseBuilderTest extends FlatSpec with Matchers {
+  behavior of "DatabaseBuilder"
+
+  it should "correctly create a simple users table" in {
+    val createQuery = DatabaseBuilder.createServiceTables("Users", DatabaseBuilderTestData.sampleService)
+    createQuery shouldBe DatabaseBuilderTestData.sampleServiceCreate
+  }
+
+  it should "correctly create a complex users table" in {
+    val createQuery = DatabaseBuilder.createServiceTables("Users", DatabaseBuilderTestData.sampleComplexService)
+    createQuery shouldBe DatabaseBuilderTestData.sampleComplexServiceCreate
+  }
+}

--- a/src/test/scala/temple/builder/DatabaseBuilderTestData.scala
+++ b/src/test/scala/temple/builder/DatabaseBuilderTestData.scala
@@ -1,0 +1,124 @@
+package temple.builder
+
+import temple.DSL.semantics.AttributeType._
+import temple.DSL.semantics.{Annotation, Attribute, ServiceBlock, StructBlock}
+import temple.generate.database.ast.ColType._
+import temple.generate.database.ast.ColumnConstraint.{Check, Unique}
+import temple.generate.database.ast.ComparisonOperator.{GreaterEqual, LessEqual}
+import temple.generate.database.ast.Statement.Create
+import temple.generate.database.ast.{ColumnDef, Statement}
+
+import scala.collection.immutable.ListMap
+
+object DatabaseBuilderTestData {
+
+  // TODO: This test doesn't include a `ForeignKey` attribute, since it is not yet supported
+  //  by the parser/semantic analysis. Once it is, please update these tests!
+  val sampleService: ServiceBlock = ServiceBlock(
+    ListMap(
+      "id"          -> Attribute(IntType()),
+      "bankBalance" -> Attribute(FloatType()),
+      "name"        -> Attribute(StringType()),
+      "isStudent"   -> Attribute(BoolType),
+      "dateOfBirth" -> Attribute(DateType),
+      "timeOfDay"   -> Attribute(TimeType),
+      "expiry"      -> Attribute(DateTimeType),
+      "image"       -> Attribute(BlobType()),
+    ),
+  )
+
+  val sampleServiceCreate: Seq[Statement.Create] =
+    Seq(
+      Create(
+        "Users",
+        Seq(
+          ColumnDef("id", IntCol(4)),
+          ColumnDef("bankBalance", FloatCol(8)),
+          ColumnDef("name", StringCol),
+          ColumnDef("isStudent", BoolCol),
+          ColumnDef("dateOfBirth", DateCol),
+          ColumnDef("timeOfDay", TimeCol),
+          ColumnDef("expiry", DateTimeTzCol),
+          ColumnDef("image", BlobCol),
+        ),
+      ),
+    )
+
+  val sampleComplexService: ServiceBlock = ServiceBlock(
+    ListMap(
+      "id"             -> Attribute(IntType(max = Some(100), min = Some(10), precision = 2)),
+      "anotherId"      -> Attribute(IntType(max = Some(100), min = Some(10))),
+      "yetAnotherId"   -> Attribute(IntType(max = Some(100), min = Some(10), precision = 8)),
+      "bankBalance"    -> Attribute(FloatType(max = Some(300), min = Some(0), precision = 4)),
+      "bigBankBalance" -> Attribute(FloatType(max = Some(123), min = Some(0))),
+      "name"           -> Attribute(StringType(max = None, min = Some(1))),
+      "initials"       -> Attribute(StringType(max = Some(5), min = Some(0))),
+      "isStudent"      -> Attribute(BoolType),
+      "dateOfBirth"    -> Attribute(DateType),
+      "timeOfDay"      -> Attribute(TimeType),
+      "expiry"         -> Attribute(DateTimeType),
+      "image"          -> Attribute(BlobType()),
+    ),
+    structs = ListMap(
+      "Test" -> StructBlock(
+        ListMap(
+          "favouriteColour" -> Attribute(StringType(), valueAnnotations = Set(Annotation.Unique)),
+          "bedTime"         -> Attribute(TimeType),
+          "favouriteNumber" -> Attribute(IntType(max = Some(10), min = Some(0))),
+        ),
+      ),
+    ),
+  )
+
+  val sampleComplexServiceCreate: Seq[Statement.Create] =
+    Seq(
+      Create(
+        "Test",
+        Seq(
+          ColumnDef("favouriteColour", StringCol, Seq(Unique)),
+          ColumnDef("bedTime", TimeCol),
+          ColumnDef(
+            "favouriteNumber",
+            IntCol(4),
+            Seq(
+              Check("favouriteNumber", LessEqual, "10"),
+              Check("favouriteNumber", GreaterEqual, "0"),
+            ),
+          ),
+        ),
+      ),
+      Create(
+        "Users",
+        Seq(
+          ColumnDef("id", IntCol(2), Seq(Check("id", LessEqual, "100"), Check("id", GreaterEqual, "10"))),
+          ColumnDef(
+            "anotherId",
+            IntCol(4),
+            Seq(Check("anotherId", LessEqual, "100"), Check("anotherId", GreaterEqual, "10")),
+          ),
+          ColumnDef(
+            "yetAnotherId",
+            IntCol(8),
+            Seq(Check("yetAnotherId", LessEqual, "100"), Check("yetAnotherId", GreaterEqual, "10")),
+          ),
+          ColumnDef(
+            "bankBalance",
+            FloatCol(4),
+            Seq(Check("bankBalance", LessEqual, "300.0"), Check("bankBalance", GreaterEqual, "0.0")),
+          ),
+          ColumnDef(
+            "bigBankBalance",
+            FloatCol(8),
+            Seq(Check("bigBankBalance", LessEqual, "123.0"), Check("bigBankBalance", GreaterEqual, "0.0")),
+          ),
+          ColumnDef("name", StringCol, Seq(Check("length(name)", GreaterEqual, "1"))),
+          ColumnDef("initials", BoundedStringCol(5), Seq(Check("length(initials)", GreaterEqual, "0"))),
+          ColumnDef("isStudent", BoolCol),
+          ColumnDef("dateOfBirth", DateCol),
+          ColumnDef("timeOfDay", TimeCol),
+          ColumnDef("expiry", DateTimeTzCol),
+          ColumnDef("image", BlobCol),
+        ),
+      ),
+    )
+}


### PR DESCRIPTION
This is a first in a number of PRs that perform the mapping from our Templefile to Postgres. Here, we perform the highest level mapping, from `ServiceBlock` to `Statement.Create`.

The implementation here is database agnostic - the next PR will call these functions and pass the result to the associated database provider. 

I’m not 100% set on the `Builder` name, please shout if you have a better suggestion.

The current package structure I’m envisaging looks like this - where the main mapping entry point is `ProjectBuilder`, which will assemble an entire project by calling into the generic sub-builders, and then calling into the implementation specific objects, like `PostgresGenerator` etc. Thoughts?:

```
📁 temple
┖─ 📁 builder
   ┠─ 📝 DatabaseBuilder.scala
   ┠─ 📝 DockerBuilder.scala
   ┠─ 📝 ServerBuilder.scala
   ┠─ ...
   ┖─ 📁 project
       ┠─ 📝 ProjectBuilder.scala
       ┖─ ...
```

### Test Plan
- Additional unit tests added, with simple types and complex constrained types