### PR TITLE
[go-gen] Add handlers and errors.go generation to auth

### DIFF
--- a/src/main/resources/go/genFiles/auth/dao/errors.go.snippet
+++ b/src/main/resources/go/genFiles/auth/dao/errors.go.snippet
@@ -1,0 +1,11 @@
+package dao
+
+import (
+	"errors"
+)
+
+// ErrAuthNotFound is returned when the provided email was not found
+var ErrAuthNotFound = errors.New("auth not found")
+
+// ErrDuplicateAuth is returned when an auth already exists
+var ErrDuplicateAuth = errors.New("auth already exists")

--- a/src/main/resources/go/genFiles/auth/main/handlers.go.snippet
+++ b/src/main/resources/go/genFiles/auth/main/handlers.go.snippet
@@ -1,3 +1,108 @@
-func (env *env) registerAuthHandler(w http.ResponseWriter, r *http.Request) {}
+func (env *env) registerAuthHandler(w http.ResponseWriter, r *http.Request) {
+	var req registerAuthRequest
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Invalid request parameters: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusBadRequest)
+		return
+	}
 
-func (env *env) loginAuthHandler(w http.ResponseWriter, r *http.Request) {}
+	_, err = valid.ValidateStruct(req)
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Invalid request parameters: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusBadRequest)
+		return
+	}
+
+	// Hash and salt the password before storing
+	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(req.Password), bcrypt.DefaultCost)
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Could not hash password: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusInternalServerError)
+		return
+	}
+
+	uuid, err := uuid.NewUUID()
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Could not create UUID: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusInternalServerError)
+		return
+	}
+
+	auth, err := env.dao.CreateAuth(dao.CreateAuthInput{
+		ID:       uuid,
+		Email:    req.Email,
+		Password: string(hashedPassword),
+	})
+	if err != nil {
+		switch err {
+		case dao.ErrDuplicateAuth:
+			http.Error(w, util.CreateErrorJSON(err.Error()), http.StatusForbidden)
+		default:
+			errMsg := util.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))
+			http.Error(w, errMsg, http.StatusInternalServerError)
+		}
+		return
+	}
+
+	accessToken, err := createToken(auth.ID, env.jwtCredential.Key, env.jwtCredential.Secret)
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Could not create access token: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusInternalServerError)
+		return
+	}
+
+	json.NewEncoder(w).Encode(registerAuthResponse{
+		AccessToken: accessToken,
+	})
+}
+
+func (env *env) loginAuthHandler(w http.ResponseWriter, r *http.Request) {
+	var req loginAuthRequest
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Invalid request parameters: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusBadRequest)
+		return
+	}
+
+	_, err = valid.ValidateStruct(req)
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Invalid request parameters: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusBadRequest)
+		return
+	}
+
+	auth, err := env.dao.ReadAuth(dao.ReadAuthInput{
+		Email: req.Email,
+	})
+	if err != nil {
+		switch err {
+		case dao.ErrAuthNotFound:
+			errMsg := util.CreateErrorJSON(fmt.Sprintf("Invalid email or password"))
+			http.Error(w, errMsg, http.StatusUnauthorized)
+		default:
+			errMsg := util.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))
+			http.Error(w, errMsg, http.StatusInternalServerError)
+		}
+		return
+	}
+
+	err = bcrypt.CompareHashAndPassword([]byte(auth.Password), []byte(req.Password))
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Invalid email or password"))
+		http.Error(w, errMsg, http.StatusUnauthorized)
+		return
+	}
+
+	accessToken, err := createToken(auth.ID, env.jwtCredential.Key, env.jwtCredential.Secret)
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Could not create access token: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusInternalServerError)
+		return
+	}
+
+	json.NewEncoder(w).Encode(loginAuthResponse{
+		AccessToken: accessToken,
+	})
+}

--- a/src/main/scala/temple/generate/server/go/auth/GoAuthServiceDAOGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/auth/GoAuthServiceDAOGenerator.scala
@@ -1,0 +1,9 @@
+package temple.generate.server.go.auth
+
+import temple.utils.FileUtils
+
+object GoAuthServiceDAOGenerator {
+
+  private[auth] def generateErrors(): String =
+    FileUtils.readResources("go/genFiles/auth/dao/errors.go.snippet").stripLineEnd
+}

