### PR TITLE
[go-gen] Setup auth generation and generate auth imports

### DIFF
--- a/src/main/scala/temple/generate/service/AuthServiceGenerator.scala
+++ b/src/main/scala/temple/generate/service/AuthServiceGenerator.scala
@@ -1,0 +1,10 @@
+package temple.generate.service
+
+import temple.generate.FileSystem._
+
+/** AuthServiceGenerator provides an interface for generating Auth service boilerplate from an ADT */
+trait AuthServiceGenerator {
+
+  /** Given an AuthServiceRoot ADT, generate the Auth service boilerplate in a specific language */
+  def generate(authServiceRoot: AuthServiceRoot): Map[File, FileContent]
+}

--- a/src/main/scala/temple/generate/service/AuthServiceRoot.scala
+++ b/src/main/scala/temple/generate/service/AuthServiceRoot.scala
@@ -1,0 +1,3 @@
+package temple.generate.service
+
+case class AuthServiceRoot(module: String, port: Int)

--- a/src/main/scala/temple/generate/service/go/GoCommonGenerator.scala
+++ b/src/main/scala/temple/generate/service/go/GoCommonGenerator.scala
@@ -1,0 +1,10 @@
+package temple.generate.service.go
+
+import temple.generate.utils.CodeTerm.{mkCode}
+
+object GoCommonGenerator {
+
+  private[go] def generateMod(module: String): String = mkCode.doubleLines(s"module $module", "go 1.13")
+
+  private[go] def generatePackage(packageName: String): String = s"package $packageName"
+}

