### PR TITLE
[go-gen] Add prefix command

### DIFF
--- a/src/main/scala/temple/generate/utils/CodeTerm.scala
+++ b/src/main/scala/temple/generate/utils/CodeTerm.scala
@@ -99,6 +99,9 @@ object CodeTerm {
 
   sealed class CodeWrap private (start: String, end: String) {
 
+    /** Add a string before the opening symbol, without any spacing */
+    def prefix(prefix: String): CodeWrap = new CodeWrap(prefix + start, end)
+
     /** Wrap a (comma-separated list of) terms in parentheses */
     def apply(string: CodeTerm*): String = mkCode(start, string, end)
 


### PR DESCRIPTION
Mostly for @smithwjv’s benefit, for function calls.

```scala
CodeWrap.parens.prefixed("f")(
  args,
)
CodeWrap.parens.prefixed("f").tabbedList(
  args,
)
```
generates `f(args)`/
```
f(
  args
)
```