### PR TITLE
[Semantics] Distinguish language config between services and targets

### DIFF
--- a/src/main/scala/temple/DSL/semantics/Analyser.scala
+++ b/src/main/scala/temple/DSL/semantics/Analyser.scala
@@ -153,7 +153,7 @@ object Analyser {
 
   /** A parser of Metadata items that can occur in service blocks */
   private val parseServiceMetadata = new MetadataParser[ServiceMetadata] {
-    registerKeyword("language", TokenArgType)(Language.parse(_))
+    registerKeyword("language", TokenArgType)(ServiceLanguage.parse(_))
     registerKeyword("database", TokenArgType)(Database.parse(_))
     registerKeyword("auth", "login", TokenArgType)(ServiceAuth)
     registerKeyword("uses", "services", ListArgType(TokenArgType))(Uses)
@@ -161,14 +161,14 @@ object Analyser {
 
   /** A parser of Metadata items that can occur in project blocks */
   private val parseProjectMetadata = new MetadataParser[ProjectMetadata] {
-    registerKeyword("language", TokenArgType)(Language.parse(_))
+    registerKeyword("language", TokenArgType)(ServiceLanguage.parse(_))
     registerKeyword("database", TokenArgType)(Database.parse(_))
     registerKeyword("provider", TokenArgType)(Provider.parse(_))
   }
 
   /** A parser of Metadata items that can occur in target blocks */
   private val parseTargetMetadata = new MetadataParser[TargetMetadata] {
-    registerKeyword("language", TokenArgType)(Language.parse(_))
+    registerKeyword("language", TokenArgType)(TargetLanguage.parse(_))
     registerKeyword("auth", "services", ListArgType(TokenArgType))(TargetAuth)
   }
 

--- a/src/main/scala/temple/DSL/semantics/Metadata.scala
+++ b/src/main/scala/temple/DSL/semantics/Metadata.scala
@@ -10,19 +10,27 @@ object Metadata {
   sealed trait ServiceMetadata extends Metadata
   sealed trait ProjectMetadata extends Metadata
 
-  sealed abstract class Language private (name: String, aliases: String*)
+  sealed abstract class TargetLanguage private (name: String, aliases: String*)
       extends EnumEntry(name, aliases)
       with TargetMetadata
+
+  object TargetLanguage extends Enum[TargetLanguage] {
+    val values: IndexedSeq[TargetLanguage] = findValues
+
+    case object Swift      extends TargetLanguage("Swift")
+    case object JavaScript extends TargetLanguage("JavaScript", "js")
+  }
+
+  sealed abstract class ServiceLanguage private (name: String, aliases: String*)
+      extends EnumEntry(name, aliases)
       with ServiceMetadata
       with ProjectMetadata
 
-  object Language extends Enum[Language] {
-    val values: IndexedSeq[Language] = findValues
+  object ServiceLanguage extends Enum[ServiceLanguage] {
+    val values: IndexedSeq[ServiceLanguage] = findValues
 
-    case object Go         extends Language("Go", "golang")
-    case object Scala      extends Language("Scala")
-    case object Swift      extends Language("Swift")
-    case object JavaScript extends Language("JavaScript", "js")
+    case object Go    extends ServiceLanguage("Go", "golang")
+    case object Scala extends ServiceLanguage("Scala")
   }
 
   sealed abstract class Provider private (name: String) extends EnumEntry(name) with ProjectMetadata

--- a/src/test/scala/temple/DSL/semantics/TempleBlockTest.scala
+++ b/src/test/scala/temple/DSL/semantics/TempleBlockTest.scala
@@ -8,26 +8,26 @@ class TempleBlockTest extends FlatSpec with Matchers {
 
   it should "lookupLocalMetadata for project block" in {
     val projectBlock = ProjectBlock(Seq(Metadata.Database.Postgres))
-    projectBlock.lookupLocalMetadata[Metadata.Language] shouldBe None
+    projectBlock.lookupLocalMetadata[Metadata.ServiceLanguage] shouldBe None
     projectBlock.lookupLocalMetadata[Metadata.Database] shouldBe Some(Metadata.Database.Postgres)
 
-    val targetBlock = TargetBlock(Seq(Metadata.Language.JavaScript))
-    targetBlock.lookupLocalMetadata[Metadata.Language] shouldBe Some(Metadata.Language.JavaScript)
+    val targetBlock = TargetBlock(Seq(Metadata.TargetLanguage.JavaScript))
+    targetBlock.lookupLocalMetadata[Metadata.TargetLanguage] shouldBe Some(Metadata.TargetLanguage.JavaScript)
     targetBlock.lookupLocalMetadata[Metadata.Database] shouldBe None
   }
 
   it should "fail to lookupMetadata without being in a project file" in {
-    val projectBlock = ProjectBlock(Seq(Metadata.Language.JavaScript))
+    val projectBlock = ProjectBlock(Seq(Metadata.ServiceLanguage.Go))
     a[NullPointerException] should be thrownBy { projectBlock.lookupMetadata[Metadata.Database] }
   }
 
   it should "lookupMetadata when in a project file" in {
-    val projectBlock = ProjectBlock(Seq(Metadata.Language.JavaScript, Metadata.Database.Postgres))
-    val serviceBlock = ServiceBlock(Map.empty, Seq(Metadata.Language.Go))
+    val projectBlock = ProjectBlock(Seq(Metadata.ServiceLanguage.Scala, Metadata.Database.Postgres))
+    val serviceBlock = ServiceBlock(Map.empty, Seq(Metadata.ServiceLanguage.Go))
 
     Templefile("TestProject", projectBlock, Map.empty, Map("Users" -> serviceBlock))
 
-    serviceBlock.lookupMetadata[Metadata.Language] shouldBe Some(Metadata.Language.Go)
+    serviceBlock.lookupMetadata[Metadata.ServiceLanguage] shouldBe Some(Metadata.ServiceLanguage.Go)
     serviceBlock.lookupMetadata[Metadata.Database] shouldBe Some(Metadata.Database.Postgres)
     serviceBlock.lookupMetadata[Metadata.Uses] shouldBe None
   }


### PR DESCRIPTION
For @jaylees14, keep language options for targets and services distinct