### PR TITLE
Builder test data

### DIFF
--- a/src/test/scala/temple/builder/BuilderTestData.scala
+++ b/src/test/scala/temple/builder/BuilderTestData.scala
@@ -1,0 +1,50 @@
+package temple.builder
+
+import temple.DSL.semantics.AttributeType.{BlobType, BoolType, DateTimeType, DateType, FloatType, IntType, StringType, TimeType}
+import temple.DSL.semantics.{Annotation, Attribute, ServiceBlock, StructBlock}
+
+import scala.collection.immutable.ListMap
+
+object BuilderTestData {
+
+  // TODO: This test doesn't include a `ForeignKey` attribute, since it is not yet supported
+  //  by the parser/semantic analysis. Once it is, please update these tests!
+  val sampleService: ServiceBlock = ServiceBlock(
+    ListMap(
+      "id"          -> Attribute(IntType()),
+      "bankBalance" -> Attribute(FloatType()),
+      "name"        -> Attribute(StringType()),
+      "isStudent"   -> Attribute(BoolType),
+      "dateOfBirth" -> Attribute(DateType),
+      "timeOfDay"   -> Attribute(TimeType),
+      "expiry"      -> Attribute(DateTimeType),
+      "image"       -> Attribute(BlobType()),
+    ),
+  )
+
+  val sampleComplexService: ServiceBlock = ServiceBlock(
+    ListMap(
+      "id"             -> Attribute(IntType(max = Some(100), min = Some(10), precision = 2)),
+      "anotherId"      -> Attribute(IntType(max = Some(100), min = Some(10))),
+      "yetAnotherId"   -> Attribute(IntType(max = Some(100), min = Some(10), precision = 8)),
+      "bankBalance"    -> Attribute(FloatType(max = Some(300), min = Some(0), precision = 4)),
+      "bigBankBalance" -> Attribute(FloatType(max = Some(123), min = Some(0))),
+      "name"           -> Attribute(StringType(max = None, min = Some(1))),
+      "initials"       -> Attribute(StringType(max = Some(5), min = Some(0))),
+      "isStudent"      -> Attribute(BoolType),
+      "dateOfBirth"    -> Attribute(DateType),
+      "timeOfDay"      -> Attribute(TimeType),
+      "expiry"         -> Attribute(DateTimeType),
+      "image"          -> Attribute(BlobType()),
+    ),
+    structs = ListMap(
+      "Test" -> StructBlock(
+        ListMap(
+          "favouriteColour" -> Attribute(StringType(), valueAnnotations = Set(Annotation.Unique)),
+          "bedTime"         -> Attribute(TimeType, valueAnnotations = Set(Annotation.Nullable)),
+          "favouriteNumber" -> Attribute(IntType(max = Some(10), min = Some(0))),
+        ),
+      ),
+    ),
+  )
+}

--- a/src/test/scala/temple/builder/DatabaseBuilderTest.scala
+++ b/src/test/scala/temple/builder/DatabaseBuilderTest.scala
@@ -6,12 +6,12 @@ class DatabaseBuilderTest extends FlatSpec with Matchers {
   behavior of "DatabaseBuilder"
 
   it should "correctly create a simple users table" in {
-    val createQuery = DatabaseBuilder.createServiceTables("temple_user", DatabaseBuilderTestData.sampleService)
+    val createQuery = DatabaseBuilder.createServiceTables("temple_user", BuilderTestData.sampleService)
     createQuery shouldBe DatabaseBuilderTestData.sampleServiceCreate
   }
 
   it should "correctly create a complex users table" in {
-    val createQuery = DatabaseBuilder.createServiceTables("temple_user", DatabaseBuilderTestData.sampleComplexService)
+    val createQuery = DatabaseBuilder.createServiceTables("temple_user", BuilderTestData.sampleComplexService)
     createQuery shouldBe DatabaseBuilderTestData.sampleComplexServiceCreate
   }
 }

