### PR TITLE
[deployment] Fix typos in markdown

### DIFF
--- a/DEPLOYMENT
+++ b/DEPLOYMENT
@@ -13,8 +13,6 @@ Given a version number MAJOR.MINOR.PATCH, increment the:
 3. PATCH version when you make backwards compatible bug fixes.
 Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format.
 
-Current Version: `v0.001`
-
 ## Stages 
 
 1. In terminal, at the point you want to deploy from run `git tag v{version_number}`
@@ -29,4 +27,4 @@ Should you want to remove a tag for any reason:
 
 1. Delete locally `git tag -d v{version_number}`
 
-2. Delete the tag from the remote `git push --delete origin v{verison_number}`
+2. Delete the tag from the remote `git push --delete origin v{version_number}`


### PR DESCRIPTION
Fix the typo in "version" and remove the "current version", since in the list of instructions about deploying, it doesn't mention updating a Markdown file.. so who's going to remember to do that 😉 