### PR TITLE
[grafana] Generate yml config for grafana

### DIFF
--- a/src/main/scala/temple/generate/metrics/grafana/GrafanaDashboardConfigGenerator.scala
+++ b/src/main/scala/temple/generate/metrics/grafana/GrafanaDashboardConfigGenerator.scala
@@ -1,0 +1,11 @@
+package temple.generate.metrics.grafana
+
+import io.circe.yaml.Printer
+import io.circe.syntax._
+import temple.generate.metrics.grafana.ast.GrafanaDashboardConfig
+
+object GrafanaDashboardConfigGenerator {
+
+  def generate(providerName: String): String =
+    Printer(preserveOrder = true).pretty(GrafanaDashboardConfig(providerName).asJson)
+}

--- a/src/main/scala/temple/generate/metrics/grafana/GrafanaDashboardGenerator.scala
+++ b/src/main/scala/temple/generate/metrics/grafana/GrafanaDashboardGenerator.scala
@@ -2,7 +2,6 @@ package temple.generate.metrics.grafana
 
 import io.circe.syntax._
 import temple.generate.metrics.grafana.ast.{GrafanaPanel, GrafanaRoot, GrafanaTarget, Row}
-import temple.utils.StringUtils
 
 object GrafanaDashboardGenerator {
   private val maxWidth    = 24

--- a/src/main/scala/temple/generate/metrics/grafana/ast/GrafanaDashboardConfig.scala
+++ b/src/main/scala/temple/generate/metrics/grafana/ast/GrafanaDashboardConfig.scala
@@ -1,0 +1,26 @@
+package temple.generate.metrics.grafana.ast
+
+import io.circe.Json
+import temple.generate.JsonEncodable
+
+import scala.collection.immutable.ListMap
+
+private[grafana] case class GrafanaDashboardConfig(provider: String) extends JsonEncodable.Object {
+
+  override def jsonEntryIterator: IterableOnce[(String, Json)] =
+    Seq(
+      "apiVersion" ~> 1,
+      "providers" ~> Seq(
+        ListMap(
+          "name"            ~> provider,
+          "orgId"           ~> 1,
+          "folder"          ~> "",
+          "type"            ~> "file",
+          "disableDeletion" ~> false,
+          "editable"        ~> true,
+          "allowUiUpdates"  ~> true,
+          "options"         ~> ListMap("path" ~> "/etc/grafana/provisioning/dashboards"),
+        ),
+      ),
+    )
+}

--- a/src/test/scala/temple/generate/metrics/grafana/GrafanaDashboardConfigGeneratorTest.scala
+++ b/src/test/scala/temple/generate/metrics/grafana/GrafanaDashboardConfigGeneratorTest.scala
@@ -1,0 +1,15 @@
+package temple.generate.metrics.grafana
+
+import org.scalatest.{FlatSpec, Matchers}
+import temple.generate.metrics.grafana.GrafanaDashboardGeneratorTestUtils.{makeTarget, _}
+import temple.generate.metrics.grafana.ast.Row
+import temple.generate.metrics.grafana.ast.Row.{Metric, Query}
+
+class GrafanaDashboardConfigGeneratorTest extends FlatSpec with Matchers {
+  behavior of "GrafanaDashboardConfigGenerator"
+
+  it should "generate correct config" in {
+    val generated = GrafanaDashboardConfigGenerator.generate("Prometheus")
+    generated shouldBe GrafanaDashboardConfigGeneratorTestData.prometheusConfig
+  }
+}

--- a/src/test/scala/temple/generate/metrics/grafana/GrafanaDashboardConfigGeneratorTestData.scala
+++ b/src/test/scala/temple/generate/metrics/grafana/GrafanaDashboardConfigGeneratorTestData.scala
@@ -3,7 +3,7 @@ package temple.generate.metrics.grafana
 object GrafanaDashboardConfigGeneratorTestData {
 
   val prometheusConfig: String =
-    """|apiVersion: 1
+    """apiVersion: 1
       |providers:
       |- name: Prometheus
       |  orgId: 1

--- a/src/test/scala/temple/generate/metrics/grafana/GrafanaDashboardConfigGeneratorTestData.scala
+++ b/src/test/scala/temple/generate/metrics/grafana/GrafanaDashboardConfigGeneratorTestData.scala
@@ -1,0 +1,18 @@
+package temple.generate.metrics.grafana
+
+object GrafanaDashboardConfigGeneratorTestData {
+
+  val prometheusConfig: String =
+    """|apiVersion: 1
+      |providers:
+      |- name: Prometheus
+      |  orgId: 1
+      |  folder: ''
+      |  type: file
+      |  disableDeletion: false
+      |  editable: true
+      |  allowUiUpdates: true
+      |  options:
+      |    path: /etc/grafana/provisioning/dashboards
+      |""".stripMargin
+}


### PR DESCRIPTION
On top of the beautiful JSON, Grafana also needs a couple of `.yml` config files.

This is the first (from https://github.com/TempleEight/spec-golang/blob/develop/grafana/provisioning/dashboards/dashboards.yml), which is always the same for our datasource, but I've taken the name as an argument so we can be consistent everywhere