### PR TITLE
[Semantics] Add name of foreign table to foreign key attribute type

### DIFF
--- a/src/main/scala/temple/DSL/semantics/AttributeType.scala
+++ b/src/main/scala/temple/DSL/semantics/AttributeType.scala
@@ -1,20 +1,25 @@
 package temple.DSL.semantics
 
 /** The type of an attribute, i.e. a column in a database/field in a struct */
-trait AttributeType
+sealed trait AttributeType
 
 object AttributeType {
-  case object ForeignKey   extends AttributeType
-  case object BoolType     extends AttributeType
-  case object DateType     extends AttributeType
-  case object DateTimeType extends AttributeType
-  case object TimeType     extends AttributeType
+  case class ForeignKey(references: String) extends AttributeType
 
-  case class BlobType(size: Option[Long] = None)                           extends AttributeType
-  case class StringType(max: Option[Long] = None, min: Option[Int] = None) extends AttributeType
+  sealed trait PrimitiveAttributeType extends AttributeType
 
-  case class IntType(max: Option[Long] = None, min: Option[Long] = None, precision: Byte = 4) extends AttributeType
+  case object BoolType     extends PrimitiveAttributeType
+  case object DateType     extends PrimitiveAttributeType
+  case object DateTimeType extends PrimitiveAttributeType
+  case object TimeType     extends PrimitiveAttributeType
+
+  case class BlobType(size: Option[Long] = None) extends PrimitiveAttributeType
+
+  case class StringType(max: Option[Long] = None, min: Option[Int] = None) extends PrimitiveAttributeType
+
+  case class IntType(max: Option[Long] = None, min: Option[Long] = None, precision: Byte = 4)
+      extends PrimitiveAttributeType
 
   case class FloatType(max: Option[Double] = None, min: Option[Double] = None, precision: Byte = 8)
-      extends AttributeType
+      extends PrimitiveAttributeType
 }

--- a/src/main/scala/temple/builder/DatabaseBuilder.scala
+++ b/src/main/scala/temple/builder/DatabaseBuilder.scala
@@ -23,11 +23,11 @@ object DatabaseBuilder {
       } ++ nonNullConstraint
 
     val (colType, typeConstraints) = attribute.attributeType match {
-      case AttributeType.BoolType     => (ColType.BoolCol, Nil)
-      case AttributeType.DateType     => (ColType.DateCol, Nil)
-      case AttributeType.DateTimeType => (ColType.DateTimeTzCol, Nil)
-      case AttributeType.TimeType     => (ColType.TimeCol, Nil)
-      case AttributeType.ForeignKey   => (ColType.IntCol(4), Nil)
+      case AttributeType.BoolType      => (ColType.BoolCol, Nil)
+      case AttributeType.DateType      => (ColType.DateCol, Nil)
+      case AttributeType.DateTimeType  => (ColType.DateTimeTzCol, Nil)
+      case AttributeType.TimeType      => (ColType.TimeCol, Nil)
+      case AttributeType.ForeignKey(_) => (ColType.IntCol(4), Nil)
       case AttributeType.BlobType(max) =>
         (ColType.BlobCol, generateMaxMinConstraints(s"octet_length($name)", max, None))
       case AttributeType.IntType(max, min, precision) =>


### PR DESCRIPTION
This will eventually be able to be used for `REFERENCES` constraints, but only once verifying that the table is in the same database