### PR TITLE
Json encodable arrows

### DIFF
--- a/src/main/scala/temple/generate/JsonEncodable.scala
+++ b/src/main/scala/temple/generate/JsonEncodable.scala
@@ -1,5 +1,6 @@
 package temple.generate
 
+import io.circe.syntax._
 import io.circe.{Encoder, Json}
 
 /** Any class that can be encoded to JSON, at least partially using custom functions
@@ -26,6 +27,10 @@ private[generate] object JsonEncodable {
 
     // Required so that nested JsonEncodable interfaces always call the correct nested version
     implicit final protected def toJson: Json = Json.obj(jsonEntryIterator.iterator.toSeq: _*)
+
+    implicit final protected class JsonArrow(key: String) {
+      def ~>[T](x: T)(implicit encoder: Encoder[T]): (String, Json) = key -> x.asJson
+    }
   }
 
   /** Like [[temple.generate.JsonEncodable.Object]] but by providing optional values, causing the entries not to render
@@ -35,5 +40,9 @@ private[generate] object JsonEncodable {
 
     final override def jsonEntryIterator: IterableOnce[(String, Json)] =
       jsonOptionEntryIterator.iterator.collect { case (str, Some(json)) => (str, json) }
+
+    implicit final protected class JsonOptionArrow(key: String) {
+      def ~~>[T](x: Option[T])(implicit encoder: Encoder[T]): (String, Option[Json]) = key -> x.map(_.asJson)
+    }
   }
 }

--- a/src/main/scala/temple/generate/kube/ast/gen/KubeType.scala
+++ b/src/main/scala/temple/generate/kube/ast/gen/KubeType.scala
@@ -1,9 +1,10 @@
 package temple.generate.kube.ast.gen
 
 import io.circe.Json
-import io.circe.syntax._
 import temple.generate.JsonEncodable
 import temple.generate.kube.GenType
+
+import scala.Option.when
 
 private[kube] object KubeType {
 
@@ -22,11 +23,9 @@ private[kube] object KubeType {
       * The `type` label should only be set on PersistentVolume objects */
     override def jsonOptionEntryIterator: IterableOnce[(String, Option[Json])] =
       Seq(
-        "app"  -> Some(name.asJson),
-        "type" -> Option.when(genType == GenType.StorageMount)("local".asJson),
-        "kind" -> Option.when(genType == GenType.Deployment || genType == GenType.Service)(
-          if (isDb) "db".asJson else "service".asJson,
-        ),
+        "app" ~~> Some(name),
+        "type" ~~> when(genType == GenType.StorageMount)("local"),
+        "kind" ~~> when(genType == GenType.Deployment || genType == GenType.Service) { if (isDb) "db" else "service" },
       )
   }
 }

--- a/src/main/scala/temple/generate/kube/ast/gen/Spec.scala
+++ b/src/main/scala/temple/generate/kube/ast/gen/Spec.scala
@@ -1,7 +1,6 @@
 package temple.generate.kube.ast.gen
 
 import io.circe.Json
-import io.circe.syntax._
 import temple.generate.JsonEncodable
 import temple.generate.kube.ast.gen.KubeType.{Labels, Metadata}
 
@@ -32,6 +31,6 @@ object Spec {
   case class Secret(name: String) extends JsonEncodable.Object {
 
     /** Turn a case class into some key-value pairs in preparation for conversion to a JSON object */
-    override def jsonEntryIterator: IterableOnce[(String, Json)] = Seq("name" -> name.asJson)
+    override def jsonEntryIterator: IterableOnce[(String, Json)] = Seq("name" ~> name)
   }
 }

--- a/src/main/scala/temple/generate/target/openapi/Literal.scala
+++ b/src/main/scala/temple/generate/target/openapi/Literal.scala
@@ -1,7 +1,6 @@
 package temple.generate.target.openapi
 
 import io.circe.Json
-import io.circe.syntax._
 import temple.generate.JsonEncodable
 
 /** https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#requestBodyObject */
