### PR TITLE
[sql-gen] Support prepared statements in update and where

### DIFF
--- a/src/it/scala/temple/generate/database/TestData.scala
+++ b/src/it/scala/temple/generate/database/TestData.scala
@@ -7,7 +7,7 @@ import temple.generate.database.ast.ColType._
 import temple.generate.database.ast.ColumnConstraint._
 import temple.generate.database.ast.ComparisonOperator._
 import temple.generate.database.ast.Condition._
-import temple.generate.database.ast.Expression.Value
+import temple.generate.database.ast.Expression.{PreparedValue, Value}
 import temple.generate.database.ast.Statement._
 import temple.generate.database.ast._
 
@@ -196,6 +196,22 @@ object TestData {
     ),
   )
 
+  val readStatementWithWherePrepared: Read = Read(
+    "temple_user",
+    Seq(
+      Column("id"),
+      Column("bankBalance"),
+      Column("name"),
+      Column("isStudent"),
+      Column("dateOfBirth"),
+      Column("timeOfDay"),
+      Column("expiry"),
+    ),
+    Some(
+      PreparedComparison("temple_user.id", Equal),
+    ),
+  )
+
   val insertStatement: Insert = Insert(
     "temple_user",
     Seq(
@@ -324,6 +340,34 @@ object TestData {
     ),
   )
 
+  val updateStatementWithPreparedInputAndReturn: Update = Update(
+    "temple_user",
+    Seq(
+      Assignment(Column("bankBalance"), PreparedValue),
+      Assignment(Column("name"), PreparedValue),
+    ),
+    None,
+    Seq(
+      Column("bankBalance"),
+      Column("name"),
+    ),
+  )
+
+  val updateStatementWithPreparedInputWhereAndReturn: Update = Update(
+    "temple_user",
+    Seq(
+      Assignment(Column("bankBalance"), PreparedValue),
+      Assignment(Column("name"), PreparedValue),
+    ),
+    Some(
+      PreparedComparison("temple_user.id", Equal),
+    ),
+    Seq(
+      Column("bankBalance"),
+      Column("name"),
+    ),
+  )
+
   val insertDataA: Seq[PreparedVariable] = Seq(
     PreparedVariable.ShortVariable(3),
     PreparedVariable.IntVariable(4),
@@ -387,6 +431,17 @@ object TestData {
   val insertDataCheckConstraintPasses: Seq[PreparedVariable] = Seq(
     PreparedVariable.IntVariable(1),
     PreparedVariable.IntVariable(5),
+  )
+
+  val updateDataPreparedA: Seq[PreparedVariable] = Seq(
+    PreparedVariable.FloatVariable(678.90f),
+    PreparedVariable.StringVariable("Smithe Williamson"),
+  )
+
+  val updateDataPreparedB: Seq[PreparedVariable] = Seq(
+    PreparedVariable.FloatVariable(678.90f),
+    PreparedVariable.StringVariable("Smithe Williamson"),
+    PreparedVariable.ShortVariable(3),
   )
 
 }

--- a/src/main/scala/temple/generate/database/ast/Condition.scala
+++ b/src/main/scala/temple/generate/database/ast/Condition.scala
@@ -5,6 +5,7 @@ sealed trait Condition
 
 object Condition {
   case class Comparison(left: String, comparison: ComparisonOperator, right: String) extends Condition
+  case class PreparedComparison(left: String, comparison: ComparisonOperator)        extends Condition
   case class Conjunction(left: Condition, right: Condition)                          extends Condition
   case class Disjunction(left: Condition, right: Condition)                          extends Condition
   case class Inverse(condition: Condition)                                           extends Condition

--- a/src/main/scala/temple/generate/database/ast/Expression.scala
+++ b/src/main/scala/temple/generate/database/ast/Expression.scala
@@ -5,4 +5,5 @@ sealed trait Expression
 
 object Expression {
   case class Value(value: String) extends Expression
+  case object PreparedValue       extends Expression
 }

--- a/src/test/scala/temple/generate/database/PostgresGeneratorTest.scala
+++ b/src/test/scala/temple/generate/database/PostgresGeneratorTest.scala
@@ -85,4 +85,45 @@ class PostgresGeneratorTest extends FlatSpec with Matchers {
   it should "handle complex SELECT statements" in {
     PostgresGenerator.generate(TestData.readStatementComplex) shouldBe TestData.postgresSelectStringComplex
   }
+
+  it should "handle SELECT statements with prepared WHERE queries correctly" in {
+    PostgresGenerator.generate(TestData.readStatementWithWherePrepared) shouldBe TestData.postgresSelectStringWithWherePrepared
+  }
+
+  it should "handle SELECT statements with nested prepared WHERE queries correctly" in {
+    PostgresGenerator.generate(TestData.readStatementWithNestedWherePrepared) shouldBe TestData.postgresSelectStringWithNestedWherePrepared
+  }
+
+  it should "handle SELECT statements with nested prepared WHERE queries correctly with question marks" in {
+    val questionMarkContext: PostgresContext = PostgresContext(PreparedType.QuestionMarks)
+    PostgresGenerator.generate(TestData.readStatementWithNestedWherePrepared)(questionMarkContext) shouldBe TestData.postgresSelectStringWithNestedWherePreparedUsingQuestionMarks
+  }
+
+  it should "handle UPDATE statements with prepared values correctly" in {
+    PostgresGenerator.generate(TestData.updateStatementPrepared) shouldBe TestData.postgresUpdateStringPrepared
+  }
+
+  it should "handle UPDATE statements with prepared values and WHERE statement correctly" in {
+    PostgresGenerator.generate(TestData.updateStatementPreparedWithWhere) shouldBe TestData.postgresUpdateStringPreparedWithWhere
+  }
+
+  it should "handle UPDATE statements with prepared values and prepared WHERE statement correctly" in {
+    PostgresGenerator.generate(TestData.updateStatementPreparedWithWherePrepared) shouldBe TestData.postgresUpdateStringPreparedWithWherePrepared
+  }
+
+  it should "handle UPDATE statements with prepared values and nested prepared WHERE statement correctly" in {
+    PostgresGenerator.generate(TestData.updateStatementPreparedWithNestedWherePrepared) shouldBe TestData.postgresUpdateStringPreparedWithNestedWherePrepared
+  }
+
+  it should "handle UPDATE statments with prepared and provided values and nested prepared WHERE statement correctly" in {
+    PostgresGenerator.generate(TestData.updateStatementPreparedAndValuesWithNestedWherePrepared) shouldBe TestData.postgresUpdateStringPreparedAndValuesWithNestedWherePrepared
+  }
+
+  it should "handle DELETE statements with prepared WHERE statement correctly" in {
+    PostgresGenerator.generate(TestData.deleteStatementWithWherePrepared) shouldBe TestData.postgresDeleteStringWithWherePrepared
+  }
+
+  it should "handle DELETE statements with nested prepared WHERE statement correctly" in {
+    PostgresGenerator.generate(TestData.deleteStatementWithNestedWherePrepared) shouldBe TestData.postgresDeleteStringWithNestedWherePrepared
+  }
 }

--- a/src/test/scala/temple/generate/database/PostgresGeneratorTest.scala
+++ b/src/test/scala/temple/generate/database/PostgresGeneratorTest.scala
@@ -103,6 +103,11 @@ class PostgresGeneratorTest extends FlatSpec with Matchers {
     PostgresGenerator.generate(TestData.updateStatementPrepared) shouldBe TestData.postgresUpdateStringPrepared
   }
 
+  it should "handle UPDATE statements with prepared values correctly with question marks" in {
+    val questionMarkContext: PostgresContext = PostgresContext(PreparedType.QuestionMarks)
+    PostgresGenerator.generate(TestData.updateStatementPrepared)(questionMarkContext) shouldBe TestData.postgresUpdateStringPreparedWithQuestionMarks
+  }
+
   it should "handle UPDATE statements with prepared values and WHERE statement correctly" in {
     PostgresGenerator.generate(TestData.updateStatementPreparedWithWhere) shouldBe TestData.postgresUpdateStringPreparedWithWhere
   }

--- a/src/test/scala/temple/generate/database/PostgresGeneratorTestData.scala
+++ b/src/test/scala/temple/generate/database/PostgresGeneratorTestData.scala
@@ -350,6 +350,9 @@ object PostgresGeneratorTestData {
   val postgresUpdateStringPrepared: String =
     """UPDATE Users SET bankBalance = $1, name = $2;"""
 
+  val postgresUpdateStringPreparedWithQuestionMarks: String =
+    """UPDATE Users SET bankBalance = ?, name = ?;"""
+
   val updateStatementPreparedWithWhere: Update = Update(
     "Users",
     Seq(

--- a/src/test/scala/temple/generate/database/PostgresGeneratorTestData.scala
+++ b/src/test/scala/temple/generate/database/PostgresGeneratorTestData.scala
@@ -198,6 +198,45 @@ object PostgresGeneratorTestData {
   val postgresSelectStringComplex: String =
     "SELECT id, bankBalance, name, isStudent, dateOfBirth, timeOfDay, expiry FROM Users WHERE ((isStudent IS NULL) OR (Users.id >= 1)) AND ((isStudent IS NOT NULL) OR (NOT (Users.expiry < TIMESTAMP '2020-02-03 00:00:00+00')));"
 
+  val readStatementWithWherePrepared: Read = Read(
+    "Users",
+    Seq(
+      Column("id"),
+      Column("bankBalance"),
+      Column("name"),
+      Column("isStudent"),
+      Column("dateOfBirth"),
+      Column("timeOfDay"),
+      Column("expiry"),
+    ),
+    Some(
+      PreparedComparison("Users.id", Equal),
+    ),
+  )
+
+  val postgresSelectStringWithWherePrepared: String =
+    """SELECT id, bankBalance, name, isStudent, dateOfBirth, timeOfDay, expiry FROM Users WHERE Users.id = $1;"""
+
+  val readStatementWithNestedWherePrepared: Read = Read(
+    "Users",
+    Seq(Column("bankBalance")),
+    Some(
+      Conjunction(
+        Disjunction(
+          Inverse(PreparedComparison("Users.id", LessEqual)),
+          PreparedComparison("Users.isStudent", Equal),
+        ),
+        PreparedComparison("Users.timeOfDay", Equal),
+      ),
+    ),
+  )
+
+  val postgresSelectStringWithNestedWherePrepared: String =
+    """SELECT bankBalance FROM Users WHERE ((NOT (Users.id <= $1)) OR (Users.isStudent = $2)) AND (Users.timeOfDay = $3);"""
+
+  val postgresSelectStringWithNestedWherePreparedUsingQuestionMarks: String =
+    """SELECT bankBalance FROM Users WHERE ((NOT (Users.id <= ?)) OR (Users.isStudent = ?)) AND (Users.timeOfDay = ?);"""
+
   val insertStatement: Insert = Insert(
     "Users",
     Seq(
@@ -299,6 +338,86 @@ object PostgresGeneratorTestData {
   val postgresUpdateStringWithWhereAndReturn: String =
     """UPDATE Users SET bankBalance = 123.456, name = 'Will' WHERE Users.id = 123456 RETURNING bankBalance;"""
 
+  val updateStatementPrepared: Update = Update(
+    "Users",
+    Seq(
+      Assignment(Column("bankBalance"), PreparedValue),
+      Assignment(Column("name"), PreparedValue),
+    ),
+    None,
+  )
+
+  val postgresUpdateStringPrepared: String =
+    """UPDATE Users SET bankBalance = $1, name = $2;"""
+
+  val updateStatementPreparedWithWhere: Update = Update(
+    "Users",
+    Seq(
+      Assignment(Column("bankBalance"), PreparedValue),
+      Assignment(Column("name"), PreparedValue),
+    ),
+    Some(
+      Comparison("Users.id", Equal, "123456"),
+    ),
+  )
+
+  val postgresUpdateStringPreparedWithWhere: String =
+    """UPDATE Users SET bankBalance = $1, name = $2 WHERE Users.id = 123456;"""
+
+  val updateStatementPreparedWithWherePrepared: Update = Update(
+    "Users",
+    Seq(
+      Assignment(Column("bankBalance"), PreparedValue),
+      Assignment(Column("name"), PreparedValue),
+    ),
+    Some(
+      PreparedComparison("Users.id", Equal),
+    ),
+  )
+
+  val postgresUpdateStringPreparedWithWherePrepared: String =
+    """UPDATE Users SET bankBalance = $1, name = $2 WHERE Users.id = $3;"""
+
+  val updateStatementPreparedWithNestedWherePrepared: Update = Update(
+    "Users",
+    Seq(
+      Assignment(Column("bankBalance"), PreparedValue),
+      Assignment(Column("name"), PreparedValue),
+    ),
+    Some(
+      Conjunction(
+        Disjunction(
+          Inverse(PreparedComparison("Users.id", LessEqual)),
+          PreparedComparison("Users.isStudent", Equal),
+        ),
+        PreparedComparison("Users.timeOfDay", Equal),
+      ),
+    ),
+  )
+
+  val postgresUpdateStringPreparedWithNestedWherePrepared: String =
+    """UPDATE Users SET bankBalance = $1, name = $2 WHERE ((NOT (Users.id <= $3)) OR (Users.isStudent = $4)) AND (Users.timeOfDay = $5);"""
+
+  val updateStatementPreparedAndValuesWithNestedWherePrepared: Update = Update(
+    "Users",
+    Seq(
+      Assignment(Column("bankBalance"), PreparedValue),
+      Assignment(Column("name"), Value("'Hello'")),
+    ),
+    Some(
+      Conjunction(
+        Disjunction(
+          Inverse(PreparedComparison("Users.id", LessEqual)),
+          PreparedComparison("Users.isStudent", Equal),
+        ),
+        PreparedComparison("Users.timeOfDay", Equal),
+      ),
+    ),
+  )
+
+  val postgresUpdateStringPreparedAndValuesWithNestedWherePrepared: String =
+    """UPDATE Users SET bankBalance = $1, name = 'Hello' WHERE ((NOT (Users.id <= $2)) OR (Users.isStudent = $3)) AND (Users.timeOfDay = $4);"""
+
   val deleteStatement: Delete = Delete(
     "Users",
   )
@@ -315,6 +434,32 @@ object PostgresGeneratorTestData {
 
   val postgresDeleteStringWithWhere: String =
     """DELETE FROM Users WHERE Users.id = 123456;"""
+
+  val deleteStatementWithWherePrepared: Delete = Delete(
+    "Users",
+    Some(
+      PreparedComparison("Users.id", Equal),
+    ),
+  )
+
+  val postgresDeleteStringWithWherePrepared: String =
+    """DELETE FROM Users WHERE Users.id = $1;"""
+
+  val deleteStatementWithNestedWherePrepared: Delete = Delete(
+    "Users",
+    Some(
+      Conjunction(
+        Disjunction(
+          Inverse(PreparedComparison("Users.id", LessEqual)),
+          PreparedComparison("Users.isStudent", Equal),
+        ),
+        PreparedComparison("Users.timeOfDay", Equal),
+      ),
+    ),
+  )
+
+  val postgresDeleteStringWithNestedWherePrepared: String =
+    """DELETE FROM Users WHERE ((NOT (Users.id <= $1)) OR (Users.isStudent = $2)) AND (Users.timeOfDay = $3);"""
 
   val dropStatement: Drop = Drop(
     "Users",


### PR DESCRIPTION
Sorry for the PR size, quite a lot of changes were needed.

We now additionally support queries of the following structure:
- `UPDATE table SET value1 = $1, value2 = $2` - Prepared updates 
- `UPDATE table SET value1 = 5, value2 = $1` - Mixed prepared and provided updates
- `SELECT * FROM table WHERE value1 = $1` - Prepared WHERE clauses 

Also had to make sure that when we're doing `Disjunction` and `Conjunction` that the dollars are provided in the correct order, so have added some tests for that.

The final thing to support is mixed prepared and provided values in `INSERT` statements, but I'll do that in a follow up PR since this one was getting big. I'll also add all of the queries from `spec-golang` as unit tests in that PR to make sure we hit everything we need