### PR TITLE
[go-gen] Add integration tests for compiling generated Go

### DIFF
--- a/src/it/scala/temple/generate/language/service/GoGeneratorIntegrationTest.scala
+++ b/src/it/scala/temple/generate/language/service/GoGeneratorIntegrationTest.scala
@@ -74,6 +74,15 @@ class GoGeneratorIntegrationTest extends GolangSpec with Matchers with BeforeAnd
       FileUtils.File("user", "user.go"),
     )
 
+    validationErrors shouldBe empty
+  }
+
+  it should "generate compilable simple services with inter-service communication" in {
+    val validationErrors = validateAll(
+      GoServiceGenerator.generate(GoGeneratorIntegrationTestData.simpleServiceRootWithComms),
+      FileUtils.File("match", "match.go"),
+    )
+
     validationErrors shouldBe ""
   }
 }

--- a/src/it/scala/temple/generate/language/service/GoGeneratorIntegrationTest.scala
+++ b/src/it/scala/temple/generate/language/service/GoGeneratorIntegrationTest.scala
@@ -11,7 +11,7 @@ class GoGeneratorIntegrationTest extends GolangSpec with Matchers with BeforeAnd
 
   it should "fail when an empty file is provided" in {
     val validationErrors = validate("")
-    validationErrors should not be empty
+    validationErrors should not be ""
   }
 
   it should "succeed when a sample Go file is validated" in {
@@ -25,7 +25,7 @@ class GoGeneratorIntegrationTest extends GolangSpec with Matchers with BeforeAnd
         |}
         |""".stripMargin
     val validationErrors = validate(sampleFile)
-    validationErrors shouldBe empty
+    validationErrors shouldBe ""
   }
 
   it should "succeed when referencing other files" in {
@@ -63,7 +63,7 @@ class GoGeneratorIntegrationTest extends GolangSpec with Matchers with BeforeAnd
       FileUtils.File("sample-proj", "main.go"),
     )
 
-    validationErrors shouldBe empty
+    validationErrors shouldBe ""
   }
 
   behavior of "GoServiceGenerator"
@@ -74,7 +74,7 @@ class GoGeneratorIntegrationTest extends GolangSpec with Matchers with BeforeAnd
       FileUtils.File("user", "user.go"),
     )
 
-    validationErrors shouldBe empty
+    validationErrors shouldBe ""
   }
 
   it should "generate compilable simple services with inter-service communication" in {

--- a/src/it/scala/temple/generate/language/service/GoGeneratorIntegrationTest.scala
+++ b/src/it/scala/temple/generate/language/service/GoGeneratorIntegrationTest.scala
@@ -3,6 +3,7 @@ package temple.generate.language.service
 import org.scalatest.{BeforeAndAfter, Matchers}
 import temple.containers.GolangSpec
 import temple.utils.FileUtils
+import temple.generate.language.service.go.GoServiceGenerator
 
 class GoGeneratorIntegrationTest extends GolangSpec with Matchers with BeforeAndAfter {
 
@@ -63,5 +64,16 @@ class GoGeneratorIntegrationTest extends GolangSpec with Matchers with BeforeAnd
     )
 
     validationErrors shouldBe empty
+  }
+
+  behavior of "GoServiceGenerator"
+
+  it should "generate compilable simple services" in {
+    val validationErrors = validateAll(
+      GoServiceGenerator.generate(GoGeneratorIntegrationTestData.simpleServiceRoot),
+      FileUtils.File("user", "user.go"),
+    )
+
+    validationErrors shouldBe ""
   }
 }

--- a/src/it/scala/temple/generate/language/service/GoGeneratorIntegrationTestData.scala
+++ b/src/it/scala/temple/generate/language/service/GoGeneratorIntegrationTestData.scala
@@ -1,0 +1,61 @@
+package temple.generate.language.service
+
+import temple.generate.language.service.adt._
+import temple.utils.FileUtils._
+
+object GoGeneratorIntegrationTestData {
+
+  val simpleServiceRoot: ServiceRoot = ServiceRoot(
+    "user",
+    "github.com/TempleEight/spec-golang/user",
+    Seq.empty,
+    Set(Endpoint.Create, Endpoint.Read, Endpoint.Update, Endpoint.Delete),
+    80,
+  )
+
+  val simpleServiceFiles: Map[File, FileContent] = Map(
+    File("user", "user.go") -> readFile("src/test/scala/temple/generate/language/service/go/testfiles/user/user.go"),
+    File("user/dao", "errors.go") -> readFile(
+      "src/test/scala/temple/generate/language/service/go/testfiles/user/dao/errors.go",
+    ),
+    File("user/dao", "dao.go") -> readFile(
+      "src/test/scala/temple/generate/language/service/go/testfiles/user/dao/dao.go",
+    ),
+    File("user/util", "config.go") -> readFile(
+      "src/test/scala/temple/generate/language/service/go/testfiles/user/util/config.go",
+    ),
+    File("user/util", "util.go") -> readFile(
+      "src/test/scala/temple/generate/language/service/go/testfiles/user/util/util.go",
+    ),
+  )
+
+  val simpleServiceRootWithComms: ServiceRoot =
+    ServiceRoot(
+      "match",
+      "github.com/TempleEight/spec-golang/match",
+      Seq("user"),
+      Set(Endpoint.ReadAll, Endpoint.Create, Endpoint.Read, Endpoint.Update, Endpoint.Delete),
+      81,
+    )
+
+  val simpleServiceFilesWithComms: Map[File, FileContent] = Map(
+    File("match", "match.go") -> readFile(
+      "src/test/scala/temple/generate/language/service/go/testfiles/match/match.go",
+    ),
+    File("match/dao", "errors.go") -> readFile(
+      "src/test/scala/temple/generate/language/service/go/testfiles/match/dao/errors.go",
+    ),
+    File("match/dao", "dao.go") -> readFile(
+      "src/test/scala/temple/generate/language/service/go/testfiles/match/dao/dao.go",
+    ),
+    File("match/util", "config.go") -> readFile(
+      "src/test/scala/temple/generate/language/service/go/testfiles/match/util/config.go",
+    ),
+    File("match/util", "util.go") -> readFile(
+      "src/test/scala/temple/generate/language/service/go/testfiles/match/util/util.go",
+    ),
+    File("match/comm", "handler.go") -> readFile(
+      "src/test/scala/temple/generate/language/service/go/testfiles/match/comm/handler.go",
+    ),
+  )
+}

--- a/src/it/scala/temple/generate/language/service/GoGeneratorIntegrationTestData.scala
+++ b/src/it/scala/temple/generate/language/service/GoGeneratorIntegrationTestData.scala
@@ -13,22 +13,6 @@ object GoGeneratorIntegrationTestData {
     80,
   )
 
-  val simpleServiceFiles: Map[File, FileContent] = Map(
-    File("user", "user.go") -> readFile("src/test/scala/temple/generate/language/service/go/testfiles/user/user.go"),
-    File("user/dao", "errors.go") -> readFile(
-      "src/test/scala/temple/generate/language/service/go/testfiles/user/dao/errors.go",
-    ),
-    File("user/dao", "dao.go") -> readFile(
-      "src/test/scala/temple/generate/language/service/go/testfiles/user/dao/dao.go",
-    ),
-    File("user/util", "config.go") -> readFile(
-      "src/test/scala/temple/generate/language/service/go/testfiles/user/util/config.go",
-    ),
-    File("user/util", "util.go") -> readFile(
-      "src/test/scala/temple/generate/language/service/go/testfiles/user/util/util.go",
-    ),
-  )
-
   val simpleServiceRootWithComms: ServiceRoot =
     ServiceRoot(
       "match",
@@ -37,25 +21,4 @@ object GoGeneratorIntegrationTestData {
       Set(Endpoint.ReadAll, Endpoint.Create, Endpoint.Read, Endpoint.Update, Endpoint.Delete),
       81,
     )
-
-  val simpleServiceFilesWithComms: Map[File, FileContent] = Map(
-    File("match", "match.go") -> readFile(
-      "src/test/scala/temple/generate/language/service/go/testfiles/match/match.go",
-    ),
-    File("match/dao", "errors.go") -> readFile(
-      "src/test/scala/temple/generate/language/service/go/testfiles/match/dao/errors.go",
-    ),
-    File("match/dao", "dao.go") -> readFile(
-      "src/test/scala/temple/generate/language/service/go/testfiles/match/dao/dao.go",
-    ),
-    File("match/util", "config.go") -> readFile(
-      "src/test/scala/temple/generate/language/service/go/testfiles/match/util/config.go",
-    ),
-    File("match/util", "util.go") -> readFile(
-      "src/test/scala/temple/generate/language/service/go/testfiles/match/util/util.go",
-    ),
-    File("match/comm", "handler.go") -> readFile(
-      "src/test/scala/temple/generate/language/service/go/testfiles/match/comm/handler.go",
-    ),
-  )
 }

--- a/src/main/scala/temple/generate/language/service/go/GoServiceGenerator.scala
+++ b/src/main/scala/temple/generate/language/service/go/GoServiceGenerator.scala
@@ -11,6 +11,8 @@ import scala.collection.mutable.ListBuffer
 /** Implementation of [[ServiceGenerator]] for generating Go */
 object GoServiceGenerator extends ServiceGenerator {
 
+  private def generateMod(module: String): String = Seq(s"module ${module}", "", "go 1.13").mkString("\n")
+
   private def generatePackage(packageName: String): String = s"package $packageName\n"
 
   /** Given a service name, module name and whether the service uses inter-service communication, return the import
@@ -19,7 +21,7 @@ object GoServiceGenerator extends ServiceGenerator {
     val sb = new StringBuilder
     sb.append("import ")
 
-    val standardImports = Seq("encoding/json", "flag", "fmt", "log", "net/http")
+    val standardImports = Seq("flag", "log", "net/http")
       .map(doubleQuote)
       .mkString("\n")
 
@@ -185,6 +187,7 @@ object GoServiceGenerator extends ServiceGenerator {
      */
     val usesComms = serviceRoot.comms.nonEmpty
     var result = Map(
+      FileUtils.File(s"${serviceRoot.name}", "go.mod") -> generateMod(serviceRoot.module),
       FileUtils.File(serviceRoot.name, s"${serviceRoot.name}.go") -> Seq(
         generatePackage("main"),
         generateImports(

--- a/src/main/scala/temple/generate/language/service/go/GoServiceGenerator.scala
+++ b/src/main/scala/temple/generate/language/service/go/GoServiceGenerator.scala
@@ -47,9 +47,6 @@ object GoServiceGenerator extends ServiceGenerator {
   private def generateCommImports(module: String): String = mkCode(
     "import",
     CodeWrap.parens.tabbed(
-      """"fmt"""",
-      """"net/http"""",
-      "",
       s""""$module/util"""",
     ),
   )

--- a/src/test/scala/temple/generate/language/service/go/GoServiceGeneratorTestData.scala
+++ b/src/test/scala/temple/generate/language/service/go/GoServiceGeneratorTestData.scala
@@ -14,6 +14,7 @@ object GoServiceGeneratorTestData {
   )
 
   val simpleServiceFiles: Map[File, FileContent] = Map(
+    File("user", "go.mod")  -> readFile("src/test/scala/temple/generate/language/service/go/testfiles/user/go.mod"),
     File("user", "user.go") -> readFile("src/test/scala/temple/generate/language/service/go/testfiles/user/user.go"),
     File("user/dao", "errors.go") -> readFile(
       "src/test/scala/temple/generate/language/service/go/testfiles/user/dao/errors.go",
@@ -39,6 +40,7 @@ object GoServiceGeneratorTestData {
     )
 
   val simpleServiceFilesWithComms: Map[File, FileContent] = Map(
+    File("match", "go.mod") -> readFile("src/test/scala/temple/generate/language/service/go/testfiles/match/go.mod"),
     File("match", "match.go") -> readFile(
       "src/test/scala/temple/generate/language/service/go/testfiles/match/match.go",
     ),

--- a/src/test/scala/temple/generate/language/service/go/testfiles/match/comm/handler.go
+++ b/src/test/scala/temple/generate/language/service/go/testfiles/match/comm/handler.go
@@ -1,9 +1,6 @@
 package comm
 
 import (
-	"fmt"
-	"net/http"
-
 	"github.com/TempleEight/spec-golang/match/util"
 )
 

--- a/src/test/scala/temple/generate/language/service/go/testfiles/match/go.mod
+++ b/src/test/scala/temple/generate/language/service/go/testfiles/match/go.mod
@@ -1,0 +1,3 @@
+module github.com/TempleEight/spec-golang/match
+
+go 1.13

--- a/src/test/scala/temple/generate/language/service/go/testfiles/match/match.go
+++ b/src/test/scala/temple/generate/language/service/go/testfiles/match/match.go
@@ -1,9 +1,7 @@
 package main
 
 import (
-	"encoding/json"
 	"flag"
-	"fmt"
 	"log"
 	"net/http"
 

--- a/src/test/scala/temple/generate/language/service/go/testfiles/user/go.mod
+++ b/src/test/scala/temple/generate/language/service/go/testfiles/user/go.mod
@@ -1,0 +1,3 @@
+module github.com/TempleEight/spec-golang/user
+
+go 1.13

--- a/src/test/scala/temple/generate/language/service/go/testfiles/user/user.go
+++ b/src/test/scala/temple/generate/language/service/go/testfiles/user/user.go
@@ -1,9 +1,7 @@
 package main
 
 import (
-	"encoding/json"
 	"flag"
-	"fmt"
 	"log"
 	"net/http"
 


### PR DESCRIPTION
* Adds integration tests for compiling generated Go service code
* Removes unused imports from generated code, will need to be added back in when generation of handlers and DAO code is added
* Replaces `empty` with `""` in integration tests so the compilation errors are displayed

![](https://media.giphy.com/media/bMoMuUUUbff2g/giphy-downsized.gif)