@@ -14,8 +13,8 @@ case class Literal(
     with Response {
 
   override def jsonOptionEntryIterator: IterableOnce[(String, Option[Json])] = Seq(
-    "description" -> Option.when(description.nonEmpty)(description.asJson),
-    "required"    -> required.map(_.asJson),
-    "content"     -> Some(content.asJson),
+    "description" ~~> Option.when(description.nonEmpty)(description),
+    "required" ~~> required,
+    "content" ~~> Some(content),
   )
 }

--- a/src/main/scala/temple/generate/target/openapi/MediaTypeObject.scala
+++ b/src/main/scala/temple/generate/target/openapi/MediaTypeObject.scala
@@ -1,11 +1,10 @@
 package temple.generate.target.openapi
 
 import io.circe.Json
-import io.circe.syntax._
 import temple.generate.JsonEncodable
 
 // https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#mediaTypeObject
 final private[openapi] case class MediaTypeObject(schema: OpenAPIType, customFields: (String, Json)*)
     extends JsonEncodable.Object {
-  override def jsonEntryIterator: Seq[(String, Json)] = ("schema" -> schema.asJson) +: customFields
+  override def jsonEntryIterator: Seq[(String, Json)] = ("schema" ~> schema) +: customFields
 }

--- a/src/main/scala/temple/generate/target/openapi/OpenAPIFile.scala
+++ b/src/main/scala/temple/generate/target/openapi/OpenAPIFile.scala
@@ -2,7 +2,6 @@ package temple.generate.target.openapi
 
 import io.circe.Json
 import io.circe.generic.auto._
-import io.circe.syntax._
 import temple.generate.JsonEncodable
 import temple.generate.target.openapi.HTTPVerb.httpVerbKeyEncoder
 import temple.generate.target.openapi.OpenAPIFile._
@@ -14,10 +13,10 @@ case class OpenAPIFile(
 ) extends JsonEncodable.Object {
 
   override def jsonEntryIterator: IterableOnce[(String, Json)] = Seq(
-    "openapi"    -> "3.0.0".asJson,
-    "info"       -> info.asJson,
-    "paths"      -> paths.asJson,
-    "components" -> components.asJson,
+    "openapi" ~> "3.0.0",
+    "info" ~> info,
+    "paths" ~> paths,
+    "components" ~> components,
   )
 }
 

--- a/src/main/scala/temple/generate/target/openapi/OpenAPIType.scala
+++ b/src/main/scala/temple/generate/target/openapi/OpenAPIType.scala
@@ -7,7 +7,7 @@ import temple.generate.JsonEncodable
 sealed abstract private[openapi] class OpenAPIType(val typeString: String, customFields: Seq[(String, Json)])
     extends JsonEncodable.Object {
 
-  override def jsonEntryIterator: Seq[(String, Json)] = ("type" -> typeString.asJson) +: customFields
+  override def jsonEntryIterator: Seq[(String, Json)] = ("type" ~> typeString) +: customFields
 }
 
 private[openapi] object OpenAPIType {
@@ -16,8 +16,8 @@ private[openapi] object OpenAPIType {
       extends OpenAPIType(typeString, customFields)
 
   case class OpenAPIObject(properties: Map[String, OpenAPIType], customFields: (String, Json)*)
-      extends OpenAPIType("object", ("properties", properties.asJson) +: customFields)
+      extends OpenAPIType("object", ("properties" -> properties.asJson) +: customFields)
 
   case class OpenAPIArray(items: OpenAPIType, customFields: (String, Json)*)
-      extends OpenAPIType("array", ("items", items.asJson) +: customFields)
+      extends OpenAPIType("array", ("items" -> items.asJson) +: customFields)
 }

--- a/src/main/scala/temple/generate/target/openapi/RequestBody.scala
+++ b/src/main/scala/temple/generate/target/openapi/RequestBody.scala
@@ -1,7 +1,6 @@
 package temple.generate.target.openapi
 
 import io.circe.Json
-import io.circe.syntax._
 import temple.generate.JsonEncodable
 
 private[openapi] trait RequestBody extends JsonEncodable
@@ -9,6 +8,6 @@ private[openapi] trait RequestBody extends JsonEncodable
 private[openapi] object RequestBody {
 
   private[openapi] case class Ref(name: String) extends RequestBody with JsonEncodable.Object {
-    override def jsonEntryIterator: Seq[(String, Json)] = Seq("$ref" -> s"#/components/requestBody/$name".asJson)
+    override def jsonEntryIterator: Seq[(String, Json)] = Seq("$ref" ~> s"#/components/requestBody/$name")
   }
 }

--- a/src/main/scala/temple/generate/target/openapi/Response.scala
+++ b/src/main/scala/temple/generate/target/openapi/Response.scala
@@ -1,7 +1,6 @@
 package temple.generate.target.openapi
 
 import io.circe.Json
-import io.circe.syntax._
 import temple.generate.JsonEncodable
 
 private[openapi] trait Response extends JsonEncodable
@@ -9,6 +8,6 @@ private[openapi] trait Response extends JsonEncodable
 private[openapi] object Response {
 
   private[openapi] case class Ref(name: String) extends Response with JsonEncodable.Object {
-    override def jsonEntryIterator: Seq[(String, Json)] = Seq("$ref" -> s"#/components/responses/$name".asJson)
+    override def jsonEntryIterator: Seq[(String, Json)] = Seq("$ref" ~> s"#/components/responses/$name")
   }
 }


### PR DESCRIPTION
Depends on #120, but reduces all the needless .asJson in `jsonEntryIterator` and `jsonOptionEntryIterator`, by providing a custom arrow `~>`/`~~>` that inserts `.asJson`/`.map(_.asJson)`. Note that because asJson takes an implicit argument of the encoder, the arrow itself must be replaced instead, instead of dealing with the subsequently produced sequence of heterogeneously typed tuples.