### PR TITLE
[OpenAPI-gen] Finalise datastructures in preparation for generation

### DIFF
--- a/src/main/scala/temple/generate/target/openapi/OpenAPIFile.scala
+++ b/src/main/scala/temple/generate/target/openapi/OpenAPIFile.scala
@@ -24,5 +24,12 @@ case class OpenAPIFile(
 object OpenAPIFile {
   case class Components(responses: Map[String, Response] = Map.empty)
 
-  case class Info(title: String, version: String, description: Option[String])
+  case class Info(title: String, version: String, description: String) extends JsonEncodable.Partial {
+
+    override def jsonOptionEntryIterator: IterableOnce[(String, Option[Json])] = Seq(
+      "title"       -> Some(title.asJson),
+      "version"     -> Option.when(version.nonEmpty)(version.asJson),
+      "description" -> Option.when(description.nonEmpty)(description.asJson),
+    )
+  }
 }

--- a/src/main/scala/temple/generate/target/openapi/OpenAPIType.scala
+++ b/src/main/scala/temple/generate/target/openapi/OpenAPIType.scala
@@ -15,6 +15,12 @@ private[openapi] object OpenAPIType {
   sealed case class OpenAPISimpleType(override val typeString: String, customFields: (String, Json)*)
       extends OpenAPIType(typeString, customFields)
 
+  object OpenAPISimpleType {
+
+    def apply(typeString: String, format: String, customFields: (String, Json)*): OpenAPISimpleType =
+      new OpenAPISimpleType(typeString, ("format" -> format.asJson) +: customFields: _*)
+  }
+
   case class OpenAPIObject(properties: Map[String, OpenAPIType], customFields: (String, Json)*)
       extends OpenAPIType("object", ("properties", properties.asJson) +: customFields)
 

--- a/src/main/scala/temple/generate/target/openapi/Service.scala
+++ b/src/main/scala/temple/generate/target/openapi/Service.scala
@@ -1,0 +1,20 @@
+package temple.generate.target.openapi
+
+import temple.DSL.semantics.Attribute
+import temple.generate.Endpoint
+
+case class Service(
+  name: String,
+  endpoints: Set[Endpoint],
+  attributes: Map[String, Attribute],
+  structs: Map[String, Service.Struct] = Map.empty,
+)
+
+object Service {
+
+  case class Struct(
+    name: String,
+    endpoints: Set[Endpoint],
+    attributes: Map[String, Attribute],
+  )
+}


### PR DESCRIPTION
The PR for OpenAPI generation (#117) was looking too monstrous, so this should ease the pain slightly.

- `Info` now has a custom renderer, so description and version are omitted if empty
- `OpenAPISimpleType` has an optional argument `format` as it was being used so often
- A `Service` datatype was created, which will form the input of the OpenAPI generator