### PR TITLE
[builder] Rename project argument to files and use global configuration

### DIFF
--- a/src/main/scala/temple/Application.scala
+++ b/src/main/scala/temple/Application.scala
@@ -17,7 +17,7 @@ object Application {
         val project            = ProjectBuilder.build(analysedTemplefile)
 
         FileUtils.createDirectory(outputDirectory)
-        project.databaseCreationScripts.foreach {
+        project.files.foreach {
           case (file, contents) =>
             val subfolder = s"$outputDirectory/${file.folder}"
             FileUtils.createDirectory(subfolder)

--- a/src/main/scala/temple/builder/project/Project.scala
+++ b/src/main/scala/temple/builder/project/Project.scala
@@ -2,7 +2,7 @@ package temple.builder.project
 
 import temple.builder.project.Project.File
 
-case class Project(databaseCreationScripts: Map[File, String])
+case class Project(files: Map[File, String])
 
 object Project {
   case class File(folder: String, filename: String)

--- a/src/main/scala/temple/builder/project/ProjectBuilder.scala
+++ b/src/main/scala/temple/builder/project/ProjectBuilder.scala
@@ -20,7 +20,7 @@ object ProjectBuilder {
     val databaseCreationScripts = templefile.services.map {
       case (name, service) =>
         val createStatements: Seq[Statement.Create] = DatabaseBuilder.createServiceTables(name, service)
-        service.lookupMetadata[Database].getOrElse(Postgres) match {
+        service.lookupMetadata[Database].getOrElse(ProjectConfig.defaultDatabase) match {
           case Postgres =>
             implicit val context: PostgresContext = PostgresContext(QuestionMarks)
             val postgresStatements                = createStatements.map(PostgresGenerator.generate).mkString("\n\n")

--- a/src/main/scala/temple/builder/project/ProjectConfig.scala
+++ b/src/main/scala/temple/builder/project/ProjectConfig.scala
@@ -1,0 +1,8 @@
+package temple.builder.project
+
+import temple.DSL.semantics.Metadata.{Database, ServiceLanguage}
+
+object ProjectConfig {
+  val defaultLanguage: ServiceLanguage = ServiceLanguage.Go
+  val defaultDatabase: Database        = Database.Postgres
+}

--- a/src/test/scala/temple/builder/project/ProjectBuilderTest.scala
+++ b/src/test/scala/temple/builder/project/ProjectBuilderTest.scala
@@ -8,28 +8,28 @@ class ProjectBuilderTest extends FlatSpec with Matchers {
 
   it should "correctly create a simple project using postgres as the default" in {
     val project = ProjectBuilder.build(ProjectBuilderTestData.simpleTemplefile)
-    project.databaseCreationScripts shouldBe Map(
+    project.files shouldBe Map(
       File("templeuser-db", "init.sql") -> ProjectBuilderTestData.simpleTemplefilePostgresCreateOutput,
     )
   }
 
   it should "use postgres when defined at the project level" in {
     val project = ProjectBuilder.build(ProjectBuilderTestData.simpleTemplefilePostgresProject)
-    project.databaseCreationScripts shouldBe Map(
+    project.files shouldBe Map(
       File("templeuser-db", "init.sql") -> ProjectBuilderTestData.simpleTemplefilePostgresCreateOutput,
     )
   }
 
   it should "use postgres when defined at the service level" in {
     val project = ProjectBuilder.build(ProjectBuilderTestData.simpleTemplefilePostgresService)
-    project.databaseCreationScripts shouldBe Map(
+    project.files shouldBe Map(
       File("templeuser-db", "init.sql") -> ProjectBuilderTestData.simpleTemplefilePostgresCreateOutput,
     )
   }
 
   it should "correctly create a complex service with nested struct" in {
     val project = ProjectBuilder.build(ProjectBuilderTestData.complexTemplefile)
-    project.databaseCreationScripts shouldBe Map(
+    project.files shouldBe Map(
       File("complexuser-db", "init.sql") -> ProjectBuilderTestData.complexTemplefilePostgresCreateOutput,
     )
   }


### PR DESCRIPTION
There's nothing special about `databaseCreationScripts` - there's no reason this can't be files.
Also added a global project config with defaults for language/database etc to use when one isn't defined.