### PR TITLE
[openapi-gen] Refactor JsonEncodable

### DIFF
--- a/src/main/scala/temple/generate/JsonEncodable.scala
+++ b/src/main/scala/temple/generate/JsonEncodable.scala
@@ -2,7 +2,7 @@ package temple.generate
 
 import io.circe.{Encoder, Json}
 
-private[openapi] trait JsonEncodable {
+private[generate] trait JsonEncodable {
 
   /** Turn a case class into some key-value pairs in preparation for conversion to a JSON object */
   def jsonEntryIterator: IterableOnce[(String, Json)]
@@ -11,7 +11,7 @@ private[openapi] trait JsonEncodable {
   implicit final protected def encodeToJson[T <: JsonEncodable]: Encoder[T] = JsonEncodable.encodeToJson
 }
 
-private[openapi] object JsonEncodable {
+private[generate] object JsonEncodable {
 
   /** Create an encoder for JSON objects by providing a function to map them to key-value pairs */
   private def mapSequenceEncoder[T](toJsonMap: T => IterableOnce[(String, Json)]): Encoder[T] = (obj: T) => {

--- a/src/main/scala/temple/generate/JsonEncodable.scala
+++ b/src/main/scala/temple/generate/JsonEncodable.scala
@@ -1,4 +1,4 @@
-package temple.generate.target.openapi
+package temple.generate
 
 import io.circe.{Encoder, Json}
 
@@ -20,8 +20,7 @@ private[openapi] object JsonEncodable {
 
   implicit def encodeToJson[T <: JsonEncodable]: Encoder[T] = mapSequenceEncoder(_.jsonEntryIterator)
 
-  /** Like [[temple.generate.target.openapi.JsonEncodable]] but by providing optional values, causing the entries not
-    * to render */
+  /** Like [[temple.generate.JsonEncodable]] but by providing optional values, causing the entries not to render */
   trait Partial extends JsonEncodable {
     def jsonOptionEntryIterator: IterableOnce[(String, Option[Json])]
 

--- a/src/main/scala/temple/generate/target/openapi/JsonEncodable.scala
+++ b/src/main/scala/temple/generate/target/openapi/JsonEncodable.scala
@@ -4,7 +4,7 @@ import io.circe.{Encoder, Json}
 
 private[openapi] trait JsonEncodable {
 
-  /** Turn a case class into a map in preparation for conversion to a JSON object */
+  /** Turn a case class into some key-value pairs in preparation for conversion to a JSON object */
   def jsonEntryIterator: IterableOnce[(String, Json)]
 
   // Required so that nested JsonEncodable interfaces always call the correct nested version
@@ -13,13 +13,15 @@ private[openapi] trait JsonEncodable {
 
 private[openapi] object JsonEncodable {
 
-  /** Create an encoder for JSON objects by providing a function to map them to options of values */
+  /** Create an encoder for JSON objects by providing a function to map them to key-value pairs */
   private def mapSequenceEncoder[T](toJsonMap: T => IterableOnce[(String, Json)]): Encoder[T] = (obj: T) => {
     Json.obj(toJsonMap(obj).iterator.toSeq: _*)
   }
 
   implicit def encodeToJson[T <: JsonEncodable]: Encoder[T] = mapSequenceEncoder(_.jsonEntryIterator)
 
+  /** Like [[temple.generate.target.openapi.JsonEncodable]] but by providing optional values, causing the entries not
+    * to render */
   trait Partial extends JsonEncodable {
     def jsonOptionEntryIterator: IterableOnce[(String, Option[Json])]
 

--- a/src/main/scala/temple/generate/target/openapi/JsonEncodable.scala
+++ b/src/main/scala/temple/generate/target/openapi/JsonEncodable.scala
@@ -5,7 +5,7 @@ import io.circe.{Encoder, Json}
 private[openapi] trait JsonEncodable {
 
   /** Turn a case class into a map in preparation for conversion to a JSON object */
-  def toJsonMap: Map[String, Option[Json]]
+  def jsonEntryIterator: IterableOnce[(String, Json)]
 
   // Required so that nested JsonEncodable interfaces always call the correct nested version
   implicit final protected def encodeToJson[T <: JsonEncodable]: Encoder[T] = JsonEncodable.encodeToJson
@@ -14,15 +14,16 @@ private[openapi] trait JsonEncodable {
 private[openapi] object JsonEncodable {
 
   /** Create an encoder for JSON objects by providing a function to map them to options of values */
-  private def mapSequenceEncoder[T](toJsonMap: T => Map[String, Option[Json]]): Encoder[T] = (obj: T) => {
-    val jsonMap = toJsonMap(obj)
-
-    // collect only the entries that are present
-    val somes = jsonMap.iterator.collect { case (str, Some(json)) => (str, json) }.toSeq
-
-    // construct a JSON object from them
-    Json.obj(somes: _*)
+  private def mapSequenceEncoder[T](toJsonMap: T => IterableOnce[(String, Json)]): Encoder[T] = (obj: T) => {
+    Json.obj(toJsonMap(obj).iterator.toSeq: _*)
   }
 
-  implicit def encodeToJson[T <: JsonEncodable]: Encoder[T] = mapSequenceEncoder(_.toJsonMap)
+  implicit def encodeToJson[T <: JsonEncodable]: Encoder[T] = mapSequenceEncoder(_.jsonEntryIterator)
+
+  trait Partial extends JsonEncodable {
+    def jsonOptionEntryIterator: IterableOnce[(String, Option[Json])]
+
+    final override def jsonEntryIterator: IterableOnce[(String, Json)] =
+      jsonOptionEntryIterator.iterator.collect { case (str, Some(json)) => (str, json) }
+  }
 }

--- a/src/main/scala/temple/generate/target/openapi/OpenAPIGenerator.scala
+++ b/src/main/scala/temple/generate/target/openapi/OpenAPIGenerator.scala
@@ -1,7 +1,7 @@
 package temple.generate.target.openapi
 
-import temple.generate.target.openapi.OpenAPIType._
 import io.circe.syntax._
+import temple.generate.target.openapi.OpenAPIType._
 
 import scala.collection.immutable.ListMap
 

--- a/src/main/scala/temple/generate/target/openapi/OpenAPIType.scala
+++ b/src/main/scala/temple/generate/target/openapi/OpenAPIType.scala
@@ -8,8 +8,7 @@ import scala.collection.immutable.ListMap
 sealed abstract private[openapi] class OpenAPIType(val typeString: String, customFields: Seq[(String, Json)])
     extends JsonEncodable {
 
-  override def toJsonMap: Map[String, Option[Json]] =
-    ListMap("type" -> Some(typeString.asJson)) ++ customFields.to(ListMap).view.mapValues(Some(_))
+  override def jsonEntryIterator: Seq[(String, Json)] = ("type" -> typeString.asJson) +: customFields
 }
 
 private[openapi] object OpenAPIType {

--- a/src/main/scala/temple/generate/target/openapi/OpenAPIType.scala
+++ b/src/main/scala/temple/generate/target/openapi/OpenAPIType.scala
@@ -2,6 +2,7 @@ package temple.generate.target.openapi
 
 import io.circe.Json
 import io.circe.syntax._
+import temple.generate.JsonEncodable
 
 sealed abstract private[openapi] class OpenAPIType(val typeString: String, customFields: Seq[(String, Json)])
     extends JsonEncodable {

--- a/src/main/scala/temple/generate/target/openapi/OpenAPIType.scala
+++ b/src/main/scala/temple/generate/target/openapi/OpenAPIType.scala
@@ -3,8 +3,6 @@ package temple.generate.target.openapi
 import io.circe.Json
 import io.circe.syntax._
 
-import scala.collection.immutable.ListMap
-
 sealed abstract private[openapi] class OpenAPIType(val typeString: String, customFields: Seq[(String, Json)])
     extends JsonEncodable {
 

--- a/src/main/scala/temple/generate/target/openapi/Response.scala
+++ b/src/main/scala/temple/generate/target/openapi/Response.scala
@@ -2,6 +2,7 @@ package temple.generate.target.openapi
 
 import io.circe.syntax._
 import io.circe.{Encoder, Json}
+import temple.generate.JsonEncodable
 
 /** https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#responseObject */
 private[openapi] case class Response(

--- a/src/main/scala/temple/generate/target/openapi/Response.scala
+++ b/src/main/scala/temple/generate/target/openapi/Response.scala
@@ -1,10 +1,7 @@
 package temple.generate.target.openapi
 
 import io.circe.syntax._
-
 import io.circe.{Encoder, Json}
-
-import scala.collection.immutable.ListMap
 
 /** https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#responseObject */
 private[openapi] case class Response(

--- a/src/main/scala/temple/generate/target/openapi/Response.scala
+++ b/src/main/scala/temple/generate/target/openapi/Response.scala
@@ -11,9 +11,9 @@ private[openapi] case class Response(
   description: String,
   content: Map[String, Response.MediaTypeObject],
   required: Option[Boolean] = None,
-) extends JsonEncodable {
+) extends JsonEncodable.Partial {
 
-  override def toJsonMap: Map[String, Option[Json]] = ListMap(
+  override def jsonOptionEntryIterator: IterableOnce[(String, Option[Json])] = Seq(
     "description" -> Some(description.asJson),
     "required"    -> required.map(_.asJson),
     "content"     -> Some(content.asJson(Encoder.encodeMapLike)),
@@ -23,11 +23,9 @@ private[openapi] case class Response(
 private[openapi] object Response {
 
   /** https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#mediaTypeObject */
-  private[openapi] case class MediaTypeObject(schema: OpenAPIType, fieldEntries: (String, Json)*)
+  private[openapi] case class MediaTypeObject(schema: OpenAPIType, customFields: (String, Json)*)
       extends JsonEncodable {
-    final lazy val customFields: Map[String, Json] = fieldEntries.to(ListMap)
 
-    override def toJsonMap: Map[String, Option[Json]] =
-      ListMap("schema" -> Some(schema.asJson)) ++ customFields.view.mapValues(Some(_))
+    override def jsonEntryIterator: Seq[(String, Json)] = ("schema" -> schema.asJson) +: customFields
   }
 }


### PR DESCRIPTION
This provides versions with and without optionals for each value in the tree, and moves it up to the root `generation` package for Lewis

Code cov is reduced merely because the number of lines is reduced, and so the other untested lines are proportionally more significant