### PR TITLE
[sql-gen] Allow arguments to be preprovided to the insert query

### DIFF
--- a/src/it/scala/temple/generate/database/PostgresGeneratorIntegrationTest.scala
+++ b/src/it/scala/temple/generate/database/PostgresGeneratorIntegrationTest.scala
@@ -7,7 +7,8 @@ import org.postgresql.util.PSQLException
 import org.scalatest.{BeforeAndAfter, Matchers}
 import temple.containers.PostgresSpec
 import temple.generate.database.ast.ColType.BlobCol
-import temple.generate.database.ast.{Column, ColumnDef, Statement}
+import temple.generate.database.ast.Expression.PreparedValue
+import temple.generate.database.ast.{Assignment, Column, ColumnDef, Statement}
 import temple.utils.FileUtils
 
 class PostgresGeneratorIntegrationTest extends PostgresSpec with Matchers with BeforeAndAfter {
@@ -149,7 +150,7 @@ class PostgresGeneratorIntegrationTest extends PostgresSpec with Matchers with B
     val createStatement = Statement.Create("temple_user", Seq(ColumnDef("picture", BlobCol)))
     executeWithoutResults(PostgresGenerator.generate(createStatement))
 
-    val insertStatement = Statement.Insert("temple_user", Seq(Column("picture")))
+    val insertStatement = Statement.Insert("temple_user", Seq(Assignment(Column("picture"), PreparedValue)))
     val insertData      = Seq(PreparedVariable.BlobVariable(fileContents))
     executePreparedWithoutResults(PostgresGenerator.generate(insertStatement), insertData)
 

--- a/src/it/scala/temple/generate/database/TestData.scala
+++ b/src/it/scala/temple/generate/database/TestData.scala
@@ -215,36 +215,36 @@ object TestData {
   val insertStatement: Insert = Insert(
     "temple_user",
     Seq(
-      Column("id"),
-      Column("anotherId"),
-      Column("yetAnotherId"),
-      Column("bankBalance"),
-      Column("bigBankBalance"),
-      Column("name"),
-      Column("initials"),
-      Column("isStudent"),
-      Column("dateOfBirth"),
-      Column("timeOfDay"),
-      Column("expiry"),
-      Column("veryUnique"),
+      Assignment(Column("id"), PreparedValue),
+      Assignment(Column("anotherId"), PreparedValue),
+      Assignment(Column("yetAnotherId"), PreparedValue),
+      Assignment(Column("bankBalance"), PreparedValue),
+      Assignment(Column("bigBankBalance"), PreparedValue),
+      Assignment(Column("name"), PreparedValue),
+      Assignment(Column("initials"), PreparedValue),
+      Assignment(Column("isStudent"), PreparedValue),
+      Assignment(Column("dateOfBirth"), PreparedValue),
+      Assignment(Column("timeOfDay"), PreparedValue),
+      Assignment(Column("expiry"), PreparedValue),
+      Assignment(Column("veryUnique"), PreparedValue),
     ),
   )
 
   val insertStatementWithReturn: Insert = Insert(
     "temple_user",
     Seq(
-      Column("id"),
-      Column("anotherId"),
-      Column("yetAnotherId"),
-      Column("bankBalance"),
-      Column("bigBankBalance"),
-      Column("name"),
-      Column("initials"),
-      Column("isStudent"),
-      Column("dateOfBirth"),
-      Column("timeOfDay"),
-      Column("expiry"),
-      Column("veryUnique"),
+      Assignment(Column("id"), PreparedValue),
+      Assignment(Column("anotherId"), PreparedValue),
+      Assignment(Column("yetAnotherId"), PreparedValue),
+      Assignment(Column("bankBalance"), PreparedValue),
+      Assignment(Column("bigBankBalance"), PreparedValue),
+      Assignment(Column("name"), PreparedValue),
+      Assignment(Column("initials"), PreparedValue),
+      Assignment(Column("isStudent"), PreparedValue),
+      Assignment(Column("dateOfBirth"), PreparedValue),
+      Assignment(Column("timeOfDay"), PreparedValue),
+      Assignment(Column("expiry"), PreparedValue),
+      Assignment(Column("veryUnique"), PreparedValue),
     ),
     Seq(
       Column("id"),
@@ -254,24 +254,24 @@ object TestData {
   val insertStatementForUniqueConstraint: Insert = Insert(
     "unique_test",
     Seq(
-      Column("itemID"),
-      Column("createdAt"),
+      Assignment(Column("itemID"), PreparedValue),
+      Assignment(Column("createdAt"), PreparedValue),
     ),
   )
 
   val insertStatementForReferenceConstraint: Insert = Insert(
     "reference_test",
     Seq(
-      Column("itemID"),
-      Column("userID"),
+      Assignment(Column("itemID"), PreparedValue),
+      Assignment(Column("userID"), PreparedValue),
     ),
   )
 
   val insertStatementForCheckConstraint: Insert = Insert(
     "check_test",
     Seq(
-      Column("itemID"),
-      Column("value"),
+      Assignment(Column("itemID"), PreparedValue),
+      Assignment(Column("value"), PreparedValue),
     ),
   )
 

--- a/src/main/scala/temple/generate/database/ast/Statement.scala
+++ b/src/main/scala/temple/generate/database/ast/Statement.scala
@@ -4,9 +4,11 @@ package temple.generate.database.ast
 sealed trait Statement
 
 object Statement {
-  case class Create(tableName: String, columns: Seq[ColumnDef])                                  extends Statement
-  case class Read(tableName: String, columns: Seq[Column], condition: Option[Condition] = None)  extends Statement
-  case class Insert(tableName: String, columns: Seq[Column], returnColumns: Seq[Column] = Seq()) extends Statement
+  case class Create(tableName: String, columns: Seq[ColumnDef])                                 extends Statement
+  case class Read(tableName: String, columns: Seq[Column], condition: Option[Condition] = None) extends Statement
+
+  case class Insert(tableName: String, assignment: Seq[Assignment], returnColumns: Seq[Column] = Seq())
+      extends Statement
 
   case class Update(
     tableName: String,

--- a/src/test/scala/temple/generate/database/PostgresGeneratorTest.scala
+++ b/src/test/scala/temple/generate/database/PostgresGeneratorTest.scala
@@ -38,6 +38,10 @@ class PostgresGeneratorTest extends FlatSpec with Matchers {
     PostgresGenerator.generate(TestData.insertStatementWithReturn) shouldBe TestData.postgresInsertStringWithReturn
   }
 
+  it should "generate correct INSERT statements with prepared and provided values" in {
+    PostgresGenerator.generate(TestData.insertStatementWithProvidedValue) shouldBe TestData.postgresInsertStringWithProvidedValue
+  }
+
   it should "handle conjunctions in WHERE correctly" in {
     PostgresGenerator.generate(TestData.readStatementWithWhereConjunction) shouldBe TestData.postgresSelectStringWithWhereConjunction
   }
@@ -130,5 +134,25 @@ class PostgresGeneratorTest extends FlatSpec with Matchers {
 
   it should "handle DELETE statements with nested prepared WHERE statement correctly" in {
     PostgresGenerator.generate(TestData.deleteStatementWithNestedWherePrepared) shouldBe TestData.postgresDeleteStringWithNestedWherePrepared
+  }
+
+  it should "handle a list query from spec-golang" in {
+    PostgresGenerator.generate(TestData.specGolangList) shouldBe TestData.specGolangListPostgresString
+  }
+
+  it should "handle a create query from spec-golang" in {
+    PostgresGenerator.generate(TestData.specGolangCreate) shouldBe TestData.specGolangCreatePostgresString
+  }
+
+  it should "handle a read query from spec-golang" in {
+    PostgresGenerator.generate(TestData.specGolangRead) shouldBe TestData.specGolangReadPostgresString
+  }
+
+  it should "handle a update query from spec-golang" in {
+    PostgresGenerator.generate(TestData.specGolangUpdate) shouldBe TestData.specGolangUpdatePostgresString
+  }
+
+  it should "handle a delete query from spec-golang" in {
+    PostgresGenerator.generate(TestData.specGolangDelete) shouldBe TestData.specGolangDeletePostgresString
   }
 }

--- a/src/test/scala/temple/generate/database/PostgresGeneratorTestData.scala
+++ b/src/test/scala/temple/generate/database/PostgresGeneratorTestData.scala
@@ -240,13 +240,13 @@ object PostgresGeneratorTestData {
   val insertStatement: Insert = Insert(
     "Users",
     Seq(
-      Column("id"),
-      Column("bankBalance"),
-      Column("name"),
-      Column("isStudent"),
-      Column("dateOfBirth"),
-      Column("timeOfDay"),
-      Column("expiry"),
+      Assignment(Column("id"), PreparedValue),
+      Assignment(Column("bankBalance"), PreparedValue),
+      Assignment(Column("name"), PreparedValue),
+      Assignment(Column("isStudent"), PreparedValue),
+      Assignment(Column("dateOfBirth"), PreparedValue),
+      Assignment(Column("timeOfDay"), PreparedValue),
+      Assignment(Column("expiry"), PreparedValue),
     ),
   )
 
@@ -259,13 +259,13 @@ object PostgresGeneratorTestData {
   val insertStatementWithReturn: Insert = Insert(
     "Users",
     Seq(
-      Column("id"),
-      Column("bankBalance"),
-      Column("name"),
-      Column("isStudent"),
-      Column("dateOfBirth"),
-      Column("timeOfDay"),
-      Column("expiry"),
+      Assignment(Column("id"), PreparedValue),
+      Assignment(Column("bankBalance"), PreparedValue),
+      Assignment(Column("name"), PreparedValue),
+      Assignment(Column("isStudent"), PreparedValue),
+      Assignment(Column("dateOfBirth"), PreparedValue),
+      Assignment(Column("timeOfDay"), PreparedValue),
+      Assignment(Column("expiry"), PreparedValue),
     ),
     Seq(
       Column("id"),
@@ -280,6 +280,22 @@ object PostgresGeneratorTestData {
 
   val postgresInsertStringWithReturn: String =
     "INSERT INTO Users (id, bankBalance, name, isStudent, dateOfBirth, timeOfDay, expiry) VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING id, bankBalance, name, isStudent, dateOfBirth, timeOfDay, expiry;"
+
+  val insertStatementWithProvidedValue: Insert = Insert(
+    "Users",
+    Seq(
+      Assignment(Column("id"), Value("180")),
+      Assignment(Column("bankBalance"), PreparedValue),
+      Assignment(Column("name"), PreparedValue),
+      Assignment(Column("isStudent"), PreparedValue),
+      Assignment(Column("dateOfBirth"), PreparedValue),
+      Assignment(Column("timeOfDay"), PreparedValue),
+      Assignment(Column("expiry"), PreparedValue),
+    ),
+  )
+
+  val postgresInsertStringWithProvidedValue: String =
+    "INSERT INTO Users (id, bankBalance, name, isStudent, dateOfBirth, timeOfDay, expiry) VALUES (180, $1, $2, $3, $4, $5, $6);"
 
   val updateStatement: Update = Update(
     "Users",
@@ -478,4 +494,95 @@ object PostgresGeneratorTestData {
 
   val postgresDropStringIfExists: String =
     """DROP TABLE Users IF EXISTS;"""
+
+  // Examples from spec-golang
+  val specGolangList: Read = Read(
+    "match",
+    Seq(
+      Column("id"),
+      Column("created_by"),
+      Column("userOne"),
+      Column("userTwo"),
+      Column("matchedOn"),
+    ),
+    Some(
+      PreparedComparison("created_by", Equal),
+    ),
+  )
+
+  val specGolangListPostgresString: String =
+    """SELECT id, created_by, userOne, userTwo, matchedOn FROM match WHERE created_by = $1;"""
+
+  val specGolangCreate: Insert = Insert(
+    "match",
+    Seq(
+      Assignment(Column("id"), PreparedValue),
+      Assignment(Column("created_by"), PreparedValue),
+      Assignment(Column("userOne"), PreparedValue),
+      Assignment(Column("userTwo"), PreparedValue),
+      Assignment(Column("matchedOn"), Value("NOW()")),
+    ),
+    Seq(
+      Column("id"),
+      Column("created_by"),
+      Column("userOne"),
+      Column("userTwo"),
+      Column("matchedOn"),
+    ),
+  )
+
+  val specGolangCreatePostgresString: String =
+    """INSERT INTO match (id, created_by, userOne, userTwo, matchedOn) VALUES ($1, $2, $3, $4, NOW()) RETURNING id, created_by, userOne, userTwo, matchedOn;"""
+
+  val specGolangRead: Read = Read(
+    "match",
+    Seq(
+      Column("id"),
+      Column("created_by"),
+      Column("userOne"),
+      Column("userTwo"),
+      Column("matchedOn"),
+    ),
+    Some(
+      PreparedComparison("id", Equal),
+    ),
+  )
+
+  val specGolangReadPostgresString: String =
+    """SELECT id, created_by, userOne, userTwo, matchedOn FROM match WHERE id = $1;"""
+
+  val specGolangUpdate: Update = Update(
+    "match",
+    Seq(
+      Assignment(Column("userOne"), PreparedValue),
+      Assignment(Column("userTwo"), PreparedValue),
+      Assignment(Column("matchedOn"), Value("NOW()")),
+    ),
+    Some(
+      PreparedComparison("id", Equal),
+    ),
+    Seq(
+      Column("id"),
+      Column("created_by"),
+      Column("userOne"),
+      Column("userTwo"),
+      Column("matchedOn"),
+    ),
+  )
+
+  val specGolangUpdatePostgresString: String =
+    """UPDATE match SET userOne = $1, userTwo = $2, matchedOn = NOW() WHERE id = $3 RETURNING id, created_by, userOne, userTwo, matchedOn;"""
+
+  val specGolangDelete: Delete = Delete(
+    "match",
+    Some(
+      PreparedComparison(
+        "id",
+        Equal,
+      ),
+    ),
+  )
+
+  val specGolangDeletePostgresString: String =
+    """DELETE FROM match WHERE id = $1;"""
 }


### PR DESCRIPTION
Support INSERT statements where values are pre-provided

Also add unit tests for each query we make in `spec-golang`, so we know it works :P 