--- a/src/main/scala/temple/generate/server/go/auth/GoAuthServiceGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/auth/GoAuthServiceGenerator.scala
@@ -10,6 +10,8 @@ object GoAuthServiceGenerator extends AuthServiceGenerator {
   override def generate(authServiceRoot: AuthServiceRoot): Map[File, FileContent] =
     /* TODO
      * auth.go main
+     * dao.go
+     * config.json
      */
     Map(
       File("auth", "go.mod") -> GoCommonGenerator.generateMod(authServiceRoot.module),

--- a/src/main/scala/temple/generate/server/go/auth/GoAuthServiceGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/auth/GoAuthServiceGenerator.scala
@@ -10,7 +10,6 @@ object GoAuthServiceGenerator extends AuthServiceGenerator {
   override def generate(authServiceRoot: AuthServiceRoot): Map[File, FileContent] =
     /* TODO
      * auth.go main
-     * auth.go handlers
      */
     Map(
       File("auth", "go.mod") -> GoCommonGenerator.generateMod(authServiceRoot.module),

--- a/src/main/scala/temple/generate/server/go/auth/GoAuthServiceGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/auth/GoAuthServiceGenerator.scala
@@ -25,6 +25,7 @@ object GoAuthServiceGenerator extends AuthServiceGenerator {
         GoAuthServiceMainGenerator.generateHandlers(),
         GoAuthServiceMainGenerator.generateCreateToken(),
       ),
+      File("auth/dao", "errors.go") -> GoAuthServiceDAOGenerator.generateErrors(),
       File("auth/comm", "handler.go") -> mkCode.doubleLines(
         GoCommonGenerator.generatePackage("comm"),
         GoAuthServiceCommGenerator.generateImports(authServiceRoot.module),

--- a/src/main/scala/temple/generate/server/go/service/GoServiceDAOGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/GoServiceDAOGenerator.scala
@@ -3,7 +3,7 @@ package temple.generate.server.go.service
 import temple.generate.utils.CodeTerm.{CodeWrap, mkCode}
 import temple.utils.FileUtils
 
-object GoServiceDaoGenerator {
+object GoServiceDAOGenerator {
 
   private[go] def generateImports(module: String): String = mkCode(
     "import",

--- a/src/main/scala/temple/generate/server/go/service/GoServiceGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/GoServiceGenerator.scala
@@ -42,12 +42,12 @@ object GoServiceGenerator extends ServiceGenerator {
           serviceRoot.operations,
         ),
       ),
-      File(s"${serviceRoot.name}/dao", "errors.go") -> GoServiceDaoGenerator.generateErrors(serviceRoot.name),
+      File(s"${serviceRoot.name}/dao", "errors.go") -> GoServiceDAOGenerator.generateErrors(serviceRoot.name),
       File(s"${serviceRoot.name}/dao", "dao.go") -> mkCode.doubleLines(
         GoCommonGenerator.generatePackage("dao"),
-        GoServiceDaoGenerator.generateImports(serviceRoot.module),
-        GoServiceDaoGenerator.generateStructs(),
-        GoServiceDaoGenerator.generateInit(),
+        GoServiceDAOGenerator.generateImports(serviceRoot.module),
+        GoServiceDAOGenerator.generateStructs(),
+        GoServiceDAOGenerator.generateInit(),
       ),
       File(s"${serviceRoot.name}/util", "util.go") -> mkCode.doubleLines(
         GoCommonGenerator.generatePackage("util"),

--- a/src/main/scala/temple/generate/server/go/service/GoServiceGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/GoServiceGenerator.scala
@@ -12,8 +12,10 @@ object GoServiceGenerator extends ServiceGenerator {
 
   override def generate(serviceRoot: ServiceRoot): Map[File, FileContent] = {
     /* TODO
+     * main in <>.go
      * handlers in <>.go
-     * structs and methods in dao.go
+     * dao.go
+     * handler.go
      * config.json
      */
     val usesComms = serviceRoot.comms.nonEmpty

--- a/src/test/scala/temple/generate/server/go/GoAuthServiceGeneratorTestData.scala
+++ b/src/test/scala/temple/generate/server/go/GoAuthServiceGeneratorTestData.scala
@@ -14,6 +14,9 @@ object GoAuthServiceGeneratorTestData {
   val authServiceFiles: Map[File, FileContent] = Map(
     File("auth", "go.mod")  -> readFile("src/test/scala/temple/generate/server/go/testfiles/auth/go.mod.snippet"),
     File("auth", "auth.go") -> readFile("src/test/scala/temple/generate/server/go/testfiles/auth/auth.go.snippet"),
+    File("auth/dao", "errors.go") -> readFile(
+      "src/test/scala/temple/generate/server/go/testfiles/auth/dao/errors.go.snippet",
+    ),
     File("auth/comm", "handler.go") -> readFile(
       "src/test/scala/temple/generate/server/go/testfiles/auth/comm/handler.go.snippet",
     ),

--- a/src/test/scala/temple/generate/server/go/testfiles/auth/auth.go.snippet
+++ b/src/test/scala/temple/generate/server/go/testfiles/auth/auth.go.snippet
@@ -69,9 +69,114 @@ func jsonMiddleware(next http.Handler) http.Handler {
 	})
 }
 
-func (env *env) registerAuthHandler(w http.ResponseWriter, r *http.Request) {}
+func (env *env) registerAuthHandler(w http.ResponseWriter, r *http.Request) {
+	var req registerAuthRequest
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Invalid request parameters: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusBadRequest)
+		return
+	}
 
-func (env *env) loginAuthHandler(w http.ResponseWriter, r *http.Request) {}
+	_, err = valid.ValidateStruct(req)
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Invalid request parameters: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusBadRequest)
+		return
+	}
+
+	// Hash and salt the password before storing
+	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(req.Password), bcrypt.DefaultCost)
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Could not hash password: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusInternalServerError)
+		return
+	}
+
+	uuid, err := uuid.NewUUID()
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Could not create UUID: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusInternalServerError)
+		return
+	}
+
+	auth, err := env.dao.CreateAuth(dao.CreateAuthInput{
+		ID:       uuid,
+		Email:    req.Email,
+		Password: string(hashedPassword),
+	})
+	if err != nil {
+		switch err {
+		case dao.ErrDuplicateAuth:
+			http.Error(w, util.CreateErrorJSON(err.Error()), http.StatusForbidden)
+		default:
+			errMsg := util.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))
+			http.Error(w, errMsg, http.StatusInternalServerError)
+		}
+		return
+	}
+
+	accessToken, err := createToken(auth.ID, env.jwtCredential.Key, env.jwtCredential.Secret)
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Could not create access token: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusInternalServerError)
+		return
+	}
+
+	json.NewEncoder(w).Encode(registerAuthResponse{
+		AccessToken: accessToken,
+	})
+}
+
+func (env *env) loginAuthHandler(w http.ResponseWriter, r *http.Request) {
+	var req loginAuthRequest
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Invalid request parameters: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusBadRequest)
+		return
+	}
+
+	_, err = valid.ValidateStruct(req)
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Invalid request parameters: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusBadRequest)
+		return
+	}
+
+	auth, err := env.dao.ReadAuth(dao.ReadAuthInput{
+		Email: req.Email,
+	})
+	if err != nil {
+		switch err {
+		case dao.ErrAuthNotFound:
+			errMsg := util.CreateErrorJSON(fmt.Sprintf("Invalid email or password"))
+			http.Error(w, errMsg, http.StatusUnauthorized)
+		default:
+			errMsg := util.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))
+			http.Error(w, errMsg, http.StatusInternalServerError)
+		}
+		return
+	}
+
+	err = bcrypt.CompareHashAndPassword([]byte(auth.Password), []byte(req.Password))
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Invalid email or password"))
+		http.Error(w, errMsg, http.StatusUnauthorized)
+		return
+	}
+
+	accessToken, err := createToken(auth.ID, env.jwtCredential.Key, env.jwtCredential.Secret)
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Could not create access token: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusInternalServerError)
+		return
+	}
+
+	json.NewEncoder(w).Encode(loginAuthResponse{
+		AccessToken: accessToken,
+	})
+}
 
 // Create an access token with a 24 hour lifetime
 func createToken(id uuid.UUID, issuer string, secret string) (string, error) {

--- a/src/test/scala/temple/generate/server/go/testfiles/auth/dao/errors.go.snippet
+++ b/src/test/scala/temple/generate/server/go/testfiles/auth/dao/errors.go.snippet
@@ -1,0 +1,11 @@
+package dao
+
+import (
+	"errors"
+)
+
+// ErrAuthNotFound is returned when the provided email was not found
+var ErrAuthNotFound = errors.New("auth not found")
+
+// ErrDuplicateAuth is returned when an auth already exists
+var ErrDuplicateAuth = errors.New("auth already exists")


### PR DESCRIPTION
* Adds handlers for registering and logging in to the Auth service
* Adds `errors.go` generation to Auth service
* Renames `Dao` -> `DAO`

Small PR, ignore `.snippet`. Ready to start doing full `dao.go` generation, gonna be fun. Auth service is generated aside from `dao.go` and the main function.