### PR TITLE
[K8s-Gen] Generate Database Deployment Scripts

### DIFF
--- a/src/main/scala/temple/generate/kube/KubernetesGenerator.scala
+++ b/src/main/scala/temple/generate/kube/KubernetesGenerator.scala
@@ -107,7 +107,7 @@ object KubernetesGenerator {
     val container = Container(
       service.image,
       service.name,
-      service.ports.map(x => ContainerPort(x._2)),
+      service.ports.map { case (_, port) => ContainerPort(port) },
       env = Seq(),
       volumeMounts = Seq(),
     )

--- a/src/main/scala/temple/generate/kube/KubernetesGenerator.scala
+++ b/src/main/scala/temple/generate/kube/KubernetesGenerator.scala
@@ -52,10 +52,10 @@ object KubernetesGenerator {
       ports = Seq(),
       env = service.envVars.map(x => EnvVar(x._1, x._2)),
       volumeMounts = Seq(
-        VolumeMount("/var/lib/postgresql/data", None, name + "-claim"),
-        VolumeMount("/docker-entrypoint-initdb.d/init.sql", Some("init.sql"), name + "-init"),
+        VolumeMount(service.dbStorage.dataMount, None, name + "-claim"),
+        VolumeMount(service.dbStorage.initMount, Some(service.dbStorage.initFile), name + "-init"),
       ),
-      lifecycle = Some(Lifecycle("echo done")),
+      lifecycle = Some(Lifecycle(service.dbLifecycleCommand)),
     )
 
     val podSpec = PodSpec(

--- a/src/main/scala/temple/generate/kube/KubernetesGenerator.scala
+++ b/src/main/scala/temple/generate/kube/KubernetesGenerator.scala
@@ -7,6 +7,7 @@ import temple.generate.FileSystem._
 import temple.generate.kube.ast.OrchestrationType._
 import temple.generate.kube.ast.gen.KubeType._
 import temple.generate.kube.ast.gen.Spec._
+import temple.generate.kube.ast.gen.{PlacementStrategy, RestartPolicy}
 import temple.generate.utils.CodeTerm.mkCode
 
 /** Generates the Kubernetes config files for each microservice */
@@ -63,7 +64,7 @@ object KubernetesGenerator {
         dbContainer,
       ),
       imagePullSecrets = Seq(),
-      restartPolicy = "Always",
+      restartPolicy = RestartPolicy.Always,
       volumes = Seq(
         Volume(name + "-init", ConfigMap(name + "-config")),
         Volume(name + "-claim", PersistentVolume(name + "-claim")),
@@ -74,7 +75,7 @@ object KubernetesGenerator {
       DeploymentSpec(
         1,
         Selector(Labels(service.name, GenType.Deployment, isDb = true)),
-        strategy = Some(Strategy("Recreate")),
+        strategy = Some(Strategy(PlacementStrategy.Recreate)),
         Template(
           Metadata(name, Labels(service.name, GenType.Deployment, isDb = true)),
           podSpec,
@@ -117,7 +118,7 @@ object KubernetesGenerator {
         container,
       ),
       Seq(Secret(service.secretName)),
-      restartPolicy = "Always",
+      restartPolicy = RestartPolicy.Always,
       volumes = Seq(),
     )
 

--- a/src/main/scala/temple/generate/kube/ast/OrchestrationType.scala
+++ b/src/main/scala/temple/generate/kube/ast/OrchestrationType.scala
@@ -1,5 +1,7 @@
 package temple.generate.kube.ast
 
+import temple.generate.kube.ast.gen.LifecycleCommand.LifecycleCommand
+
 object OrchestrationType {
 
   /** Input information to generate kubernetes scripts */
@@ -14,6 +16,8 @@ object OrchestrationType {
     * @param replicas The number of replicas of the pod that should be exposed
     * @param secretName The name of the Kubernetes secret used to fetch images from the registry
     * @param envVars A sequence of key -> value to set as environment variables in the container
+    * @param dbStorage Object that defines how the service db should store data
+    * @param dbLifecycleCommand The command to be ran in the database container on startup e.g to init the db
     */
   case class Service(
     name: String,
@@ -23,6 +27,16 @@ object OrchestrationType {
     replicas: Int,
     secretName: String,
     envVars: Seq[(String, String)],
+    dbStorage: DbStorage,
+    dbLifecycleCommand: LifecycleCommand,
   )
+
+  /**
+    * Encapsulates how the db stores data
+    * @param dataMount the file system location for the db container to store data at
+    * @param initMount Where to mount the db init script (i.e schema) to
+    * @param initFile The filename of the db init script
+    */
+  case class DbStorage(dataMount: String, initMount: String, initFile: String)
 
 }

--- a/src/main/scala/temple/generate/kube/ast/OrchestrationType.scala
+++ b/src/main/scala/temple/generate/kube/ast/OrchestrationType.scala
@@ -9,10 +9,20 @@ object OrchestrationType {
     * Describes one microservice deployment in Kubernetes
     * @param name Service Name
     * @param image The name *including registry* of the docker image for this service
+    * @param dbImage The name of the docker image to use for the service's datastore
     * @param ports The ports the Pod should expose, including the names of the ports (i.e www -> 80)
     * @param replicas The number of replicas of the pod that should be exposed
-    * @param secretName The name of the Kubernetes secret used to fetch images from the registr
+    * @param secretName The name of the Kubernetes secret used to fetch images from the registry
+    * @param envVars A sequence of key -> value to set as environment variables in the container
     */
-  case class Service(name: String, image: String, ports: Seq[(String, Int)], replicas: Int, secretName: String)
+  case class Service(
+    name: String,
+    image: String,
+    dbImage: String,
+    ports: Seq[(String, Int)],
+    replicas: Int,
+    secretName: String,
+    envVars: Seq[(String, String)],
+  )
 
 }

--- a/src/main/scala/temple/generate/kube/ast/gen/KubeType.scala
+++ b/src/main/scala/temple/generate/kube/ast/gen/KubeType.scala
@@ -14,7 +14,9 @@ private[kube] object KubeType {
   case class Body[T <: Spec](spec: T)
 
   /** A Kubernetes yaml file metadata block */
-  case class Metadata(name: String, labels: Labels)
+  case class Metadata(name: String, labels: Labels) extends JsonEncodable.Object {
+    override def jsonEntryIterator: IterableOnce[(String, Json)] = Seq("name" ~> name, "labels" ~> labels)
+  }
 
   /** A Kubernetes yaml file labels block */
   case class Labels(name: String, genType: GenType, isDb: Boolean) extends JsonEncodable.Partial {

--- a/src/main/scala/temple/generate/kube/ast/gen/LifecycleCommand.scala
+++ b/src/main/scala/temple/generate/kube/ast/gen/LifecycleCommand.scala
@@ -1,0 +1,7 @@
+package temple.generate.kube.ast.gen
+
+object LifecycleCommand {
+  type LifecycleCommand = String
+  val echoDone: LifecycleCommand  = "echo done"
+  val psqlSetup: LifecycleCommand = "psql -U postgres -f /docker-entrypoint-initdb.d/init.sql && echo done"
+}

--- a/src/main/scala/temple/generate/kube/ast/gen/PlacementStrategy.scala
+++ b/src/main/scala/temple/generate/kube/ast/gen/PlacementStrategy.scala
@@ -1,0 +1,6 @@
+package temple.generate.kube.ast.gen
+
+object PlacementStrategy {
+  type Strategy = String
+  val Recreate: Strategy = "Recreate"
+}

--- a/src/main/scala/temple/generate/kube/ast/gen/RestartPolicy.scala
+++ b/src/main/scala/temple/generate/kube/ast/gen/RestartPolicy.scala
@@ -1,0 +1,6 @@
+package temple.generate.kube.ast.gen
+
+object RestartPolicy {
+  type RestartPolicy = String
+  val Always: RestartPolicy = "Always"
+}

--- a/src/main/scala/temple/generate/kube/ast/gen/Spec.scala
+++ b/src/main/scala/temple/generate/kube/ast/gen/Spec.scala
@@ -4,33 +4,148 @@ import io.circe.Json
 import temple.generate.JsonEncodable
 import temple.generate.kube.ast.gen.KubeType.{Labels, Metadata}
 
-sealed trait Spec
+import scala.Option.when
+
+sealed trait Spec extends JsonEncodable.Partial
 
 object Spec {
-  case class DeploymentSpec(replicas: Int, selector: Selector, template: Template) extends Spec
 
-  case class ServiceSpec(ports: Seq[ServicePort], selector: Labels) extends Spec
+  case class DeploymentSpec(replicas: Int, selector: Selector, strategy: Option[Strategy], template: Template)
+      extends Spec {
 
-  case class Selector(matchLabels: Labels)
+    /** Turn a case class into some key-value pairs in preparation for conversion to a JSON object */
+    override def jsonOptionEntryIterator: IterableOnce[(String, Option[Json])] =
+      Seq(
+        "replicas" ~~> Some(replicas),
+        "selector" ~~> Some(selector),
+        "strategy" ~~> strategy,
+        "template" ~~> Some(template),
+      )
+  }
 
-  case class Template(metadata: Metadata, spec: PodSpec)
+  case class ServiceSpec(ports: Seq[ServicePort], selector: Labels) extends Spec {
+
+    override def jsonOptionEntryIterator: IterableOnce[(String, Option[Json])] = Seq(
+      "ports" ~~> when(ports.nonEmpty)(ports),
+      "selector" ~~> Some(selector),
+    )
+  }
+
+  case class Selector(matchLabels: Labels) extends JsonEncodable.Object {
+    override def jsonEntryIterator: IterableOnce[(String, Json)] = Seq("matchLabels" ~> matchLabels)
+  }
+
+  case class Template(metadata: Metadata, spec: PodSpec) extends JsonEncodable.Object {
+
+    override def jsonEntryIterator: IterableOnce[(String, Json)] = Seq(
+      "metadata" ~> metadata,
+      "spec" ~> spec,
+    )
+  }
+
+  case class Strategy(strategy: String) extends JsonEncodable.Object {
+
+    override def jsonEntryIterator: IterableOnce[(String, Json)] = Seq("type" ~> strategy)
+  }
 
   case class PodSpec(
     hostname: String,
     containers: Seq[Container],
     imagePullSecrets: Seq[Secret],
     restartPolicy: String,
-  ) extends Spec
+    volumes: Seq[Volume],
+  ) extends Spec {
 
-  case class Container(image: String, name: String, ports: Seq[ContainerPort])
+    override def jsonOptionEntryIterator: IterableOnce[(String, Option[Json])] =
+      Seq(
+        "hostname" ~~> Some(hostname),
+        "containers" ~~> when(containers.nonEmpty)(containers),
+        "imagePullSecrets" ~~> when(imagePullSecrets.nonEmpty)(imagePullSecrets),
+        "restartPolicy" ~~> Some(restartPolicy),
+        "volumes" ~~> when(volumes.nonEmpty)(volumes),
+      )
+  }
 
-  case class ContainerPort(containerPort: Int)
+  case class Volume(name: String, storage: Storage) extends JsonEncodable.Object {
 
-  case class ServicePort(name: String, port: Int, targetPort: Int)
+    override def jsonEntryIterator: IterableOnce[(String, Json)] =
+      Seq("name" ~> name) ++ storage.jsonEntryIterator
+  }
+
+  sealed trait Storage extends JsonEncodable.Object
+
+  case class ConfigMap(name: String) extends Storage {
+
+    override def jsonEntryIterator: IterableOnce[(String, Json)] = Seq("configMap" ~> Map("name" -> name))
+  }
+
+  case class PersistentVolume(name: String) extends Storage {
+
+    override def jsonEntryIterator: IterableOnce[(String, Json)] =
+      Seq("persistentVolumeClaim" ~> Map("claimName" -> name))
+  }
+
+  case class Container(
+    image: String,
+    name: String,
+    ports: Seq[ContainerPort],
+    env: Seq[EnvVar],
+    volumeMounts: Seq[VolumeMount],
+    lifecycle: Option[Lifecycle] = None,
+  ) extends JsonEncodable.Partial {
+
+    override def jsonOptionEntryIterator: IterableOnce[(String, Option[Json])] =
+      Seq(
+        "env" ~~> when(env.nonEmpty)(env),
+        "image" ~~> Some(image),
+        "name" ~~> Some(name),
+        "ports" ~~> when(ports.nonEmpty)(ports),
+        "volumeMounts" ~~> when(volumeMounts.nonEmpty)(volumeMounts),
+        "lifecycle" ~~> lifecycle,
+      )
+  }
+
+  case class Lifecycle(command: String) extends JsonEncodable.Object {
+
+    override def jsonEntryIterator: IterableOnce[(String, Json)] =
+      Seq(
+        "postStart" ~>
+        Map(
+          "exec" ->
+          Map("command" -> Seq("/bin/sh", "-c", command)),
+        ),
+      )
+  }
+
+  case class ContainerPort(containerPort: Int) extends JsonEncodable.Object {
+
+    override def jsonEntryIterator: IterableOnce[(String, Json)] = Seq("containerPort" ~> containerPort)
+  }
+
+  case class EnvVar(name: String, value: String) extends JsonEncodable.Object {
+
+    override def jsonEntryIterator: IterableOnce[(String, Json)] =
+      Seq("name" ~> name, "value" ~> value)
+  }
+
+  case class ServicePort(name: String, port: Int, targetPort: Int) extends JsonEncodable.Object {
+
+    override def jsonEntryIterator: IterableOnce[(String, Json)] =
+      Seq(
+        "name" ~> name,
+        "port" ~> port,
+        "targetPort" ~> targetPort,
+      )
+  }
+
+  case class VolumeMount(mountPath: String, subPath: Option[String], name: String) extends JsonEncodable.Partial {
+
+    override def jsonOptionEntryIterator: IterableOnce[(String, Option[Json])] =
+      Seq("mountPath" ~~> Some(mountPath), "subPath" ~~> subPath, "name" ~~> Some(name))
+  }
 
   case class Secret(name: String) extends JsonEncodable.Object {
 
-    /** Turn a case class into some key-value pairs in preparation for conversion to a JSON object */
     override def jsonEntryIterator: IterableOnce[(String, Json)] = Seq("name" ~> name)
   }
 }

--- a/src/main/scala/temple/generate/kube/ast/gen/Spec.scala
+++ b/src/main/scala/temple/generate/kube/ast/gen/Spec.scala
@@ -32,6 +32,7 @@ object Spec {
   }
 
   case class Selector(matchLabels: Labels) extends JsonEncodable.Object {
+
     override def jsonEntryIterator: IterableOnce[(String, Json)] = Seq("matchLabels" ~> matchLabels)
   }
 

--- a/src/test/resources/kube/user-db-deployment.yaml
+++ b/src/test/resources/kube/user-db-deployment.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: user-db
+  labels:
+    app: user
+    kind: db
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: user
+      kind: db
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      name: user-db
+      labels:
+        app: user
+        kind: db
+    spec:
+      hostname: user-db
+      containers:
+      - env:
+        - name: PGUSER
+          value: postgres
+        image: postgres:12.1
+        name: user-db
+        volumeMounts:
+        - mountPath: /var/lib/postgresql/data
+          name: user-db-claim
+        - mountPath: /docker-entrypoint-initdb.d/init.sql
+          subPath: init.sql
+          name: user-db-init
+        lifecycle:
+          postStart:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - echo done
+      restartPolicy: Always
+      volumes:
+      - name: user-db-init
+        configMap:
+          name: user-db-config
+      - name: user-db-claim
+        persistentVolumeClaim:
+          claimName: user-db-claim

--- a/src/test/scala/temple/generate/kube/KubernetesGeneratorTest.scala
+++ b/src/test/scala/temple/generate/kube/KubernetesGeneratorTest.scala
@@ -57,4 +57,11 @@ class KubernetesGeneratorTest extends FlatSpec with Matchers {
     output(file) should be(UnitTestData.userService)
   }
 
+  it should "generate correct database deployments" in {
+    val output = KubernetesGenerator.generate(UnitTestData.basicOrchestrationRoot)
+    val file   = File("kube/user", "db-deployment.yaml")
+    output.keys should contain(file)
+    output(file) should be(UnitTestData.userDbDeployment)
+  }
+
 }

--- a/src/test/scala/temple/generate/kube/UnitTestData.scala
+++ b/src/test/scala/temple/generate/kube/UnitTestData.scala
@@ -10,9 +10,11 @@ object UnitTestData {
       Service(
         name = "user",
         image = "temple-user-service",
+        dbImage = "postgres:12.1",
         ports = Seq("api" -> 80),
         replicas = 1,
         secretName = "regcred",
+        envVars = Seq("PGUSER" -> "postgres"),
       ),
     ),
   )
@@ -39,7 +41,8 @@ object UnitTestData {
       |metadata:
       |  name: user-db
       |  labels:
-      |    app: user-db""".stripMargin
+      |    app: user
+      |    kind: db""".stripMargin
 
   val userDbServiceHeader: String =
     """apiVersion: v1
@@ -47,7 +50,8 @@ object UnitTestData {
       |metadata:
       |  name: user-db
       |  labels:
-      |    app: user-db""".stripMargin
+      |    app: user
+      |    kind: db""".stripMargin
 
   val userDbStorageVolumeHeader: String =
     """apiVersion: v1
@@ -55,7 +59,7 @@ object UnitTestData {
       |metadata:
       |  name: user-db
       |  labels:
-      |    app: user-db
+      |    app: user
       |    type: local""".stripMargin
 
   val userDbStorageClaimHeader: String =
@@ -64,9 +68,11 @@ object UnitTestData {
       |metadata:
       |  name: user-db
       |  labels:
-      |    app: user-db""".stripMargin
+      |    app: user""".stripMargin
 
   val userDeployment: String = FileUtils.readResources("kube/user-deployment.yaml")
 
   val userService: String = FileUtils.readResources("kube/user-service.yaml")
+
+  val userDbDeployment: String = FileUtils.readResources("kube/user-db-deployment.yaml")
 }

--- a/src/test/scala/temple/generate/kube/UnitTestData.scala
+++ b/src/test/scala/temple/generate/kube/UnitTestData.scala
@@ -1,6 +1,7 @@
 package temple.generate.kube
 
 import temple.generate.kube.ast.OrchestrationType._
+import temple.generate.kube.ast.gen.LifecycleCommand
 import temple.utils.FileUtils
 
 object UnitTestData {
@@ -15,6 +16,12 @@ object UnitTestData {
         replicas = 1,
         secretName = "regcred",
         envVars = Seq("PGUSER" -> "postgres"),
+        dbStorage = DbStorage(
+          dataMount = "/var/lib/postgresql/data",
+          initMount = "/docker-entrypoint-initdb.d/init.sql",
+          initFile = "init.sql",
+        ),
+        dbLifecycleCommand = LifecycleCommand.echoDone,
       ),
     ),
   )


### PR DESCRIPTION
This refactors the existing Deployment generation code to also allow for database deployments to be built, which should also mean generalisation to more complicated deployments in the future should be achievable. 

Also implements the DB deployment generation as per the sample kube service