### PR TITLE
[DSL] Support the Enumerate metadata item

### DIFF
--- a/src/main/scala/temple/DSL/parser/DSLParser.scala
+++ b/src/main/scala/temple/DSL/parser/DSLParser.scala
@@ -22,7 +22,7 @@ class DSLParser extends JavaTokenParsers with UtilParsers {
   }
 
   /** A parser generator for a semicolon (optional at the end of a block). */
-  protected def semicolon: Parser[String] = ";" | guard("""$""".r | "}")
+  protected def semicolon: Parser[String] = guard("""$""".r | "}") | ";"
 
   /** A parser generator for an entry within a block. */
   protected def entry: Parser[Entry] = rootItem <~ semicolon.? | (attribute | metadata) <~ semicolon

--- a/src/main/scala/temple/DSL/parser/DSLParser.scala
+++ b/src/main/scala/temple/DSL/parser/DSLParser.scala
@@ -28,9 +28,10 @@ class DSLParser extends JavaTokenParsers with UtilParsers {
   protected def entry: Parser[Entry] = rootItem <~ semicolon.? | (attribute | metadata) <~ semicolon
 
   /** A parser generator for a line of metadata */
-  protected def metadata: Parser[Entry.Metadata] = "#" ~> lowerIdent ~ (allArgs | shorthandListArg) ^^ {
-    case function ~ args => Entry.Metadata(function, args)
-  }
+  protected def metadata: Parser[Entry.Metadata] =
+    "#" ~> lowerIdent ~ (allArgs | shorthandListArg | success(Args())) ^^ {
+      case function ~ args => Entry.Metadata(function, args)
+    }
 
   /** A parser generator for a struct’s attribute */
   protected def attribute: Parser[Entry.Attribute] =

--- a/src/main/scala/temple/DSL/parser/DSLParser.scala
+++ b/src/main/scala/temple/DSL/parser/DSLParser.scala
@@ -22,7 +22,7 @@ class DSLParser extends JavaTokenParsers with UtilParsers {
   }
 
   /** A parser generator for a semicolon (optional at the end of a block). */
-  protected def semicolon: Parser[String] = ";" | guard("}" | """$""".r)
+  protected def semicolon: Parser[String] = ";" | guard("""$""".r | "}")
 
   /** A parser generator for an entry within a block. */
   protected def entry: Parser[Entry] = rootItem <~ semicolon.? | (attribute | metadata) <~ semicolon

--- a/src/main/scala/temple/DSL/semantics/Analyser.scala
+++ b/src/main/scala/temple/DSL/semantics/Analyser.scala
@@ -155,7 +155,7 @@ object Analyser {
   private val parseServiceMetadata = new MetadataParser[ServiceMetadata] {
     registerKeyword("language", TokenArgType)(ServiceLanguage.parse(_))
     registerKeyword("database", TokenArgType)(Database.parse(_))
-    registerOptionalKeyword("enumerate", "by", TokenArgType)(ServiceEnumerate)
+    registerOptionalKeyword("enumerable", "by", TokenArgType)(ServiceEnumerable)
     registerKeyword("auth", "login", TokenArgType)(ServiceAuth)
     registerKeyword("uses", "services", ListArgType(TokenArgType))(Uses)
   }

--- a/src/main/scala/temple/DSL/semantics/Analyser.scala
+++ b/src/main/scala/temple/DSL/semantics/Analyser.scala
@@ -155,6 +155,7 @@ object Analyser {
   private val parseServiceMetadata = new MetadataParser[ServiceMetadata] {
     registerKeyword("language", TokenArgType)(ServiceLanguage.parse(_))
     registerKeyword("database", TokenArgType)(Database.parse(_))
+    registerOptionalKeyword("enumerate", "by", TokenArgType)(ServiceEnumerate)
     registerKeyword("auth", "login", TokenArgType)(ServiceAuth)
     registerKeyword("uses", "services", ListArgType(TokenArgType))(Uses)
   }

--- a/src/main/scala/temple/DSL/semantics/Metadata.scala
+++ b/src/main/scala/temple/DSL/semantics/Metadata.scala
@@ -50,9 +50,9 @@ object Metadata {
     case object Postgres extends Database("postgres", "PostgreSQL")
   }
 
-  case class ServiceAuth(login: String)           extends ServiceMetadata
-  case class ServiceEnumerate(by: Option[String]) extends ServiceMetadata
-  case class TargetAuth(services: Seq[String])    extends TargetMetadata
-  case class Uses(services: Seq[String])          extends ServiceMetadata
+  case class ServiceAuth(login: String)            extends ServiceMetadata
+  case class ServiceEnumerable(by: Option[String]) extends ServiceMetadata
+  case class TargetAuth(services: Seq[String])     extends TargetMetadata
+  case class Uses(services: Seq[String])           extends ServiceMetadata
 
 }

--- a/src/main/scala/temple/DSL/semantics/Metadata.scala
+++ b/src/main/scala/temple/DSL/semantics/Metadata.scala
@@ -50,8 +50,9 @@ object Metadata {
     case object Postgres extends Database("postgres", "PostgreSQL")
   }
 
-  case class ServiceAuth(login: String)        extends ServiceMetadata
-  case class TargetAuth(services: Seq[String]) extends TargetMetadata
-  case class Uses(services: Seq[String])       extends ServiceMetadata
+  case class ServiceAuth(login: String)           extends ServiceMetadata
+  case class ServiceEnumerate(by: Option[String]) extends ServiceMetadata
+  case class TargetAuth(services: Seq[String])    extends TargetMetadata
+  case class Uses(services: Seq[String])          extends ServiceMetadata
 
 }

--- a/src/main/scala/temple/DSL/semantics/MetadataParser.scala
+++ b/src/main/scala/temple/DSL/semantics/MetadataParser.scala
@@ -50,9 +50,7 @@ class MetadataParser[T <: Metadata]() {
     * Add a handler for a new type of metadata, with an optional argument.
     *
     * @param metaKey The name of the metadata item to add
-    * @param argKey The name of the single argument to the metadata. Note that there is also
-    *               [[temple.DSL.semantics.MetadataParser#registerOptionalKeyword(java.lang.String, java.lang.String, temple.DSL.semantics.ArgType, scala.Function1)]]
-    *               if this is the same as `metaKey`.
+    * @param argKey The name of the single argument to the metadata.
     * @param argType The type of the field to expect
     * @param constructor The function to turn an optional input of type [[ArgType]] into a value of type [[T]]
     * @tparam A The underlying type of the field, inferred from `argType`
@@ -65,12 +63,6 @@ class MetadataParser[T <: Metadata]() {
         val argMap                    = parseParameters(argKey -> Some(NoArg))(args)
         constructor(argMap.getOptionArg(argKey, argType))
       })
-
-  /** A shorthand for
-    * [[temple.DSL.semantics.MetadataParser#registerOptionalKeyword(java.lang.String, temple.DSL.semantics.ArgType, scala.Function1)]]
-    * with the same `key` used for both the metadata name and its single argument */
-  final protected def registerOptionalKeyword[A](key: String, argType: ArgType[A])(constructor: Option[A] => T): Unit =
-    registerOptionalKeyword(key, key, argType)(constructor)
 
   /** Perform parsing by looking up the relevant function and passing it the argument list */
   final def apply(metaKey: String, args: Args)(implicit context: BlockContext): T =

--- a/src/main/scala/temple/DSL/semantics/MetadataParser.scala
+++ b/src/main/scala/temple/DSL/semantics/MetadataParser.scala
@@ -2,8 +2,8 @@ package temple.DSL.semantics
 
 import temple.DSL.semantics.Analyser.parseParameters
 import temple.DSL.semantics.ErrorHandling.{BlockContext, Context, fail}
+import temple.DSL.syntax.Arg.NoArg
 import temple.DSL.syntax.Args
-import temple.utils.MapUtils._
 
 import scala.collection.mutable
 
@@ -24,7 +24,8 @@ class MetadataParser[T <: Metadata]() {
     *
     * @param metaKey The name of the metadata item to add
     * @param argKey The name of the single argument to the metadata. Note that there is also
-    *               [[temple.DSL.semantics.MetadataParser#registerKeyword]]
+    *               [[temple.DSL.semantics.MetadataParser#registerKeyword(java.lang.String, temple.DSL.semantics.ArgType, scala.Option, scala.Function1)]]
+    *               if this is the same as `metaKey`.
     * @param argType The type of the field to expect
     * @param constructor The function to turn an input of type [[ArgType]] into a value of type [[T]]
     * @tparam A The underlying type of the field, inferred from `argType`
@@ -39,13 +40,39 @@ class MetadataParser[T <: Metadata]() {
         constructor(argMap.getArg(argKey, argType))
       })
 
-  /** A shorthand for [[temple.DSL.semantics.MetadataParser#registerKeyword]] with the same `key` used for both the
-    * metadata name and its single argument */
+  /** A shorthand for
+    * [[temple.DSL.semantics.MetadataParser#registerKeyword(java.lang.String, temple.DSL.semantics.ArgType, scala.Option, scala.Function1)]]
+    * with the same `key` used for both the metadata name and its single argument */
   final protected def registerKeyword[A](key: String, argType: ArgType[A])(constructor: A => T): Unit =
     registerKeyword(key, key, argType)(constructor)
 
-  /** Perform parsing by looking up the relevant function and
-    * [[scala.collection.IterableOnceOps#foldRight(java.lang.Object, scala.Function2)]] supports */
+  /**
+    * Add a handler for a new type of metadata, with an optional argument.
+    *
+    * @param metaKey The name of the metadata item to add
+    * @param argKey The name of the single argument to the metadata. Note that there is also
+    *               [[temple.DSL.semantics.MetadataParser#registerOptionalKeyword(java.lang.String, java.lang.String, temple.DSL.semantics.ArgType, scala.Function1)]]
+    *               if this is the same as `metaKey`.
+    * @param argType The type of the field to expect
+    * @param constructor The function to turn an optional input of type [[ArgType]] into a value of type [[T]]
+    * @tparam A The underlying type of the field, inferred from `argType`
+    */
+  final protected def registerOptionalKeyword[A](metaKey: String, argKey: String, argType: ArgType[A])(
+    constructor: Option[A] => T,
+  ): Unit =
+    matchers += (metaKey -> { args =>
+        implicit val context: Context = Context(metaKey)
+        val argMap                    = parseParameters(argKey -> Some(NoArg))(args)
+        constructor(argMap.getOptionArg(argKey, argType))
+      })
+
+  /** A shorthand for
+    * [[temple.DSL.semantics.MetadataParser#registerOptionalKeyword(java.lang.String, temple.DSL.semantics.ArgType, scala.Function1)]]
+    * with the same `key` used for both the metadata name and its single argument */
+  final protected def registerOptionalKeyword[A](key: String, argType: ArgType[A])(constructor: Option[A] => T): Unit =
+    registerOptionalKeyword(key, key, argType)(constructor)
+
+  /** Perform parsing by looking up the relevant function and passing it the argument list */
   final def apply(metaKey: String, args: Args)(implicit context: BlockContext): T =
     matchers.get(metaKey).map(_(args)) getOrElse {
       fail(s"No valid metadata $metaKey in $context")

--- a/src/main/scala/temple/DSL/syntax/Entry.scala
+++ b/src/main/scala/temple/DSL/syntax/Entry.scala
@@ -1,5 +1,8 @@
 package temple.DSL.syntax
 
+import temple.DSL.syntax.Arg.ListArg
+import temple.generate.utils.CodeTerm.{codeParens, mkCode}
+
 /** Any element of a service/struct */
 abstract class Entry(val typeName: String)
 
@@ -11,6 +14,12 @@ object Entry {
   }
 
   case class Metadata(metaKey: String, args: Args = Args()) extends Entry("metadata") {
-    override def toString: String = s"#$metaKey ($args);"
+
+    private def argsToString: String = args match {
+      case Args(Seq(list: ListArg), Seq()) => list.toString
+      case Args(Seq(), Seq())              => ""
+      case args                            => codeParens(args.toString)
+    }
+    override def toString: String = mkCode.stmt("#" + metaKey, argsToString)
   }
 }

--- a/src/main/scala/temple/generate/utils/CodeTerm.scala
+++ b/src/main/scala/temple/generate/utils/CodeTerm.scala
@@ -87,12 +87,17 @@ object CodeTerm {
     def stmt(string: CodeTerm*): String = mkCode(string, ";")
   }
 
-  object codeParens {
+  sealed class codeParens private (start: String, end: String) {
 
     /** Wrap a code snippet in parentheses */
-    def apply(string: CodeTerm*): String = mkCode("(", string, ")")
+    def apply(string: CodeTerm*): String = mkCode(start, string, end)
 
     /** Wrap a code snippet in parentheses, with newlines inside them */
-    def spaced(string: CodeTerm*): String = mkCode("(", "\n", indent(mkCode(string)), "\n", ")")
+    def spaced(string: CodeTerm*): String = mkCode(start, "\n", indent(mkCode(string)), "\n", end)
+  }
+
+  object codeParens extends codeParens("(", ")") {
+    object curly  extends codeParens("{", "}")
+    object square extends codeParens("[", "]")
   }
 }

--- a/src/test/scala/temple/DSL/parser/DSLParserTest.scala
+++ b/src/test/scala/temple/DSL/parser/DSLParserTest.scala
@@ -63,10 +63,10 @@ class DSLParserTest extends FlatSpec with Matchers {
             Seq(
               Attribute("field", AttributeType.Primitive("string"), Seq(Annotation("nullable"))),
               Attribute("friend", AttributeType.Foreign("User")),
-              Metadata("enumerate", Args(kwargs = Seq("by" -> Arg.TokenArg("User")))),
+              Metadata("enumerable", Args(kwargs = Seq("by" -> Arg.TokenArg("friend")))),
             ),
           ),
-          Metadata("enumerate"),
+          Metadata("enumerable"),
           Metadata("auth", Args(kwargs = Seq("login" -> Arg.TokenArg("username")))),
           Metadata("uses", Args(Seq(Arg.ListArg(Seq(Arg.TokenArg("Booking"), Arg.TokenArg("Events")))))),
         ),

--- a/src/test/scala/temple/DSL/parser/DSLParserTest.scala
+++ b/src/test/scala/temple/DSL/parser/DSLParserTest.scala
@@ -63,10 +63,10 @@ class DSLParserTest extends FlatSpec with Matchers {
             Seq(
               Attribute("field", AttributeType.Primitive("string"), Seq(Annotation("nullable"))),
               Attribute("friend", AttributeType.Foreign("User")),
-              Metadata("enumerable", Args(kwargs = Seq("by" -> Arg.TokenArg("User")))),
+              Metadata("enumerate", Args(kwargs = Seq("by" -> Arg.TokenArg("User")))),
             ),
           ),
-          Metadata("enumerable"),
+          Metadata("enumerate"),
           Metadata("auth", Args(kwargs = Seq("login" -> Arg.TokenArg("username")))),
           Metadata("uses", Args(Seq(Arg.ListArg(Seq(Arg.TokenArg("Booking"), Arg.TokenArg("Events")))))),
         ),

--- a/src/test/scala/temple/DSL/parser/DSLParserTest.scala
+++ b/src/test/scala/temple/DSL/parser/DSLParserTest.scala
@@ -63,8 +63,10 @@ class DSLParserTest extends FlatSpec with Matchers {
             Seq(
               Attribute("field", AttributeType.Primitive("string"), Seq(Annotation("nullable"))),
               Attribute("friend", AttributeType.Foreign("User")),
+              Metadata("enumerable", Args(kwargs = Seq("by" -> Arg.TokenArg("User")))),
             ),
           ),
+          Metadata("enumerable"),
           Metadata("auth", Args(kwargs = Seq("login" -> Arg.TokenArg("username")))),
           Metadata("uses", Args(Seq(Arg.ListArg(Seq(Arg.TokenArg("Booking"), Arg.TokenArg("Events")))))),
         ),

--- a/src/test/scala/temple/DSL/semantics/SemanticAnalyserTest.scala
+++ b/src/test/scala/temple/DSL/semantics/SemanticAnalyserTest.scala
@@ -241,6 +241,7 @@ class SemanticAnalyserTest extends FlatSpec with Matchers {
             "service",
             Seq(
               Entry.Attribute("id", syntax.AttributeType.Primitive("int")),
+              Entry.Metadata("enumerate"),
               Entry.Metadata("uses", Args(kwargs = Seq("services" -> ListArg(Seq(TokenArg("Box")))))),
               Entry.Metadata("auth", Args(kwargs = Seq("login"    -> TokenArg("id")))),
             ),

--- a/src/test/scala/temple/DSL/semantics/SemanticAnalyserTest.scala
+++ b/src/test/scala/temple/DSL/semantics/SemanticAnalyserTest.scala
@@ -241,7 +241,7 @@ class SemanticAnalyserTest extends FlatSpec with Matchers {
             "service",
             Seq(
               Entry.Attribute("id", syntax.AttributeType.Primitive("int")),
-              Entry.Metadata("enumerate"),
+              Entry.Metadata("enumerable"),
               Entry.Metadata("uses", Args(kwargs = Seq("services" -> ListArg(Seq(TokenArg("Box")))))),
               Entry.Metadata("auth", Args(kwargs = Seq("login"    -> TokenArg("id")))),
             ),

--- a/src/test/scala/temple/testfiles/simple.temple
+++ b/src/test/scala/temple/testfiles/simple.temple
@@ -15,10 +15,10 @@ User: service {
   Fred: struct {
     field: string @nullable;
     friend: User;
-    #enumerable(by: User);
+    #enumerate(by: User);
   };
 
-  #enumerable;
+  #enumerate;
 
   #auth(login: username);
   #uses [Booking, Events];

--- a/src/test/scala/temple/testfiles/simple.temple
+++ b/src/test/scala/temple/testfiles/simple.temple
@@ -15,7 +15,10 @@ User: service {
   Fred: struct {
     field: string @nullable;
     friend: User;
+    #enumerable(by: User);
   };
+
+  #enumerable;
 
   #auth(login: username);
   #uses [Booking, Events];

--- a/src/test/scala/temple/testfiles/simple.temple
+++ b/src/test/scala/temple/testfiles/simple.temple
@@ -15,10 +15,10 @@ User: service {
   Fred: struct {
     field: string @nullable;
     friend: User;
-    #enumerate(by: User);
+    #enumerable(by: friend);
   };
 
-  #enumerate;
+  #enumerable;
 
   #auth(login: username);
   #uses [Booking, Events];


### PR DESCRIPTION
* Add support for parsing the metadata `#enumerate(by: User)`
* Add support for optional arguments for metadata (e.g. `by` in `#enumerate`)
* Add support for omitting the parentheses for metadata without arguments (`#enumerate;` as a shorthand for `#enumerate();`)

As asides:

* Fix the ordering of the semicolon parser, so it says `expected ";"` rather than `expected regex "$"` when something other than the end of the line is reached
* Adds methods for generating square and curly brackets