### PR TITLE
[util] Move verb into the CRUD type

### DIFF
--- a/src/main/scala/temple/generate/CRUD.scala
+++ b/src/main/scala/temple/generate/CRUD.scala
@@ -1,13 +1,13 @@
 package temple.generate
 
-sealed trait CRUD
+abstract class CRUD(val verb: String)
 
 object CRUD {
-  case object ReadAll extends CRUD
-  case object Create  extends CRUD
-  case object Read    extends CRUD
-  case object Update  extends CRUD
-  case object Delete  extends CRUD
+  case object ReadAll extends CRUD("List")
+  case object Create  extends CRUD("Create")
+  case object Read    extends CRUD("Read")
+  case object Update  extends CRUD("Update")
+  case object Delete  extends CRUD("Delete")
 
   val values = Seq(ReadAll, Create, Read, Update, Delete)
 }

--- a/src/main/scala/temple/generate/server/ServiceGenerator.scala
+++ b/src/main/scala/temple/generate/server/ServiceGenerator.scala
@@ -9,15 +9,3 @@ trait ServiceGenerator {
   /** Given a ServiceRoot ADT, generate the service boilerplate in a specific language */
   def generate(serviceRoot: ServiceRoot): Files
 }
-
-object ServiceGenerator {
-
-  /** Get the string representation of an endpoint, for use in the generated function name */
-  private[server] def verb(endpoint: CRUD): String = endpoint match {
-    case CRUD.ReadAll => "List"
-    case CRUD.Create  => "Create"
-    case CRUD.Read    => "Read"
-    case CRUD.Update  => "Update"
-    case CRUD.Delete  => "Delete"
-  }
-}

--- a/src/main/scala/temple/generate/server/go/service/GoServiceDAOGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/GoServiceDAOGenerator.scala
@@ -3,7 +3,6 @@ package temple.generate.server.go.service
 import temple.ast.{Annotation, Attribute, AttributeType}
 import temple.generate.CRUD
 import temple.generate.CRUD._
-import temple.generate.server.ServiceGenerator.verb
 import temple.generate.server.go.common.GoCommonGenerator.generateGoType
 import temple.generate.server.{CreatedByAttribute, IDAttribute}
 import temple.generate.utils.CodeTerm.{CodeWrap, mkCode}
@@ -47,7 +46,7 @@ object GoServiceDAOGenerator {
     }
 
   private def generateDAOFunctionName(operation: CRUD, serviceName: String): String =
-    s"${verb(operation)}${serviceName.capitalize}"
+    s"${operation.verb}${serviceName.capitalize}"
 
   private def generateDatastoreInterfaceFunction(
     serviceName: String,
@@ -108,7 +107,7 @@ object GoServiceDAOGenerator {
   private def generateInputStructCommentSubstring(operation: CRUD, serviceName: String): String =
     operation match {
       case ReadAll                         => s"read a $serviceName list"
-      case Create | Read | Update | Delete => s"${verb(operation).toLowerCase()} a single $serviceName"
+      case Create | Read | Update | Delete => s"${operation.verb.toLowerCase()} a single $serviceName"
     }
 
   private def generateReadAllInputStructFields(

--- a/src/main/scala/temple/generate/server/go/service/GoServiceMainGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/GoServiceMainGenerator.scala
@@ -1,7 +1,6 @@
 package temple.generate.server.go.service
 
 import temple.generate.CRUD
-import temple.generate.server.ServiceGenerator.verb
 import temple.generate.utils.CodeTerm
 import temple.generate.utils.CodeTerm.{CodeWrap, mkCode}
 import temple.utils.StringUtils.doubleQuote
@@ -94,7 +93,7 @@ object GoServiceMainGenerator {
     )
 
   private[service] def generateHandler(serviceName: String, operation: CRUD): String =
-    s"func $serviceName${verb(operation)}Handler(w http.ResponseWriter, r *http.Request) {}"
+    s"func $serviceName${operation.verb}Handler(w http.ResponseWriter, r *http.Request) {}"
 
   private[service] def generateHandlers(serviceName: String, operations: Set[CRUD]): String =
     mkCode.doubleLines(


### PR DESCRIPTION
It'll be useful to have a string representation of the `CRUD` value in the Grafana gen, so I've moved the function into an attribute on the type 