### PR TITLE
[OpenAPI-gen] Add parent trait for JsonEncodable, so non-objects can be encoded

### DIFF
--- a/src/main/scala/temple/generate/JsonEncodable.scala
+++ b/src/main/scala/temple/generate/JsonEncodable.scala
@@ -2,26 +2,35 @@ package temple.generate
 
 import io.circe.{Encoder, Json}
 
+/** Any class that can be encoded to JSON, at least partially using custom functions
+  *
+  * This trait should be implemented by any root traits, [[temple.generate.JsonEncodable.Object]] and
+  * [[temple.generate.JsonEncodable.Partial]] should be implemented by any concrete implementations.
+  */
 private[generate] trait JsonEncodable {
-
-  /** Turn a case class into some key-value pairs in preparation for conversion to a JSON object */
-  def jsonEntryIterator: IterableOnce[(String, Json)]
+  protected def toJson: Json
 
   // Required so that nested JsonEncodable interfaces always call the correct nested version
-  implicit final protected def encodeToJson[T <: JsonEncodable]: Encoder[T] = JsonEncodable.encodeToJson
+  implicit final protected def jsonEncoder[T <: JsonEncodable]: Encoder[T] = a => a.toJson
 }
 
 private[generate] object JsonEncodable {
 
-  /** Create an encoder for JSON objects by providing a function to map them to key-value pairs */
-  private def mapSequenceEncoder[T](toJsonMap: T => IterableOnce[(String, Json)]): Encoder[T] = (obj: T) => {
-    Json.obj(toJsonMap(obj).iterator.toSeq: _*)
+  implicit def encodeToJson[T <: JsonEncodable]: Encoder[T] = _.toJson
+
+  /** Implement JsonEncodable by providing a map/key-value-sequence to go in the Json map */
+  trait Object extends JsonEncodable {
+
+    /** Turn a case class into some key-value pairs in preparation for conversion to a JSON object */
+    def jsonEntryIterator: IterableOnce[(String, Json)]
+
+    // Required so that nested JsonEncodable interfaces always call the correct nested version
+    implicit final protected def toJson: Json = Json.obj(jsonEntryIterator.iterator.toSeq: _*)
   }
 
-  implicit def encodeToJson[T <: JsonEncodable]: Encoder[T] = mapSequenceEncoder(_.jsonEntryIterator)
-
-  /** Like [[temple.generate.JsonEncodable]] but by providing optional values, causing the entries not to render */
-  trait Partial extends JsonEncodable {
+  /** Like [[temple.generate.JsonEncodable.Object]] but by providing optional values, causing the entries not to render
+    * if None is given */
+  trait Partial extends Object {
     def jsonOptionEntryIterator: IterableOnce[(String, Option[Json])]
 
     final override def jsonEntryIterator: IterableOnce[(String, Json)] =

--- a/src/main/scala/temple/generate/kube/ast/gen/Spec.scala
+++ b/src/main/scala/temple/generate/kube/ast/gen/Spec.scala
@@ -29,7 +29,7 @@ object Spec {
 
   case class ServicePort(name: String, port: Int, targetPort: Int)
 
-  case class Secret(name: String) extends JsonEncodable {
+  case class Secret(name: String) extends JsonEncodable.Object {
 
     /** Turn a case class into some key-value pairs in preparation for conversion to a JSON object */
     override def jsonEntryIterator: IterableOnce[(String, Json)] = Seq("name" -> name.asJson)

--- a/src/main/scala/temple/generate/target/openapi/MediaTypeObject.scala
+++ b/src/main/scala/temple/generate/target/openapi/MediaTypeObject.scala
@@ -5,7 +5,7 @@ import io.circe.syntax._
 import temple.generate.JsonEncodable
 
 // https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#mediaTypeObject
-private[openapi] case class MediaTypeObject(schema: OpenAPIType, customFields: (String, Json)*) extends JsonEncodable {
-
+final private[openapi] case class MediaTypeObject(schema: OpenAPIType, customFields: (String, Json)*)
+    extends JsonEncodable.Object {
   override def jsonEntryIterator: Seq[(String, Json)] = ("schema" -> schema.asJson) +: customFields
 }

--- a/src/main/scala/temple/generate/target/openapi/MediaTypeObject.scala
+++ b/src/main/scala/temple/generate/target/openapi/MediaTypeObject.scala
@@ -5,7 +5,7 @@ import io.circe.syntax._
 import temple.generate.JsonEncodable
 
 // https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#mediaTypeObject
-final private[openapi] case class MediaTypeObject(schema: OpenAPIType, customFields: (String, Json)*)
+private[openapi] case class MediaTypeObject(schema: OpenAPIType, customFields: (String, Json)*)
     extends JsonEncodable.Object {
   override def jsonEntryIterator: Seq[(String, Json)] = ("schema" -> schema.asJson) +: customFields
 }

--- a/src/main/scala/temple/generate/target/openapi/OpenAPIFile.scala
+++ b/src/main/scala/temple/generate/target/openapi/OpenAPIFile.scala
@@ -11,7 +11,7 @@ case class OpenAPIFile(
   info: Info,
   paths: Map[String, Map[HTTPVerb, Path]] = Map.empty,
   components: Components = Components(),
-) extends JsonEncodable {
+) extends JsonEncodable.Object {
 
   override def jsonEntryIterator: IterableOnce[(String, Json)] = Seq(
     "openapi"    -> "3.0.0".asJson,

--- a/src/main/scala/temple/generate/target/openapi/OpenAPIType.scala
+++ b/src/main/scala/temple/generate/target/openapi/OpenAPIType.scala
@@ -5,7 +5,7 @@ import io.circe.syntax._
 import temple.generate.JsonEncodable
 
 sealed abstract private[openapi] class OpenAPIType(val typeString: String, customFields: Seq[(String, Json)])
-    extends JsonEncodable {
+    extends JsonEncodable.Object {
 
   override def jsonEntryIterator: Seq[(String, Json)] = ("type" -> typeString.asJson) +: customFields
 }

--- a/src/main/scala/temple/generate/target/openapi/RequestBody.scala
+++ b/src/main/scala/temple/generate/target/openapi/RequestBody.scala
@@ -8,7 +8,7 @@ private[openapi] trait RequestBody extends JsonEncodable
 
 private[openapi] object RequestBody {
 
-  private[openapi] case class Ref(name: String) extends RequestBody {
+  private[openapi] case class Ref(name: String) extends RequestBody with JsonEncodable.Object {
     override def jsonEntryIterator: Seq[(String, Json)] = Seq("$ref" -> s"#/components/requestBody/$name".asJson)
   }
 }

--- a/src/main/scala/temple/generate/target/openapi/Response.scala
+++ b/src/main/scala/temple/generate/target/openapi/Response.scala
@@ -8,7 +8,7 @@ private[openapi] trait Response extends JsonEncodable
 
 private[openapi] object Response {
 
-  private[openapi] case class Ref(name: String) extends Response {
+  private[openapi] case class Ref(name: String) extends Response with JsonEncodable.Object {
     override def jsonEntryIterator: Seq[(String, Json)] = Seq("$ref" -> s"#/components/responses/$name".asJson)
   }
 }


### PR DESCRIPTION
Small change to JsonEncodable, so that JsonEncodable can be used for non-objects (strings, arrays etc). This is so we can encode case objects as strings by extending `JsonEncodable` directly, defining `toJson`.