### PR TITLE
[DSL] Add support for comments in the DSL

### DIFF
--- a/src/main/scala/temple/DSL/parser/DSLParser.scala
+++ b/src/main/scala/temple/DSL/parser/DSLParser.scala
@@ -2,6 +2,7 @@ package temple.DSL.parser
 
 import temple.DSL.syntax._
 
+import scala.util.matching.Regex
 import scala.util.parsing.combinator.JavaTokenParsers
 
 /** A library of parser generators for the Templefile DSL */
@@ -88,4 +89,20 @@ class DSLParser extends JavaTokenParsers with UtilParsers {
 
   /** A parser generator for an annotation on an attribute */
   protected def annotation: Parser[Annotation] = "@" ~> ident ^^ Annotation
+
+  /** The updated whitespace parser, allowing for comments */
+  // (\s+|//[^\n]*\n|/\*(\*(?!/)|[^\*])*\*/)+
+  // (   |          |                      )+     any sequence of permutations of the following:
+  //  \s+                                         - genuine whitespace
+  //      //[^\n]*\n                              - a one-line comment, made of:
+  //      //                                        - a double-slash
+  //        [^\n]*                                  - zero or more characters other than newlines
+  //              \n                                - a new line
+  //                 /\*(\*(?!/)|[^\*])*\*/       - a multi-line comment, made of:
+  //                 /\*                            - a slash-star
+  //                    (       |     )*            - any number of characters that:
+  //                     \*(?!/)                      - are a star not followed by a slash
+  //                             [^\*]                - are not a star
+  //                                    \*/           - a star-slash
+  override protected val whiteSpace: Regex = """(\s+|//[^\n]*\n|/\*(\*(?!/)|[^\*])*\*/)+""".r
 }

--- a/src/main/scala/temple/DSL/parser/DSLParser.scala
+++ b/src/main/scala/temple/DSL/parser/DSLParser.scala
@@ -103,6 +103,6 @@ class DSLParser extends JavaTokenParsers with UtilParsers {
   //                    (       |     )*            - any number of characters that:
   //                     \*(?!/)                      - are a star not followed by a slash
   //                             [^\*]                - are not a star
-  //                                    \*/           - a star-slash
+  //                                    \*/         - a star-slash
   override protected val whiteSpace: Regex = """(\s+|//[^\n]*\n|/\*(\*(?!/)|[^\*])*\*/)+""".r
 }

--- a/src/test/scala/temple/testfiles/simple.temple
+++ b/src/test/scala/temple/testfiles/simple.temple
@@ -7,7 +7,7 @@ User: service {
   lastName: string;
   createdAt: datetime;
   numberOfDogs: int;
-  yeets: bool @unique @server;
+  yeets: bool @unique @server; // Don't send this to the client
   currentBankBalance: float(min: 0.0, precision: 2);
   birthDate: date;
   breakfastTime: time;
@@ -21,5 +21,5 @@ User: service {
   #enumerable;
 
   #auth(login: username);
-  #uses [Booking, Events];
+  #uses [Booking, Events, /* Reservations */];
 }


### PR DESCRIPTION
Sorry it’s in Regex, it’s just how [scala-parser-combinators](https://www.javadoc.io/static/org.scala-lang.modules/scala-parser-combinators_2.12/1.1.2/scala/util/parsing/json/Lexer.html#whitespace:Lexer.this.Parser[List[Lexer.this.Elem]]) is implemented. I hope the comment explains it adequately: anywhere where whitespace can occur, so can a comment. Note that this does not include places such as inside a string or a comment, as whitespace characters there are treated as character literals rather than ignored as whitespace.