### PR TITLE
[api] Add FlagMapView, for use with OpenAPI generation

### DIFF
--- a/src/main/scala/temple/collection/FlagMapView.scala
+++ b/src/main/scala/temple/collection/FlagMapView.scala
@@ -28,7 +28,7 @@ class FlagMapView[K, +V] private (val basis: Map[K, V], keyDesc: String = "flag"
   def flag(keys: K*): FlagMapView[K, V] = {
     keys.foreach { key =>
       if (!basis.contains(key))
-        throw new NoSuchElementException(s"The $keyDesc $key has not been defined")
+        throw new NoSuchElementException(s"$keyDesc $key has not been defined")
       flags += key
     }
     this
@@ -43,7 +43,7 @@ class FlagMapView[K, +V] private (val basis: Map[K, V], keyDesc: String = "flag"
   def unflag(keys: K*): FlagMapView[K, V] = {
     keys.foreach { key =>
       if (!basis.contains(key))
-        throw new NoSuchElementException(s"The $keyDesc $key has not been defined")
+        throw new NoSuchElementException(s"$keyDesc $key has not been defined")
       flags -= key
     }
     this

--- a/src/main/scala/temple/collection/FlagMapView.scala
+++ b/src/main/scala/temple/collection/FlagMapView.scala
@@ -74,5 +74,5 @@ object FlagMapView {
   def apply[K, V](basis: (K, V)*): FlagMapView[K, V] = new FlagMapView(Map(basis: _*))
 
   /** Create a [[temple.collection.FlagMapView]] given a key description and key-value pairs */
-  def apply[K, V](keyDesc: String, basis: (K, V)*): FlagMapView[K, V] = new FlagMapView(Map(basis: _*), keyDesc)
+  def apply[K, V](keyDesc: String)(basis: (K, V)*): FlagMapView[K, V] = new FlagMapView(Map(basis: _*), keyDesc)
 }

--- a/src/main/scala/temple/collection/FlagMapView.scala
+++ b/src/main/scala/temple/collection/FlagMapView.scala
@@ -1,0 +1,78 @@
+package temple.collection
+
+import scala.collection.{Iterable, MapView, mutable}
+
+/**
+  * This is a mutable view on a map: the values for each key are given at initialization, but the keys in the set are
+  * given later
+  *
+  * Keys are activated and deactivated with the [[temple.collection.FlagMapView#flag(scala.collection.immutable.Seq)]]
+  * and [[temple.collection.FlagMapView#unflag(scala.collection.immutable.Seq)]] functions respectively
+  *
+  * @param basis The underlying map of values for each potential key
+  * @param keyDesc A description of the key type, for use in error messages
+  * @tparam K the type of keys in this FlagMapView
+  * @tparam V the type of values in this FlagMapView
+  */
+class FlagMapView[K, +V] private (val basis: Map[K, V], keyDesc: String = "flag") extends MapView[K, V] {
+
+  /** The set of keys already enabled */
+  private val flags: mutable.Set[K] = mutable.Set[K]()
+
+  /**
+    * Enable key(s) in the map
+    * @param keys The keys to enable
+    * @throws NoSuchElementException when a key not in the initial map is given
+    * @return the FlagMapView itself
+    */
+  def flag(keys: K*): FlagMapView[K, V] = {
+    keys.foreach { key =>
+      if (!basis.contains(key))
+        throw new NoSuchElementException(s"The $keyDesc $key has not been defined")
+      flags += key
+    }
+    this
+  }
+
+  /**
+    * Disable key(s) in the map
+    * @param keys The keys to disable
+    * @throws NoSuchElementException when a key not in the initial map is given
+    * @return the FlagMapView itself
+    */
+  def unflag(keys: K*): FlagMapView[K, V] = {
+    keys.foreach { key =>
+      if (!basis.contains(key))
+        throw new NoSuchElementException(s"The $keyDesc $key has not been defined")
+      flags -= key
+    }
+    this
+  }
+
+  /** Get a view of the underlying map, containing only the enabled keys */
+  override def view: MapView[K, V] = basis.view.filterKeys(flags.contains)
+
+  /** Export a map containing only the enabled keys */
+  def toMap: Map[K, V] = view.toMap
+
+  /** Safely lookup a value in the map, only returning successfully if the key is enabled */
+  def get(key: K): Option[V] = view.get(key)
+
+  /** Get an iterator for the enabled keys */
+  def iterator: Iterator[(K, V)] = view.iterator
+
+  /** The keys that have been enabled */
+  override def keys: Iterable[K] = flags.toSet
+}
+
+object FlagMapView {
+
+  /** Create a [[temple.collection.FlagMapView]] given a basis map and optionally a description */
+  def apply[K, V](basis: Map[K, V], keyDesc: String = "flag"): FlagMapView[K, V] = new FlagMapView(basis, keyDesc)
+
+  /** Create a [[temple.collection.FlagMapView]] given key-value pairs */
+  def apply[K, V](basis: (K, V)*): FlagMapView[K, V] = new FlagMapView(Map(basis: _*))
+
+  /** Create a [[temple.collection.FlagMapView]] given a key description and key-value pairs */
+  def apply[K, V](keyDesc: String, basis: (K, V)*): FlagMapView[K, V] = new FlagMapView(Map(basis: _*), keyDesc)
+}

--- a/src/main/scala/temple/collection/FlagMapView.scala
+++ b/src/main/scala/temple/collection/FlagMapView.scala
@@ -49,17 +49,11 @@ class FlagMapView[K, +V] private (val basis: Map[K, V], keyDesc: String = "flag"
     this
   }
 
-  /** Get a view of the underlying map, containing only the enabled keys */
-  override def view: MapView[K, V] = basis.view.filterKeys(flags.contains)
-
-  /** Export a map containing only the enabled keys */
-  def toMap: Map[K, V] = view.toMap
-
   /** Safely lookup a value in the map, only returning successfully if the key is enabled */
-  def get(key: K): Option[V] = view.get(key)
+  def get(key: K): Option[V] = if (flags contains key) basis.get(key) else None
 
   /** Get an iterator for the enabled keys */
-  def iterator: Iterator[(K, V)] = view.iterator
+  def iterator: Iterator[(K, V)] = flags.iterator.map(flag => flag -> basis(flag))
 
   /** The keys that have been enabled */
   override def keys: Iterable[K] = flags.toSet

--- a/src/test/scala/temple/collection/FlagMapViewTest.scala
+++ b/src/test/scala/temple/collection/FlagMapViewTest.scala
@@ -48,6 +48,13 @@ class FlagMapViewTest extends FlatSpec with Matchers {
     map.toMap shouldBe Map("x" -> 5)
   }
 
+  it should "keys" in {
+    val map = FlagMapView(Map("x" -> 5, "y" -> 4))
+    map.flag("y")
+
+    map.keys shouldBe Set("y")
+  }
+
   it should "give good error messages" in {
     val map = FlagMapView("error")(
       400 -> "Client error",

--- a/src/test/scala/temple/collection/FlagMapViewTest.scala
+++ b/src/test/scala/temple/collection/FlagMapViewTest.scala
@@ -48,4 +48,14 @@ class FlagMapViewTest extends FlatSpec with Matchers {
     map.toMap shouldBe Map("x" -> 5)
   }
 
+  it should "give good error messages" in {
+    val map = FlagMapView("error")(
+      400 -> "Client error",
+      500 -> "Server error",
+    )
+
+    the[NoSuchElementException] thrownBy map.flag(300) should have message "error 300 has not been defined"
+    the[NoSuchElementException] thrownBy map.unflag(410) should have message "error 410 has not been defined"
+  }
+
 }

--- a/src/test/scala/temple/collection/FlagMapViewTest.scala
+++ b/src/test/scala/temple/collection/FlagMapViewTest.scala
@@ -1,0 +1,51 @@
+package temple.collection
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class FlagMapViewTest extends FlatSpec with Matchers {
+
+  behavior of "FlagMapView"
+
+  it should "get" in {
+    val map = FlagMapView("x" -> 5, "y" -> 4)
+    map.flag("x")
+
+    map.get("x") shouldBe Some(5)
+    map("x") shouldBe 5
+
+    map.get("y") shouldBe None
+    a[NoSuchElementException] shouldBe thrownBy { map("y") }
+  }
+
+  it should "toMap" in {
+    val map = FlagMapView("x" -> 5, "y" -> 4)
+    map.flag("x")
+
+    map.toMap shouldBe Map("x" -> 5)
+  }
+
+  it should "unflag" in {
+    val map = FlagMapView("x" -> 5, "y" -> 4)
+    map.flag("x")
+
+    map.get("x") shouldBe Some(5)
+    map.unflag("x")
+
+    map.get("x") shouldBe None
+  }
+
+  it should "view" in {
+    val map = FlagMapView(Map("x" -> 5, "y" -> 4))
+    map.flag("x")
+
+    map.view.size shouldBe 1
+  }
+
+  it should "map" in {
+    val map = FlagMapView(Map("x" -> 5, "y" -> 4))
+    map.flag("x")
+
+    map.toMap shouldBe Map("x" -> 5)
+  }
+
+}


### PR DESCRIPTION
```scala
  val errorTracker = FlagMapView(
    400 -> OpenAPIBuilder.generateError("Invalid request", "Invalid request parameters: name"),
    404 -> OpenAPIBuilder.generateError("ID not found", "Object not found with ID 1"),
    500 -> OpenAPIBuilder.generateError(
      "The server encountered an error while serving this request",
      "Unable to reach user service: connection timeout",
    ),
  )

  // while generating one of the endpoints:
  errorTracker.flag(500)
  val errorBlock = errorTracker.toMap.asJson // -> map just including the 500 key
```

Provide a maximal map at the start, and then specify which keys to access. This will be used for error references in the OpenAPI spec: the definition of all error codes will be provided, then they will be activated as and when the references are needed. This way, there won’t be any unused references (e.g. if no error 403 occur in the system, the 403 block won’t appear in the references block).

Other applications could include imports and initialization/closing code