### PR TITLE
Table naming

### DIFF
--- a/src/e2e/scala/temple/DSL/ParserE2ETest.scala
+++ b/src/e2e/scala/temple/DSL/ParserE2ETest.scala
@@ -23,7 +23,7 @@ class ParserE2ETest extends FlatSpec with Matchers with DSLParserMatchers {
       projectBlock = ProjectBlock(),
       targets = Map.empty,
       services = Map(
-        "User" -> ServiceBlock(
+        "TempleUser" -> ServiceBlock(
           attributes = ListMap(
             "username"           -> Attribute(StringType()),
             "email"              -> Attribute(StringType(Some(40), Some(5))),

--- a/src/e2e/scala/temple/SimpleE2ETest.scala
+++ b/src/e2e/scala/temple/SimpleE2ETest.scala
@@ -23,13 +23,13 @@ class SimpleE2ETest extends FlatSpec with Matchers {
 
     // Only one folder should have been generated
     Files.list(basePath).count() shouldBe 1
-    Files.exists(basePath.resolve("user-db")) shouldBe true
+    Files.exists(basePath.resolve("templeuser-db")) shouldBe true
 
     // Only one file should be present in the user-db folder
-    Files.list(basePath.resolve("user-db")).count() shouldBe 1
-    Files.exists(basePath.resolve("user-db").resolve("init.sql")) shouldBe true
+    Files.list(basePath.resolve("templeuser-db")).count() shouldBe 1
+    Files.exists(basePath.resolve("templeuser-db").resolve("init.sql")) shouldBe true
 
-    val initSql = Files.readString(basePath.resolve("user-db").resolve("init.sql"))
+    val initSql = Files.readString(basePath.resolve("templeuser-db").resolve("init.sql"))
     initSql shouldBe SimpleE2ETestData.createStatement
   }
 }

--- a/src/e2e/scala/temple/SimpleE2ETestData.scala
+++ b/src/e2e/scala/temple/SimpleE2ETestData.scala
@@ -3,7 +3,7 @@ package temple
 object SimpleE2ETestData {
 
   val createStatement: String =
-    """CREATE TABLE User (
+    """CREATE TABLE temple_user (
       |  username TEXT NOT NULL,
       |  email VARCHAR(40) CHECK (length(email) >= 5) NOT NULL,
       |  firstName TEXT NOT NULL,
@@ -16,7 +16,7 @@ object SimpleE2ETestData {
       |  breakfastTime TIME NOT NULL
       |);
       |
-      |CREATE TABLE Fred (
+      |CREATE TABLE fred (
       |  field TEXT,
       |  friend INT NOT NULL
       |);""".stripMargin

--- a/src/it/scala/temple/generate/database/TestData.scala
+++ b/src/it/scala/temple/generate/database/TestData.scala
@@ -14,7 +14,7 @@ import temple.generate.database.ast._
 object TestData {
 
   val createStatement: Create = Create(
-    "Users",
+    "temple_user",
     Seq(
       ColumnDef("id", IntCol(2), Seq(Unique)),
       ColumnDef("anotherId", IntCol(4), Seq(Unique)),
@@ -31,7 +31,7 @@ object TestData {
   )
 
   val createStatementWithUniqueConstraint: Create = Create(
-    "UniqueTest",
+    "unique_test",
     Seq(
       ColumnDef("itemID", IntCol(4), Seq(NonNull, PrimaryKey)),
       ColumnDef("createdAt", DateTimeTzCol, Seq(Unique)),
@@ -39,15 +39,15 @@ object TestData {
   )
 
   val createStatementWithReferenceConstraint: Create = Create(
-    "ReferenceTest",
+    "reference_test",
     Seq(
       ColumnDef("itemID", IntCol(4), Seq(NonNull, PrimaryKey)),
-      ColumnDef("userID", IntCol(4), Seq(References("Users", "id"))),
+      ColumnDef("userID", IntCol(4), Seq(References("temple_user", "id"))),
     ),
   )
 
   val createStatementWithCheckConstraint: Create = Create(
-    "CheckTest",
+    "check_test",
     Seq(
       ColumnDef("itemID", IntCol(4), Seq(NonNull, PrimaryKey)),
       ColumnDef("value", IntCol(4), Seq(Check("value", GreaterEqual, "1"), Check("value", LessEqual, "10"))),
@@ -55,7 +55,7 @@ object TestData {
   )
 
   val readStatement: Read = Read(
-    "Users",
+    "temple_user",
     Seq(
       Column("id"),
       Column("anotherId"),
@@ -72,7 +72,7 @@ object TestData {
   )
 
   val readStatementWithWhere: Read = Read(
-    "Users",
+    "temple_user",
     Seq(
       Column("id"),
       Column("anotherId"),
@@ -87,12 +87,12 @@ object TestData {
       Column("expiry"),
     ),
     Some(
-      Comparison("Users.id", Equal, "123456"),
+      Comparison("user.id", Equal, "123456"),
     ),
   )
 
   val readStatementWithWhereConjunction: Read = Read(
-    "Users",
+    "temple_user",
     Seq(
       Column("id"),
       Column("anotherId"),
@@ -108,14 +108,14 @@ object TestData {
     ),
     Some(
       Conjunction(
-        Comparison("Users.id", Equal, "123456"),
-        Comparison("Users.expiry", LessEqual, "2"),
+        Comparison("temple_user.id", Equal, "123456"),
+        Comparison("temple_user.expiry", LessEqual, "2"),
       ),
     ),
   )
 
   val readStatementWithWhereDisjunction: Read = Read(
-    "Users",
+    "temple_user",
     Seq(
       Column("id"),
       Column("anotherId"),
@@ -131,14 +131,14 @@ object TestData {
     ),
     Some(
       Disjunction(
-        Comparison("Users.id", NotEqual, "123456"),
-        Comparison("Users.expiry", Greater, "2"),
+        Comparison("temple_user.id", NotEqual, "123456"),
+        Comparison("temple_user.expiry", Greater, "2"),
       ),
     ),
   )
 
   val readStatementWithWhereInverse: Read = Read(
-    "Users",
+    "temple_user",
     Seq(
       Column("id"),
       Column("anotherId"),
@@ -154,13 +154,13 @@ object TestData {
     ),
     Some(
       Inverse(
-        Comparison("Users.id", Less, "123456"),
+        Comparison("temple_user.id", Less, "123456"),
       ),
     ),
   )
 
   val readStatementComplex: Read = Read(
-    "Users",
+    "temple_user",
     Seq(
       Column("id"),
       Column("anotherId"),
@@ -178,18 +178,18 @@ object TestData {
       Conjunction(
         Disjunction(
           IsNull(Column("isStudent")),
-          Comparison("Users.id", GreaterEqual, "1"),
+          Comparison("temple_user.id", GreaterEqual, "1"),
         ),
         Disjunction(
           Inverse(IsNull(Column("isStudent"))),
-          Inverse(Comparison("Users.expiry", Less, "TIMESTAMP '2020-02-03 00:00:00+00'")),
+          Inverse(Comparison("temple_user.expiry", Less, "TIMESTAMP '2020-02-03 00:00:00+00'")),
         ),
       ),
     ),
   )
 
   val insertStatement: Insert = Insert(
-    "Users",
+    "temple_user",
     Seq(
       Column("id"),
       Column("anotherId"),
@@ -206,7 +206,7 @@ object TestData {
   )
 
   val insertStatementForUniqueConstraint: Insert = Insert(
-    "UniqueTest",
+    "unique_test",
     Seq(
       Column("itemID"),
       Column("createdAt"),
@@ -214,7 +214,7 @@ object TestData {
   )
 
   val insertStatementForReferenceConstraint: Insert = Insert(
-    "ReferenceTest",
+    "reference_test",
     Seq(
       Column("itemID"),
       Column("userID"),
@@ -222,7 +222,7 @@ object TestData {
   )
 
   val insertStatementForCheckConstraint: Insert = Insert(
-    "CheckTest",
+    "check_test",
     Seq(
       Column("itemID"),
       Column("value"),
@@ -230,27 +230,27 @@ object TestData {
   )
 
   val deleteStatement: Delete = Delete(
-    "Users",
+    "temple_user",
   )
 
   val deleteStatementWithWhere: Delete = Delete(
-    "Users",
+    "temple_user",
     Some(
-      Comparison("Users.id", Equal, "123456"),
+      Comparison("temple_user.id", Equal, "123456"),
     ),
   )
 
   val dropStatement: Drop = Drop(
-    "Users",
+    "temple_user",
     ifExists = false,
   )
 
   val dropStatementIfExists: Drop = Drop(
-    "Users",
+    "temple_user",
   )
 
   val updateStatement: Update = Update(
-    "Users",
+    "temple_user",
     Seq(
       Assignment(Column("bankBalance"), Value("123.456")),
       Assignment(Column("name"), Value("'Will'")),
@@ -258,13 +258,13 @@ object TestData {
   )
 
   val updateStatementWithWhere: Update = Update(
-    "Users",
+    "temple_user",
     Seq(
       Assignment(Column("bankBalance"), Value("123.456")),
       Assignment(Column("name"), Value("'Will'")),
     ),
     Some(
-      Comparison("Users.id", Equal, "12345"),
+      Comparison("temple_user.id", Equal, "12345"),
     ),
   )
 

--- a/src/main/scala/temple/builder/DatabaseBuilder.scala
+++ b/src/main/scala/temple/builder/DatabaseBuilder.scala
@@ -4,6 +4,7 @@ import temple.DSL.semantics.Annotation.Nullable
 import temple.DSL.semantics.{Annotation, Attribute, AttributeType, ServiceBlock}
 import temple.generate.database.ast.ColumnConstraint.Check
 import temple.generate.database.ast._
+import temple.utils.StringUtils
 
 /** Construct database queries from a Templefile structure */
 object DatabaseBuilder {
@@ -51,7 +52,7 @@ object DatabaseBuilder {
     service.structIterator(serviceName).map {
       case (tableName, attributes) =>
         val columns = attributes.map { case (name, attributes) => toColDef(name, attributes) }
-        Statement.Create(tableName, columns.toSeq)
+        Statement.Create(StringUtils.snakeCase(tableName), columns.toSeq)
     }
   }.toSeq
 }

--- a/src/main/scala/temple/utils/StringUtils.scala
+++ b/src/main/scala/temple/utils/StringUtils.scala
@@ -7,6 +7,7 @@ object StringUtils {
   def indent(str: String, length: Int = 2): String = str.replaceAll("^|(?<=\n)", " " * length)
 
   /** Given a string, convert it to snake case */
+  // https://github.com/lift/framework/blob/f1b450db2dd6a22cf9ffe5576ec34c8e87118319/core/util/src/main/scala/net/liftweb/util/StringHelpers.scala#L91
   def snakeCase(str: String): String =
     str
       .replaceAll("([A-Z]+)([A-Z][a-z])", "$1_$2")

--- a/src/main/scala/temple/utils/StringUtils.scala
+++ b/src/main/scala/temple/utils/StringUtils.scala
@@ -5,4 +5,11 @@ object StringUtils {
 
   /** Given a string, indent it by a given number of spaces */
   def indent(str: String, length: Int = 2): String = str.replaceAll("^|(?<=\n)", " " * length)
+
+  /** Given a string, convert it to snake case */
+  def snakeCase(str: String): String =
+    str
+      .replaceAll("([A-Z]+)([A-Z][a-z])", "$1_$2")
+      .replaceAll("([a-z\\d])([A-Z])", "$1_$2")
+      .toLowerCase
 }

--- a/src/test/scala/temple/DSL/parser/DSLParserTest.scala
+++ b/src/test/scala/temple/DSL/parser/DSLParserTest.scala
@@ -35,7 +35,7 @@ class DSLParserTest extends FlatSpec with Matchers with DSLParserMatchers {
     parseResult shouldBe Seq(
       DSLRootItem("SimpleTempleTest", "project", Nil),
       DSLRootItem(
-        "User",
+        "TempleUser",
         "service",
         Seq(
           Attribute("username", AttributeType.Primitive("string")),

--- a/src/test/scala/temple/builder/DatabaseBuilderTest.scala
+++ b/src/test/scala/temple/builder/DatabaseBuilderTest.scala
@@ -6,12 +6,12 @@ class DatabaseBuilderTest extends FlatSpec with Matchers {
   behavior of "DatabaseBuilder"
 
   it should "correctly create a simple users table" in {
-    val createQuery = DatabaseBuilder.createServiceTables("Users", DatabaseBuilderTestData.sampleService)
+    val createQuery = DatabaseBuilder.createServiceTables("temple_user", DatabaseBuilderTestData.sampleService)
     createQuery shouldBe DatabaseBuilderTestData.sampleServiceCreate
   }
 
   it should "correctly create a complex users table" in {
-    val createQuery = DatabaseBuilder.createServiceTables("Users", DatabaseBuilderTestData.sampleComplexService)
+    val createQuery = DatabaseBuilder.createServiceTables("temple_user", DatabaseBuilderTestData.sampleComplexService)
     createQuery shouldBe DatabaseBuilderTestData.sampleComplexServiceCreate
   }
 }

--- a/src/test/scala/temple/builder/DatabaseBuilderTestData.scala
+++ b/src/test/scala/temple/builder/DatabaseBuilderTestData.scala
@@ -30,7 +30,7 @@ object DatabaseBuilderTestData {
   val sampleServiceCreate: Seq[Statement.Create] =
     Seq(
       Create(
-        "Users",
+        "temple_user",
         Seq(
           ColumnDef("id", IntCol(4), Seq(NonNull)),
           ColumnDef("bankBalance", FloatCol(8), Seq(NonNull)),
@@ -73,7 +73,7 @@ object DatabaseBuilderTestData {
   val sampleComplexServiceCreate: Seq[Statement.Create] =
     Seq(
       Create(
-        "Users",
+        "temple_user",
         Seq(
           ColumnDef("id", IntCol(2), Seq(Check("id", LessEqual, "100"), Check("id", GreaterEqual, "10"), NonNull)),
           ColumnDef(
@@ -106,7 +106,7 @@ object DatabaseBuilderTestData {
         ),
       ),
       Create(
-        "Test",
+        "test",
         Seq(
           ColumnDef("favouriteColour", StringCol, Seq(Unique, NonNull)),
           ColumnDef("bedTime", TimeCol),

--- a/src/test/scala/temple/builder/project/ProjectBuilderTest.scala
+++ b/src/test/scala/temple/builder/project/ProjectBuilderTest.scala
@@ -9,28 +9,28 @@ class ProjectBuilderTest extends FlatSpec with Matchers {
   it should "correctly create a simple project using postgres as the default" in {
     val project = ProjectBuilder.build(ProjectBuilderTestData.simpleTemplefile)
     project.databaseCreationScripts shouldBe Map(
-      File("users-db", "init.sql") -> ProjectBuilderTestData.simpleTemplefilePostgresCreateOutput,
+      File("templeuser-db", "init.sql") -> ProjectBuilderTestData.simpleTemplefilePostgresCreateOutput,
     )
   }
 
   it should "use postgres when defined at the project level" in {
     val project = ProjectBuilder.build(ProjectBuilderTestData.simpleTemplefilePostgresProject)
     project.databaseCreationScripts shouldBe Map(
-      File("users-db", "init.sql") -> ProjectBuilderTestData.simpleTemplefilePostgresCreateOutput,
+      File("templeuser-db", "init.sql") -> ProjectBuilderTestData.simpleTemplefilePostgresCreateOutput,
     )
   }
 
   it should "use postgres when defined at the service level" in {
     val project = ProjectBuilder.build(ProjectBuilderTestData.simpleTemplefilePostgresService)
     project.databaseCreationScripts shouldBe Map(
-      File("users-db", "init.sql") -> ProjectBuilderTestData.simpleTemplefilePostgresCreateOutput,
+      File("templeuser-db", "init.sql") -> ProjectBuilderTestData.simpleTemplefilePostgresCreateOutput,
     )
   }
 
   it should "correctly create a complex service with nested struct" in {
     val project = ProjectBuilder.build(ProjectBuilderTestData.complexTemplefile)
     project.databaseCreationScripts shouldBe Map(
-      File("complexusers-db", "init.sql") -> ProjectBuilderTestData.complexTemplefilePostgresCreateOutput,
+      File("complexuser-db", "init.sql") -> ProjectBuilderTestData.complexTemplefilePostgresCreateOutput,
     )
   }
 }

--- a/src/test/scala/temple/builder/project/ProjectBuilderTestData.scala
+++ b/src/test/scala/temple/builder/project/ProjectBuilderTestData.scala
@@ -39,7 +39,7 @@ object ProjectBuilderTestData {
     ProjectBlock(),
     Map(),
     Map(
-      "Users" -> ServiceBlock(simpleServiceAttributes),
+      "TempleUser" -> ServiceBlock(simpleServiceAttributes),
     ),
   )
 
@@ -48,7 +48,7 @@ object ProjectBuilderTestData {
     ProjectBlock(Seq(Database.Postgres)),
     Map(),
     Map(
-      "Users" -> ServiceBlock(simpleServiceAttributes),
+      "TempleUser" -> ServiceBlock(simpleServiceAttributes),
     ),
   )
 
@@ -57,12 +57,12 @@ object ProjectBuilderTestData {
     ProjectBlock(),
     Map(),
     Map(
-      "Users" -> ServiceBlock(simpleServiceAttributes, metadata = Seq(Database.Postgres)),
+      "TempleUser" -> ServiceBlock(simpleServiceAttributes, metadata = Seq(Database.Postgres)),
     ),
   )
 
   val simpleTemplefilePostgresCreateOutput: String =
-    """CREATE TABLE Users (
+    """CREATE TABLE temple_user (
       |  intField INT NOT NULL,
       |  doubleField DOUBLE PRECISION NOT NULL,
       |  stringField TEXT NOT NULL,
@@ -78,15 +78,15 @@ object ProjectBuilderTestData {
     ProjectBlock(),
     Map(),
     Map(
-      "ComplexUsers" -> ServiceBlock(
+      "ComplexUser" -> ServiceBlock(
         complexServiceAttributes,
-        structs = Map("Users" -> StructBlock(simpleServiceAttributes)),
+        structs = Map("TempleUser" -> StructBlock(simpleServiceAttributes)),
       ),
     ),
   )
 
   val complexTemplefilePostgresCreateOutput: String =
-    """CREATE TABLE ComplexUsers (
+    """CREATE TABLE complex_user (
       |  smallIntField SMALLINT CHECK (smallIntField <= 100) CHECK (smallIntField >= 10) NOT NULL,
       |  intField INT CHECK (intField <= 100) CHECK (intField >= 10) NOT NULL,
       |  bigIntField BIGINT CHECK (bigIntField <= 100) CHECK (bigIntField >= 10) NOT NULL,

--- a/src/test/scala/temple/testfiles/simple.temple
+++ b/src/test/scala/temple/testfiles/simple.temple
@@ -1,6 +1,6 @@
 SimpleTempleTest: project {}
 
-User: service {
+TempleUser: service {
   username: string;
   email: string(40,5);
   firstName: string;

--- a/src/test/scala/temple/utils/StringUtilsTest.scala
+++ b/src/test/scala/temple/utils/StringUtilsTest.scala
@@ -54,4 +54,8 @@ class StringUtilsTest extends FlatSpec with Matchers {
   it should "not remove leading underscores" in {
     snakeCase("_fooBarBaz") shouldBe "_foo_bar_baz"
   }
+
+  it should "correctly convert a capitalised phrase" in {
+    snakeCase("CustomerID") shouldBe "customer_id"
+  }
 }

--- a/src/test/scala/temple/utils/StringUtilsTest.scala
+++ b/src/test/scala/temple/utils/StringUtilsTest.scala
@@ -1,7 +1,7 @@
 package temple.utils
 
 import org.scalatest.{FlatSpec, Matchers}
-import temple.utils.StringUtils.indent
+import temple.utils.StringUtils.{indent, snakeCase}
 
 class StringUtilsTest extends FlatSpec with Matchers {
   behavior of "indent"
@@ -23,5 +23,23 @@ class StringUtilsTest extends FlatSpec with Matchers {
   it should "add spaces on each line" in {
     indent("abcd\nefg", 1) shouldEqual " abcd\n efg"
     indent("abcd\nefg\n", 1) shouldEqual " abcd\n efg\n "
+  }
+
+  behavior of "snakeCase"
+
+  it should "convert an all upper case string to lower case" in {
+    snakeCase("ABCDEFG") shouldBe "abcdefg"
+  }
+
+  it should "correctly convert from camel case to snake case" in {
+    snakeCase("someRandomCamelCase") shouldBe "some_random_camel_case"
+  }
+
+  it should "ignore random capitalised words" in {
+    snakeCase("someRANDOMCamelCaseCHARACTERS") shouldBe "some_random_camel_case_characters"
+  }
+
+  it should "numbers" in {
+    snakeCase("some1917Numbers") shouldBe "some1917_numbers"
   }
 }

--- a/src/test/scala/temple/utils/StringUtilsTest.scala
+++ b/src/test/scala/temple/utils/StringUtilsTest.scala
@@ -39,7 +39,19 @@ class StringUtilsTest extends FlatSpec with Matchers {
     snakeCase("someRANDOMCamelCaseCHARACTERS") shouldBe "some_random_camel_case_characters"
   }
 
-  it should "numbers" in {
+  it should "handle numbers" in {
     snakeCase("some1917Numbers") shouldBe "some1917_numbers"
+  }
+
+  it should "not change snake case strings" in {
+    snakeCase("already_has_snake_case") shouldBe "already_has_snake_case"
+  }
+
+  it should "deal with mixed naming" in {
+    snakeCase("foo_barBaz_boo") shouldBe "foo_bar_baz_boo"
+  }
+
+  it should "not remove leading underscores" in {
+    snakeCase("_fooBarBaz") shouldBe "_foo_bar_baz"
   }
 }


### PR DESCRIPTION
Renamed all services to be singular (i.e `Users` → `User`) - however, since User is a reserved keyword in Postgres and we don't have something to handle that, I've renamed it to `TempleUser`.

All table names are now in snake case, so we have a method to convert user provided names to snake case