--- a/src/test/scala/temple/builder/DatabaseBuilderTestData.scala
+++ b/src/test/scala/temple/builder/DatabaseBuilderTestData.scala
@@ -1,14 +1,10 @@
 package temple.builder
 
-import temple.DSL.semantics.AttributeType._
-import temple.DSL.semantics.{Annotation, Attribute, ServiceBlock, StructBlock}
 import temple.generate.database.ast.ColType._
 import temple.generate.database.ast.ColumnConstraint.{Check, NonNull, Unique}
 import temple.generate.database.ast.ComparisonOperator.{GreaterEqual, LessEqual}
 import temple.generate.database.ast.Statement.Create
 import temple.generate.database.ast.{ColumnDef, Statement}
-
-import scala.collection.immutable.ListMap
 
 object DatabaseBuilderTestData {
 

--- a/src/test/scala/temple/builder/DatabaseBuilderTestData.scala
+++ b/src/test/scala/temple/builder/DatabaseBuilderTestData.scala
@@ -12,21 +12,6 @@ import scala.collection.immutable.ListMap
 
 object DatabaseBuilderTestData {
 
-  // TODO: This test doesn't include a `ForeignKey` attribute, since it is not yet supported
-  //  by the parser/semantic analysis. Once it is, please update these tests!
-  val sampleService: ServiceBlock = ServiceBlock(
-    ListMap(
-      "id"          -> Attribute(IntType()),
-      "bankBalance" -> Attribute(FloatType()),
-      "name"        -> Attribute(StringType()),
-      "isStudent"   -> Attribute(BoolType),
-      "dateOfBirth" -> Attribute(DateType),
-      "timeOfDay"   -> Attribute(TimeType),
-      "expiry"      -> Attribute(DateTimeType),
-      "image"       -> Attribute(BlobType()),
-    ),
-  )
-
   val sampleServiceCreate: Seq[Statement.Create] =
     Seq(
       Create(
@@ -43,32 +28,6 @@ object DatabaseBuilderTestData {
         ),
       ),
     )
-
-  val sampleComplexService: ServiceBlock = ServiceBlock(
-    ListMap(
-      "id"             -> Attribute(IntType(max = Some(100), min = Some(10), precision = 2)),
-      "anotherId"      -> Attribute(IntType(max = Some(100), min = Some(10))),
-      "yetAnotherId"   -> Attribute(IntType(max = Some(100), min = Some(10), precision = 8)),
-      "bankBalance"    -> Attribute(FloatType(max = Some(300), min = Some(0), precision = 4)),
-      "bigBankBalance" -> Attribute(FloatType(max = Some(123), min = Some(0))),
-      "name"           -> Attribute(StringType(max = None, min = Some(1))),
-      "initials"       -> Attribute(StringType(max = Some(5), min = Some(0))),
-      "isStudent"      -> Attribute(BoolType),
-      "dateOfBirth"    -> Attribute(DateType),
-      "timeOfDay"      -> Attribute(TimeType),
-      "expiry"         -> Attribute(DateTimeType),
-      "image"          -> Attribute(BlobType()),
-    ),
-    structs = ListMap(
-      "Test" -> StructBlock(
-        ListMap(
-          "favouriteColour" -> Attribute(StringType(), valueAnnotations = Set(Annotation.Unique)),
-          "bedTime"         -> Attribute(TimeType, valueAnnotations = Set(Annotation.Nullable)),
-          "favouriteNumber" -> Attribute(IntType(max = Some(10), min = Some(0))),
-        ),
-      ),
-    ),
-  )
 
   val sampleComplexServiceCreate: Seq[Statement.Create] =
     Seq(


### PR DESCRIPTION
It might be useful in a future PR to use the `ServiceBlocks` defined in the `DatabaseBuilderIntegrationTestData` for other types of `BuilderIntegregrationTests`... So, let's move them to their own file.