### PR TITLE
[grafana] Use custom type for datasource

### DIFF
--- a/src/main/scala/temple/builder/MetricsBuilder.scala
+++ b/src/main/scala/temple/builder/MetricsBuilder.scala
@@ -1,7 +1,7 @@
 package temple.builder
 
 import temple.generate.CRUD
-import temple.generate.metrics.grafana.ast.Row
+import temple.generate.metrics.grafana.ast.{Datasource, Row}
 import temple.generate.metrics.grafana.ast.Row.{Metric, Query}
 
 object MetricsBuilder {
@@ -40,21 +40,21 @@ object MetricsBuilder {
       ),
     )
 
-  def createDashboardRows(serviceName: String, endpoints: Set[CRUD]): Seq[Row] =
+  def createDashboardRows(serviceName: String, datasource: Datasource, endpoints: Set[CRUD]): Seq[Row] =
     endpoints.zipWithIndex.map {
       case (endpoint, index) =>
         Row(
           Metric(
             index * 2,
             s"$endpoint $serviceName Requests",
-            "Prometheus",
+            datasource,
             "QPS",
             qpsQueries(serviceName.toLowerCase, endpoint.toString.toLowerCase),
           ),
           Metric(
             index * 2 + 1,
             s"DB $endpoint Queries",
-            "Prometheus",
+            datasource,
             "Time (seconds)",
             databaseDurationQueries(serviceName.toLowerCase, endpoint.toString.toLowerCase),
           ),

--- a/src/main/scala/temple/builder/project/ProjectBuilder.scala
+++ b/src/main/scala/temple/builder/project/ProjectBuilder.scala
@@ -12,6 +12,7 @@ import temple.generate.database.{PostgresContext, PostgresGenerator}
 import temple.generate.docker.DockerfileGenerator
 import temple.generate.kube.KubernetesGenerator
 import temple.generate.metrics.grafana.GrafanaDashboardGenerator
+import temple.generate.metrics.grafana.ast.Datasource
 import temple.utils.StringUtils
 
 object ProjectBuilder {
@@ -66,8 +67,10 @@ object ProjectBuilder {
 
     val metrics = templefile.services.map {
       case (name, service) =>
-        val rows             = MetricsBuilder.createDashboardRows(name, endpoints(service))
-        val grafanaDashboard = GrafanaDashboardGenerator.generate(name.toLowerCase, name, rows)
+        // TODO: Get this from templefile
+        val datasource: Datasource = Datasource.Prometheus("Prometheus")
+        val rows                   = MetricsBuilder.createDashboardRows(name, datasource, endpoints(service))
+        val grafanaDashboard       = GrafanaDashboardGenerator.generate(name.toLowerCase, name, rows)
         (File(s"grafana/provisioning/dashboards", s"${name.toLowerCase}.json"), grafanaDashboard)
     }
 

--- a/src/main/scala/temple/generate/metrics/grafana/GrafanaDashboardConfigGenerator.scala
+++ b/src/main/scala/temple/generate/metrics/grafana/GrafanaDashboardConfigGenerator.scala
@@ -2,10 +2,10 @@ package temple.generate.metrics.grafana
 
 import io.circe.yaml.Printer
 import io.circe.syntax._
-import temple.generate.metrics.grafana.ast.GrafanaDashboardConfig
+import temple.generate.metrics.grafana.ast.{GrafanaDashboardConfig, Datasource}
 
 object GrafanaDashboardConfigGenerator {
 
-  def generate(providerName: String): String =
-    Printer(preserveOrder = true).pretty(GrafanaDashboardConfig(providerName).asJson)
+  def generate(datasource: Datasource): String =
+    Printer(preserveOrder = true).pretty(GrafanaDashboardConfig(datasource).asJson)
 }

--- a/src/main/scala/temple/generate/metrics/grafana/ast/Datasource.scala
+++ b/src/main/scala/temple/generate/metrics/grafana/ast/Datasource.scala
@@ -1,0 +1,8 @@
+package temple.generate.metrics.grafana.ast
+
+sealed abstract class Datasource(val name: String, val typ: String)
+
+object Datasource {
+  // https://grafana.com/docs/grafana/v6.6/features/datasources/prometheus/
+  case class Prometheus(override val name: String) extends Datasource(name, "prometheus")
+}

--- a/src/main/scala/temple/generate/metrics/grafana/ast/GrafanaDashboardConfig.scala
+++ b/src/main/scala/temple/generate/metrics/grafana/ast/GrafanaDashboardConfig.scala
@@ -5,14 +5,14 @@ import temple.generate.JsonEncodable
 
 import scala.collection.immutable.ListMap
 
-private[grafana] case class GrafanaDashboardConfig(provider: String) extends JsonEncodable.Object {
+private[grafana] case class GrafanaDashboardConfig(datasource: Datasource) extends JsonEncodable.Object {
 
   override def jsonEntryIterator: IterableOnce[(String, Json)] =
     Seq(
       "apiVersion" ~> 1,
       "providers" ~> Seq(
         ListMap(
-          "name"            ~> provider,
+          "name"            ~> datasource.name,
           "orgId"           ~> 1,
           "folder"          ~> "",
           "type"            ~> "file",

--- a/src/main/scala/temple/generate/metrics/grafana/ast/GrafanaPanel.scala
+++ b/src/main/scala/temple/generate/metrics/grafana/ast/GrafanaPanel.scala
@@ -8,7 +8,7 @@ import scala.collection.immutable.ListMap
 private[grafana] case class GrafanaPanel(
   id: Int,
   title: String,
-  datasource: String,
+  datasource: Datasource,
   width: Int,
   height: Int,
   x: Int,
@@ -22,7 +22,7 @@ private[grafana] case class GrafanaPanel(
     "bars"         ~> false,
     "dashLength"   ~> 10,
     "dashes"       ~> false,
-    "datasource"   ~> datasource,
+    "datasource"   ~> datasource.name,
     "fill"         ~> 1,
     "fillGradient" ~> 0,
     "gridPos"      ~> ListMap("h" -> height, "w" -> width, "x" -> x, "y" -> y),

--- a/src/main/scala/temple/generate/metrics/grafana/ast/Row.scala
+++ b/src/main/scala/temple/generate/metrics/grafana/ast/Row.scala
@@ -8,7 +8,7 @@ case class Row(metrics: Metric*)
 object Row {
 
   /** A metric defines a single dashboard item, potentially showing multiple queries */
-  case class Metric(id: Int, title: String, datasource: String, yAxisLabel: String, queries: Seq[Query])
+  case class Metric(id: Int, title: String, datasource: Datasource, yAxisLabel: String, queries: Seq[Query])
 
   /** A query is a single expression, along with a formatted legend
     * See https://grafana.com/docs/grafana/latest/features/datasources/prometheus/#query-editor */

--- a/src/test/scala/temple/generate/metrics/grafana/GrafanaDashboardConfigGeneratorTest.scala
+++ b/src/test/scala/temple/generate/metrics/grafana/GrafanaDashboardConfigGeneratorTest.scala
@@ -1,15 +1,13 @@
 package temple.generate.metrics.grafana
 
 import org.scalatest.{FlatSpec, Matchers}
-import temple.generate.metrics.grafana.GrafanaDashboardGeneratorTestUtils.{makeTarget, _}
-import temple.generate.metrics.grafana.ast.Row
-import temple.generate.metrics.grafana.ast.Row.{Metric, Query}
+import temple.generate.metrics.grafana.ast.Datasource
 
 class GrafanaDashboardConfigGeneratorTest extends FlatSpec with Matchers {
   behavior of "GrafanaDashboardConfigGenerator"
 
   it should "generate correct config" in {
-    val generated = GrafanaDashboardConfigGenerator.generate("Prometheus")
+    val generated = GrafanaDashboardConfigGenerator.generate(Datasource.Prometheus("Prometheus"))
     generated shouldBe GrafanaDashboardConfigGeneratorTestData.prometheusConfig
   }
 }

--- a/src/test/scala/temple/generate/metrics/grafana/GrafanaDashboardGeneratorTest.scala
+++ b/src/test/scala/temple/generate/metrics/grafana/GrafanaDashboardGeneratorTest.scala
@@ -1,9 +1,9 @@
 package temple.generate.metrics.grafana
 
 import org.scalatest.{FlatSpec, Matchers}
-import temple.generate.metrics.grafana.ast.Row
-import temple.generate.metrics.grafana.ast.Row.{Metric, Query}
 import temple.generate.metrics.grafana.GrafanaDashboardGeneratorTestUtils.{makeTarget, _}
+import temple.generate.metrics.grafana.ast.Row.{Metric, Query}
+import temple.generate.metrics.grafana.ast.{Datasource, Row}
 
 class GrafanaDashboardGeneratorTest extends FlatSpec with Matchers {
   behavior of "GrafanaDashboardGenerator"
@@ -22,7 +22,11 @@ class GrafanaDashboardGeneratorTest extends FlatSpec with Matchers {
     )
 
     val generated = GrafanaDashboardGenerator
-      .generate("abcdefg", "Example", Seq(Row(Metric(1, "My Example Metric", "Prometheus", "MyYAxis", Seq()))))
+      .generate(
+        "abcdefg",
+        "Example",
+        Seq(Row(Metric(1, "My Example Metric", Datasource.Prometheus("Prometheus"), "MyYAxis", Seq()))),
+      )
 
     generated shouldBe expected
   }
@@ -42,10 +46,10 @@ class GrafanaDashboardGeneratorTest extends FlatSpec with Matchers {
       "Example",
       Seq(
         Row(
-          Metric(1, "My First Metric", "Prometheus", "MyYAxis1", Seq()),
-          Metric(2, "My Second Metric", "Prometheus", "MyYAxis2", Seq()),
-          Metric(3, "My Third Metric", "Prometheus", "MyYAxis3", Seq()),
-          Metric(4, "My Fourth Metric", "Prometheus", "MyYAxis4", Seq()),
+          Metric(1, "My First Metric", Datasource.Prometheus("Prometheus"), "MyYAxis1", Seq()),
+          Metric(2, "My Second Metric", Datasource.Prometheus("Prometheus"), "MyYAxis2", Seq()),
+          Metric(3, "My Third Metric", Datasource.Prometheus("Prometheus"), "MyYAxis3", Seq()),
+          Metric(4, "My Fourth Metric", Datasource.Prometheus("Prometheus"), "MyYAxis4", Seq()),
         ),
       ),
     )
@@ -68,10 +72,10 @@ class GrafanaDashboardGeneratorTest extends FlatSpec with Matchers {
       "Example",
       Seq(
         Row(
-          Metric(1, "My First Metric", "Prometheus", "MyYAxis1", Seq()),
-          Metric(2, "My Second Metric", "Prometheus", "MyYAxis2", Seq()),
-          Metric(3, "My Third Metric", "Prometheus", "MyYAxis3", Seq()),
-          Metric(4, "My Fourth Metric", "Prometheus", "MyYAxis4", Seq()),
+          Metric(1, "My First Metric", Datasource.Prometheus("Prometheus"), "MyYAxis1", Seq()),
+          Metric(2, "My Second Metric", Datasource.Prometheus("Prometheus"), "MyYAxis2", Seq()),
+          Metric(3, "My Third Metric", Datasource.Prometheus("Prometheus"), "MyYAxis3", Seq()),
+          Metric(4, "My Fourth Metric", Datasource.Prometheus("Prometheus"), "MyYAxis4", Seq()),
         ),
       ),
     )
@@ -94,12 +98,12 @@ class GrafanaDashboardGeneratorTest extends FlatSpec with Matchers {
       "Example",
       Seq(
         Row(
-          Metric(1, "My First Metric", "Prometheus", "MyYAxis1", Seq()),
-          Metric(2, "My Second Metric", "Prometheus", "MyYAxis2", Seq()),
+          Metric(1, "My First Metric", Datasource.Prometheus("Prometheus"), "MyYAxis1", Seq()),
+          Metric(2, "My Second Metric", Datasource.Prometheus("Prometheus"), "MyYAxis2", Seq()),
         ),
         Row(
-          Metric(3, "My Third Metric", "Prometheus", "MyYAxis3", Seq()),
-          Metric(4, "My Fourth Metric", "Prometheus", "MyYAxis4", Seq()),
+          Metric(3, "My Third Metric", Datasource.Prometheus("Prometheus"), "MyYAxis3", Seq()),
+          Metric(4, "My Fourth Metric", Datasource.Prometheus("Prometheus"), "MyYAxis4", Seq()),
         ),
       ),
     )
@@ -121,14 +125,38 @@ class GrafanaDashboardGeneratorTest extends FlatSpec with Matchers {
 
     val topRow = Seq(
       Row(
-        Metric(1, "My First Metric", "Prometheus", "MyYAxis1", Seq(Query("rate(my_first_metric)", "Success"))),
-        Metric(2, "My Second Metric", "Prometheus", "MyYAxis2", Seq(Query("rate(my_second_metric)", "Success"))),
+        Metric(
+          1,
+          "My First Metric",
+          Datasource.Prometheus("Prometheus"),
+          "MyYAxis1",
+          Seq(Query("rate(my_first_metric)", "Success")),
+        ),
+        Metric(
+          2,
+          "My Second Metric",
+          Datasource.Prometheus("Prometheus"),
+          "MyYAxis2",
+          Seq(Query("rate(my_second_metric)", "Success")),
+        ),
       ),
     )
     val bottomRow = Seq(
       Row(
-        Metric(3, "My Third Metric", "Prometheus", "MyYAxis3", Seq(Query("rate(my_third_metric)", "Success"))),
-        Metric(4, "My Fourth Metric", "Prometheus", "MyYAxis4", Seq(Query("rate(my_fourth_metric)", "Success"))),
+        Metric(
+          3,
+          "My Third Metric",
+          Datasource.Prometheus("Prometheus"),
+          "MyYAxis3",
+          Seq(Query("rate(my_third_metric)", "Success")),
+        ),
+        Metric(
+          4,
+          "My Fourth Metric",
+          Datasource.Prometheus("Prometheus"),
+          "MyYAxis4",
+          Seq(Query("rate(my_fourth_metric)", "Success")),
+        ),
       ),
     )
 
@@ -164,14 +192,14 @@ class GrafanaDashboardGeneratorTest extends FlatSpec with Matchers {
 
     val topRow = Seq(
       Row(
-        Metric(1, "My First Metric", "Prometheus", "MyYAxis1", queries(0)),
-        Metric(2, "My Second Metric", "Prometheus", "MyYAxis2", queries(1)),
+        Metric(1, "My First Metric", Datasource.Prometheus("Prometheus"), "MyYAxis1", queries(0)),
+        Metric(2, "My Second Metric", Datasource.Prometheus("Prometheus"), "MyYAxis2", queries(1)),
       ),
     )
     val bottomRow = Seq(
       Row(
-        Metric(3, "My Third Metric", "Prometheus", "MyYAxis3", queries(2)),
-        Metric(4, "My Fourth Metric", "Prometheus", "MyYAxis4", queries(3)),
+        Metric(3, "My Third Metric", Datasource.Prometheus("Prometheus"), "MyYAxis3", queries(2)),
+        Metric(4, "My Fourth Metric", Datasource.Prometheus("Prometheus"), "MyYAxis4", queries(3)),
       ),
     )
     val generated = GrafanaDashboardGenerator.generate("abcdefg", "Example", topRow ++ bottomRow)


### PR DESCRIPTION
When creating a datasource in Grafana, the user can assign it a name. This is then what's used to reference it from panels etc.

At the moment I was just using strings for this, but it feels nicer to wrap it in it's own type and then use this everywhere. 

The fact we're using "Prometheus" for the name is somewhat coincidental, we can use any unique identifier here.