--- a/src/main/scala/temple/generate/service/go/GoServiceGenerator.scala
+++ b/src/main/scala/temple/generate/service/go/GoServiceGenerator.scala
@@ -9,10 +9,6 @@ import scala.Option.when
 /** Implementation of [[ServiceGenerator]] for generating Go */
 object GoServiceGenerator extends ServiceGenerator {
 
-  private def generateMod(module: String): String = mkCode.doubleLines(s"module $module", "go 1.13")
-
-  private def generatePackage(packageName: String): String = s"package $packageName"
-
   override def generate(serviceRoot: ServiceRoot): Map[File, FileContent] = {
     /* TODO
      * handlers in <>.go
@@ -21,9 +17,9 @@ object GoServiceGenerator extends ServiceGenerator {
      */
     val usesComms = serviceRoot.comms.nonEmpty
     (Map(
-      File(s"${serviceRoot.name}", "go.mod") -> generateMod(serviceRoot.module),
+      File(s"${serviceRoot.name}", "go.mod") -> GoCommonGenerator.generateMod(serviceRoot.module),
       File(serviceRoot.name, s"${serviceRoot.name}.go") -> mkCode.doubleLines(
-        generatePackage("main"),
+        GoCommonGenerator.generatePackage("main"),
         GoServiceMainGenerator.generateImports(
           serviceRoot.name,
           serviceRoot.module,
@@ -47,7 +43,7 @@ object GoServiceGenerator extends ServiceGenerator {
       ),
       File(s"${serviceRoot.name}/dao", "errors.go") -> GoServiceDaoGenerator.generateErrors(serviceRoot.name),
       File(s"${serviceRoot.name}/dao", "dao.go") -> mkCode.doubleLines(
-        generatePackage("dao"),
+        GoCommonGenerator.generatePackage("dao"),
         GoServiceDaoGenerator.generateImports(serviceRoot.module),
         GoServiceDaoGenerator.generateStructs(),
         GoServiceDaoGenerator.generateInit(),
@@ -56,7 +52,7 @@ object GoServiceGenerator extends ServiceGenerator {
       File(s"${serviceRoot.name}/util", "util.go")   -> GoServiceUtilGenerator.generateUtil(),
     ) ++ when(usesComms)(
       File(s"${serviceRoot.name}/comm", "handler.go") -> mkCode.doubleLines(
-        generatePackage("comm"),
+        GoCommonGenerator.generatePackage("comm"),
         GoServiceCommGenerator.generateImports(serviceRoot.module),
         GoServiceCommGenerator.generateStructs(),
         GoServiceCommGenerator.generateInit(),

--- a/src/main/scala/temple/generate/service/go/auth/GoAuthServiceGenerator.scala
+++ b/src/main/scala/temple/generate/service/go/auth/GoAuthServiceGenerator.scala
@@ -1,0 +1,23 @@
+package temple.generate.service.go.auth
+
+import temple.generate.service.{AuthServiceGenerator, AuthServiceRoot}
+import temple.generate.service.go.GoCommonGenerator
+import temple.generate.utils.CodeTerm.{CodeWrap, mkCode}
+import temple.generate.FileSystem._
+import temple.utils.StringUtils.doubleQuote
+
+object GoAuthServiceGenerator extends AuthServiceGenerator {
+
+  override def generate(authServiceRoot: AuthServiceRoot): Map[File, FileContent] =
+    (
+      Map(
+        File("auth", "go.mod") -> GoCommonGenerator.generateMod(authServiceRoot.module),
+        File("auth", "auth.go") -> mkCode.doubleLines(
+          GoCommonGenerator.generatePackage("main"),
+          GoAuthServiceMainGenerator.generateAuthImports(
+            authServiceRoot.module,
+          ),
+        ),
+      ),
+    ).map { case (path, contents) => path -> (contents + "\n") }
+}

--- a/src/main/scala/temple/generate/service/go/auth/GoAuthServiceGenerator.scala
+++ b/src/main/scala/temple/generate/service/go/auth/GoAuthServiceGenerator.scala
@@ -9,14 +9,12 @@ import temple.utils.StringUtils.doubleQuote
 object GoAuthServiceGenerator extends AuthServiceGenerator {
 
   override def generate(authServiceRoot: AuthServiceRoot): Map[File, FileContent] =
-    (
-      Map(
-        File("auth", "go.mod") -> GoCommonGenerator.generateMod(authServiceRoot.module),
-        File("auth", "auth.go") -> mkCode.doubleLines(
-          GoCommonGenerator.generatePackage("main"),
-          GoAuthServiceMainGenerator.generateAuthImports(
-            authServiceRoot.module,
-          ),
+    Map(
+      File("auth", "go.mod") -> GoCommonGenerator.generateMod(authServiceRoot.module),
+      File("auth", "auth.go") -> mkCode.doubleLines(
+        GoCommonGenerator.generatePackage("main"),
+        GoAuthServiceMainGenerator.generateAuthImports(
+          authServiceRoot.module,
         ),
       ),
     ).map { case (path, contents) => path -> (contents + "\n") }

--- a/src/main/scala/temple/generate/service/go/auth/GoAuthServiceMainGenerator.scala
+++ b/src/main/scala/temple/generate/service/go/auth/GoAuthServiceMainGenerator.scala
@@ -1,0 +1,25 @@
+package temple.generate.service.go.auth
+
+import temple.generate.utils.CodeTerm.{CodeWrap, mkCode}
+import temple.utils.StringUtils.doubleQuote
+
+object GoAuthServiceMainGenerator {
+
+  private[auth] def generateAuthImports(module: String): String = {
+    val standardImports = Seq("encoding/json", "flag", "fmt", "log", "net/http", "time").map(doubleQuote)
+
+    val officialImports = doubleQuote("golang.org/x/crypto/bcrypt")
+
+    val customImports = Seq(
+      doubleQuote(s"$module/comm"),
+      doubleQuote(s"$module/dao"),
+      doubleQuote(s"$module/util"),
+      s"valid ${doubleQuote("github.com/asaskevich/govalidator")}",
+      doubleQuote("github.com/dgrijalva/jwt-go"),
+      doubleQuote("github.com/google/uuid"),
+      doubleQuote("github.com/gorilla/mux"),
+    )
+
+    mkCode("import", CodeWrap.parens.tabbed(standardImports, "", officialImports, "", customImports))
+  }
+}

--- a/src/test/scala/temple/generate/service/go/GoAuthServiceGeneratorTest.scala
+++ b/src/test/scala/temple/generate/service/go/GoAuthServiceGeneratorTest.scala
@@ -1,0 +1,13 @@
+package temple.generate.service.go
+
+import org.scalatest.{FlatSpec, Matchers}
+import temple.generate.service.go.auth.GoAuthServiceGenerator
+
+class GoAuthServiceGeneratorTest extends FlatSpec with Matchers {
+
+  behavior of "GoAuthServiceGenerator"
+
+  it should "generate auth services correctly" in {
+    GoAuthServiceGenerator.generate(GoAuthServiceGeneratorTestData.authServiceRoot) shouldBe GoAuthServiceGeneratorTestData.authServiceFiles
+  }
+}

--- a/src/test/scala/temple/generate/service/go/GoAuthServiceGeneratorTestData.scala
+++ b/src/test/scala/temple/generate/service/go/GoAuthServiceGeneratorTestData.scala
@@ -1,0 +1,18 @@
+package temple.generate.service.go
+
+import temple.generate.service.AuthServiceRoot
+import temple.generate.FileSystem._
+import temple.utils.FileUtils._
+
+object GoAuthServiceGeneratorTestData {
+
+  val authServiceRoot: AuthServiceRoot = AuthServiceRoot(
+    "github.com/TempleEight/spec-golang/auth",
+    82,
+  )
+
+  val authServiceFiles: Map[File, FileContent] = Map(
+    File("auth", "go.mod")  -> readFile("src/test/scala/temple/generate/service/go/testfiles/auth/go.mod"),
+    File("auth", "auth.go") -> readFile("src/test/scala/temple/generate/service/go/testfiles/auth/auth.go"),
+  )
+}

--- a/src/test/scala/temple/generate/service/go/testfiles/auth/auth.go
+++ b/src/test/scala/temple/generate/service/go/testfiles/auth/auth.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/TempleEight/spec-golang/auth/comm"
+	"github.com/TempleEight/spec-golang/auth/dao"
+	"github.com/TempleEight/spec-golang/auth/util"
+	valid "github.com/asaskevich/govalidator"
+	"github.com/dgrijalva/jwt-go"
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
+)

--- a/src/test/scala/temple/generate/service/go/testfiles/auth/go.mod
+++ b/src/test/scala/temple/generate/service/go/testfiles/auth/go.mod
@@ -1,0 +1,3 @@
+module github.com/TempleEight/spec-golang/auth
+
+go 1.13


### PR DESCRIPTION
* Splits up Auth service generation from other service generation
* Moves generation common to both generating Auth and other services to `GoCommonGenerator`
* Adds import generation for Auth service
* Adds go.mod generation for Auth service
* Adds unit tests

Rather than having to shoehorn the Auth service generation into the other services and have to switch all over the place, I think it's quicker and less painful to separate it.