### PR TITLE
[it][test] Run go mod tidy prior to building the project

### DIFF
--- a/docker/shell2http.Dockerfile
+++ b/docker/shell2http.Dockerfile
@@ -23,4 +23,4 @@ COPY configure_go.py configure_go.py
 
 ENTRYPOINT /app/shell2http -show-errors\
  -form GET:/hadolint "echo \$v_dockerfile | ./jq-linux64 -r .contents > Dockerfile && hadolint Dockerfile"\
- GET:/go "python3 configure_go.py && cd \$v_root && go build \$v_entrypoint 2>&1"
+ GET:/go "python3 configure_go.py && cd \$v_root && go mod tidy &>/dev/null; go build \$v_entrypoint 2>&1"


### PR DESCRIPTION
Currently dependency pulling causes integration tests to fail, so this does that before building the project.

NB: Can't use `&&`, since `go mod tidy` will fail if it can't find a project, but this isn't echo'd back to the user since output is redirected. 