### PR TITLE
[SQL-gen] Remove unused Null case class

### DIFF
--- a/src/main/scala/temple/generate/database/ast/ColumnConstraint.scala
+++ b/src/main/scala/temple/generate/database/ast/ColumnConstraint.scala
@@ -5,7 +5,6 @@ sealed trait ColumnConstraint
 
 object ColumnConstraint {
   case object NonNull                                                     extends ColumnConstraint
-  case object Null                                                        extends ColumnConstraint
   case class Check(left: String, comp: ComparisonOperator, right: String) extends ColumnConstraint
   case object Unique                                                      extends ColumnConstraint
   case object PrimaryKey                                                  extends ColumnConstraint


### PR DESCRIPTION
Sorry for the large PR. This removes the unused Null case that was made redundant in #55.