### PR TITLE
[go-gen] Simplify CodeWrap

### DIFF
--- a/src/main/scala/temple/DSL/syntax/Entry.scala
+++ b/src/main/scala/temple/DSL/syntax/Entry.scala
@@ -1,7 +1,7 @@
 package temple.DSL.syntax
 
 import temple.DSL.syntax.Arg.ListArg
-import temple.generate.utils.CodeTerm.{codeWrap, mkCode}
+import temple.generate.utils.CodeTerm.{CodeWrap, mkCode}
 
 /** Any element of a service/struct */
 abstract class Entry(val typeName: String)
@@ -18,7 +18,7 @@ object Entry {
     private def argsToString: String = args match {
       case Args(Seq(list: ListArg), Seq()) => list.toString
       case Args(Seq(), Seq())              => ""
-      case args                            => codeWrap.parens(args.toString)
+      case args                            => CodeWrap.parens(args.toString)
     }
     override def toString: String = mkCode.stmt("#" + metaKey, argsToString)
   }

--- a/src/main/scala/temple/generate/database/PostgresGenerator.scala
+++ b/src/main/scala/temple/generate/database/PostgresGenerator.scala
@@ -39,10 +39,10 @@ object PostgresGenerator extends DatabaseGenerator[PostgresContext] {
   private def generateConstraint(constraint: ColumnConstraint): String =
     constraint match {
       case NonNull                    => "NOT NULL"
-      case Check(left, comp, right)   => mkCode("CHECK", codeWrap.parens(left, generateComparison(comp), right))
+      case Check(left, comp, right)   => mkCode("CHECK", CodeWrap.parens(left, generateComparison(comp), right))
       case Unique                     => "UNIQUE"
       case PrimaryKey                 => "PRIMARY KEY"
-      case References(table, colName) => mkCode("REFERENCES", table, codeWrap.parens(colName))
+      case References(table, colName) => mkCode("REFERENCES", table, CodeWrap.parens(colName))
     }
 
   /** Given a query modifier, generate the type required by PostgreSQL */
@@ -50,13 +50,13 @@ object PostgresGenerator extends DatabaseGenerator[PostgresContext] {
     condition match {
       case Comparison(left, comp, right) => mkCode(left, generateComparison(comp), right)
       case Inverse(IsNull(column))       => mkCode(column.name, "IS NOT NULL")
-      case Inverse(condition)            => mkCode("NOT", codeWrap.parens(generateCondition(condition)))
+      case Inverse(condition)            => mkCode("NOT", CodeWrap.parens(generateCondition(condition)))
       case IsNull(column)                => mkCode(column.name, "IS NULL")
 
       case Disjunction(left, right) =>
-        mkCode(codeWrap.parens(generateCondition(left)), "OR", codeWrap.parens(generateCondition(right)))
+        mkCode(CodeWrap.parens(generateCondition(left)), "OR", CodeWrap.parens(generateCondition(right)))
       case Conjunction(left, right) =>
-        mkCode(codeWrap.parens(generateCondition(left)), "AND", codeWrap.parens(generateCondition(right)))
+        mkCode(CodeWrap.parens(generateCondition(left)), "AND", CodeWrap.parens(generateCondition(right)))
     }
 
   /** Given conditions, generate a Postgres WHERE clause  */
@@ -102,7 +102,7 @@ object PostgresGenerator extends DatabaseGenerator[PostgresContext] {
     statement match {
       case Create(tableName, columns) =>
         val stringColumns = mkCode.spacedList(columns.map(generateColumnDef))
-        mkCode.stmt("CREATE TABLE", tableName, codeWrap.parens.spaced(stringColumns))
+        mkCode.stmt("CREATE TABLE", tableName, CodeWrap.parens.spaced(stringColumns))
       case Read(tableName, columns, conditions) =>
         val stringColumns    = columns.map(_.name).mkString(", ")
         val stringConditions = generateConditionString(conditions)
@@ -110,7 +110,7 @@ object PostgresGenerator extends DatabaseGenerator[PostgresContext] {
       case Insert(tableName, columns) =>
         val stringColumns = columns.map(_.name).mkString(", ")
         val values        = generatePreparedValues(columns)
-        mkCode.stmt("INSERT INTO", tableName, codeWrap.parens(stringColumns), "VALUES", codeWrap.parens(values))
+        mkCode.stmt("INSERT INTO", tableName, CodeWrap.parens(stringColumns), "VALUES", CodeWrap.parens(values))
       case Update(tableName, assignments, conditions) =>
         val stringAssignments = assignments.map(generateAssignment).mkString(", ")
         val stringConditions  = generateConditionString(conditions)

--- a/src/main/scala/temple/generate/utils/CodeTerm.scala
+++ b/src/main/scala/temple/generate/utils/CodeTerm.scala
@@ -87,7 +87,7 @@ object CodeTerm {
     def stmt(string: CodeTerm*): String = mkCode(string, ";")
   }
 
-  sealed class codeWrap private (start: String, end: String) {
+  sealed class CodeWrap private (start: String, end: String) {
 
     /** Wrap a code snippet in parentheses */
     def apply(string: CodeTerm*): String = mkCode(start, string, end)
@@ -96,22 +96,11 @@ object CodeTerm {
     def spaced(string: CodeTerm*): String = mkCode(start, "\n", indent(mkCode(string)), "\n", end)
   }
 
-  object codeWrap {
-
-    object parens extends codeWrap("(", ")") {
-      object block extends codeWrap("(\n", ")\n")
-    }
-
-    object curly extends codeWrap("{", "}") {
-      object block extends codeWrap("{\n", "}\n")
-    }
-
-    object square extends codeWrap("[", "]") {
-      object block extends codeWrap("[\n", "]\n")
-    }
-
-    object singleQuotes extends codeWrap("'", "'")
-    object doubleQuotes extends codeWrap("\"", "\"")
-    object españolQue   extends codeWrap("¿", "?")
+  object CodeWrap {
+    val parens       = new CodeWrap("(", ")")
+    val curly        = new CodeWrap("{", "}")
+    val square       = new CodeWrap("[", "]")
+    val singleQuotes = new CodeWrap("'", "'")
+    val doubleQuotes = new CodeWrap("\"", "\"")
   }
 }

--- a/src/main/scala/temple/generate/utils/CodeTerm.scala
+++ b/src/main/scala/temple/generate/utils/CodeTerm.scala
@@ -102,5 +102,6 @@ object CodeTerm {
     val square       = new CodeWrap("[", "]")
     val singleQuotes = new CodeWrap("'", "'")
     val doubleQuotes = new CodeWrap("\"", "\"")
+    val españolQue   = new CodeWrap("¿", "?")
   }
 }

--- a/src/main/scala/temple/generate/utils/CodeTerm.scala
+++ b/src/main/scala/temple/generate/utils/CodeTerm.scala
@@ -97,11 +97,8 @@ object CodeTerm {
   }
 
   object CodeWrap {
-    val parens       = new CodeWrap("(", ")")
-    val curly        = new CodeWrap("{", "}")
-    val square       = new CodeWrap("[", "]")
-    val singleQuotes = new CodeWrap("'", "'")
-    val doubleQuotes = new CodeWrap("\"", "\"")
-    val españolQue   = new CodeWrap("¿", "?")
+    val parens = new CodeWrap("(", ")")
+    val curly  = new CodeWrap("{", "}")
+    val square = new CodeWrap("[", "]")
   }
 }

--- a/src/main/scala/temple/utils/StringUtils.scala
+++ b/src/main/scala/temple/utils/StringUtils.scala
@@ -3,8 +3,11 @@ package temple.utils
 /** Utility functions useful for performing operations on strings */
 object StringUtils {
 
+  /** Match the position at the start of a line, excluding blank lines */
+  private val startOfLinePattern = """^|(?<=\n)(?!\n)(?!$)""".r
+
   /** Given a string, indent it by a given number of spaces */
-  def indent(str: String, length: Int = 2): String = str.replaceAll("^|(?<=\n)", " " * length)
+  def indent(str: String, length: Int = 2): String = startOfLinePattern.replaceAllIn(str, " " * length)
 
   /** Given a string, convert it to snake case */
   // https://github.com/lift/framework/blob/f1b450db2dd6a22cf9ffe5576ec34c8e87118319/core/util/src/main/scala/net/liftweb/util/StringHelpers.scala#L91

--- a/src/main/scala/temple/utils/StringUtils.scala
+++ b/src/main/scala/temple/utils/StringUtils.scala
@@ -3,11 +3,16 @@ package temple.utils
 /** Utility functions useful for performing operations on strings */
 object StringUtils {
 
-  /** Match the position at the start of a line, excluding blank lines */
-  private val startOfLinePattern = """^|(?<=\n)(?!\n)(?!$)""".r
+  private def indentLine(line: String, indent: String): String = if (line.isBlank) line else indent + line
 
   /** Given a string, indent it by a given number of spaces */
-  def indent(str: String, length: Int = 2): String = startOfLinePattern.replaceAllIn(str, " " * length)
+  def indent(str: String, length: Int = 2): String =
+    str
+    // limit is -1 to avoid gobbling trailing newlines
+    // https://stackoverflow.com/questions/27689065/how-to-split-string-with-trailing-empty-strings-in-result
+      .split("\n", -1)
+      .map(indentLine(_, " " * length))
+      .mkString("\n")
 
   /** Given a string, convert it to snake case */
   // https://github.com/lift/framework/blob/f1b450db2dd6a22cf9ffe5576ec34c8e87118319/core/util/src/main/scala/net/liftweb/util/StringHelpers.scala#L91

--- a/src/test/scala/temple/utils/StringUtilsTest.scala
+++ b/src/test/scala/temple/utils/StringUtilsTest.scala
@@ -7,13 +7,13 @@ class StringUtilsTest extends FlatSpec with Matchers {
 
   behavior of "indent"
 
-  it should "add spaces to an empty string" in {
-    indent("") shouldEqual "  "
+  it should "not add change an empty string" in {
+    indent("") shouldEqual ""
   }
 
-  it should "add n spaces to an empty string" in {
-    indent("", 1) shouldEqual " "
-    indent("", 3) shouldEqual "   "
+  it should "add n spaces to a string" in {
+    indent("x", 1) shouldEqual " x"
+    indent("x", 3) shouldEqual "   x"
   }
 
   it should "add spaces to a single line" in {
@@ -23,7 +23,7 @@ class StringUtilsTest extends FlatSpec with Matchers {
 
   it should "add spaces on each line except for blank lines" in {
     indent("abcd\nefg", 1) shouldEqual " abcd\n efg"
-    indent("abcd\nefg\n", 1) shouldEqual " abcd\n efg\n"
+    indent("abcd\n\nefg\n", 1) shouldEqual " abcd\n\n efg\n"
   }
 
   behavior of "snakeCase"

--- a/src/test/scala/temple/utils/StringUtilsTest.scala
+++ b/src/test/scala/temple/utils/StringUtilsTest.scala
@@ -21,9 +21,9 @@ class StringUtilsTest extends FlatSpec with Matchers {
     indent("efgh", 4) shouldEqual "    efgh"
   }
 
-  it should "add spaces on each line" in {
+  it should "add spaces on each line except for blank lines" in {
     indent("abcd\nefg", 1) shouldEqual " abcd\n efg"
-    indent("abcd\nefg\n", 1) shouldEqual " abcd\n efg\n "
+    indent("abcd\nefg\n", 1) shouldEqual " abcd\n efg\n"
   }
 
   behavior of "snakeCase"

--- a/src/test/scala/temple/utils/StringUtilsTest.scala
+++ b/src/test/scala/temple/utils/StringUtilsTest.scala
@@ -7,7 +7,7 @@ class StringUtilsTest extends FlatSpec with Matchers {
 
   behavior of "indent"
 
-  it should "not add change an empty string" in {
+  it should "not change an empty string" in {
     indent("") shouldEqual ""
   }
 


### PR DESCRIPTION
Jumping on the back of #93 with some simplifications. The block methods have been removed as they are the same as `CodeWrap#spaced`.