### PR TITLE
[prom] Add prometheus config generator

### DIFF
--- a/src/main/scala/temple/DSL/semantics/Analyzer.scala
+++ b/src/main/scala/temple/DSL/semantics/Analyzer.scala
@@ -1,6 +1,6 @@
 package temple.DSL.semantics
 
-import MetadataParser.assertNoParameters
+import temple.DSL.semantics.MetadataParser.assertNoParameters
 import temple.DSL.syntax
 import temple.DSL.syntax.{Arg, Args, DSLRootItem, Entry}
 import temple.ast.ArgType._

--- a/src/main/scala/temple/ast/ArgMap.scala
+++ b/src/main/scala/temple/ast/ArgMap.scala
@@ -1,7 +1,7 @@
 package temple.ast
 
-import temple.DSL.syntax.Arg
 import temple.DSL.semantics.SemanticContext
+import temple.DSL.syntax.Arg
 
 /**
   * A wrapper around a map of arguments, as produced by [[temple.DSL.semantics#parseParameters]], with methods added

--- a/src/main/scala/temple/builder/MetricsBuilder.scala
+++ b/src/main/scala/temple/builder/MetricsBuilder.scala
@@ -1,8 +1,8 @@
 package temple.builder
 
 import temple.generate.CRUD.CRUD
-import temple.generate.metrics.grafana.ast.{Datasource, Row}
 import temple.generate.metrics.grafana.ast.Row.{Metric, Query}
+import temple.generate.metrics.grafana.ast.{Datasource, Row}
 
 object MetricsBuilder {
 

--- a/src/main/scala/temple/builder/project/ProjectBuilder.scala
+++ b/src/main/scala/temple/builder/project/ProjectBuilder.scala
@@ -11,7 +11,7 @@ import temple.generate.database.ast.Statement
 import temple.generate.database.{PostgresContext, PostgresGenerator}
 import temple.generate.docker.DockerfileGenerator
 import temple.generate.kube.KubernetesGenerator
-import temple.generate.metrics.grafana.ast.{Datasource, GrafanaDatasourceConfig}
+import temple.generate.metrics.grafana.ast.Datasource
 import temple.generate.metrics.grafana.{GrafanaDashboardConfigGenerator, GrafanaDashboardGenerator, GrafanaDatasourceConfigGenerator}
 import temple.utils.StringUtils
 

--- a/src/main/scala/temple/generate/metrics/grafana/GrafanaDashboardConfigGenerator.scala
+++ b/src/main/scala/temple/generate/metrics/grafana/GrafanaDashboardConfigGenerator.scala
@@ -1,8 +1,8 @@
 package temple.generate.metrics.grafana
 
-import io.circe.yaml.Printer
 import io.circe.syntax._
-import temple.generate.metrics.grafana.ast.{GrafanaDashboardConfig, Datasource}
+import io.circe.yaml.Printer
+import temple.generate.metrics.grafana.ast.{Datasource, GrafanaDashboardConfig}
 
 object GrafanaDashboardConfigGenerator {
 

--- a/src/main/scala/temple/generate/metrics/prometheus/PrometheusConfigGenerator.scala
+++ b/src/main/scala/temple/generate/metrics/prometheus/PrometheusConfigGenerator.scala
@@ -1,0 +1,12 @@
+package temple.generate.metrics.prometheus
+
+import io.circe.yaml.Printer
+import io.circe.syntax._
+import io.circe.yaml.Printer.FlowStyle
+import temple.generate.metrics.prometheus.ast.{PrometheusConfig, PrometheusJob}
+
+object PrometheusConfigGenerator {
+
+  def generate(jobs: Seq[PrometheusJob]): String =
+    Printer(preserveOrder = true).pretty(PrometheusConfig(jobs).asJson)
+}

--- a/src/main/scala/temple/generate/metrics/prometheus/PrometheusConfigGenerator.scala
+++ b/src/main/scala/temple/generate/metrics/prometheus/PrometheusConfigGenerator.scala
@@ -1,8 +1,7 @@
 package temple.generate.metrics.prometheus
 
-import io.circe.yaml.Printer
 import io.circe.syntax._
-import io.circe.yaml.Printer.FlowStyle
+import io.circe.yaml.Printer
 import temple.generate.metrics.prometheus.ast.{PrometheusConfig, PrometheusJob}
 
 object PrometheusConfigGenerator {

--- a/src/main/scala/temple/generate/metrics/prometheus/ast/PrometheusConfig.scala
+++ b/src/main/scala/temple/generate/metrics/prometheus/ast/PrometheusConfig.scala
@@ -1,0 +1,17 @@
+package temple.generate.metrics.prometheus.ast
+
+import io.circe.Json
+import temple.generate.JsonEncodable
+
+import scala.collection.immutable.ListMap
+
+case class PrometheusConfig(jobs: Seq[PrometheusJob]) extends JsonEncodable.Object {
+
+  override def jsonEntryIterator: IterableOnce[(String, Json)] = Seq(
+    "global" ~> ListMap(
+      "scrape_interval"     ~> "15s",
+      "evaluation_interval" ~> "15s",
+    ),
+    "scrape_configs" ~> jobs,
+  )
+}

--- a/src/main/scala/temple/generate/metrics/prometheus/ast/PrometheusJob.scala
+++ b/src/main/scala/temple/generate/metrics/prometheus/ast/PrometheusJob.scala
@@ -1,0 +1,18 @@
+package temple.generate.metrics.prometheus.ast
+
+import io.circe.Json
+import temple.generate.JsonEncodable
+
+import scala.collection.immutable.ListMap
+
+case class PrometheusJob(jobName: String, metricsUrl: String) extends JsonEncodable.Object {
+
+  override def jsonEntryIterator: IterableOnce[(String, Json)] = Seq(
+    "job_name" ~> jobName,
+    "static_configs" ~> Seq(
+      ListMap(
+        "targets" ~> Seq(metricsUrl),
+      ),
+    ),
+  )
+}

--- a/src/main/scala/temple/generate/server/ServiceRoot.scala
+++ b/src/main/scala/temple/generate/server/ServiceRoot.scala
@@ -1,8 +1,8 @@
 package temple.generate.server
 
 import temple.ast.Attribute
-import temple.generate.CRUD.CRUD
 import temple.ast.Metadata.Database
+import temple.generate.CRUD.CRUD
 
 import scala.collection.immutable.ListMap
 

--- a/src/main/scala/temple/generate/target/openapi/OpenAPIGenerator.scala
+++ b/src/main/scala/temple/generate/target/openapi/OpenAPIGenerator.scala
@@ -2,9 +2,8 @@ package temple.generate.target.openapi
 
 import io.circe.syntax._
 import io.circe.yaml.Printer
+import temple.ast.{Annotation, Attribute}
 import temple.ast.AttributeType._
-import temple.ast.Annotation
-import temple.ast.Attribute
 import temple.collection.FlagMapView
 import temple.generate.CRUD._
 import temple.generate.FileSystem._

--- a/src/main/scala/temple/generate/target/openapi/ast/OpenAPIFile.scala
+++ b/src/main/scala/temple/generate/target/openapi/ast/OpenAPIFile.scala
@@ -1,9 +1,9 @@
 package temple.generate.target.openapi.ast
 
 import io.circe.Json
+import io.circe.generic.auto._
 import temple.generate.JsonEncodable
 import temple.generate.target.openapi.ast.OpenAPIFile.{Components, Info}
-import io.circe.generic.auto._
 
 import scala.Option.when
 

--- a/src/main/scala/temple/utils/FileUtils.scala
+++ b/src/main/scala/temple/utils/FileUtils.scala
@@ -2,6 +2,7 @@ package temple.utils
 
 import java.nio.charset.Charset
 import java.nio.file.{Files, Paths}
+
 import scala.io.Source
 
 /** Helper functions useful for manipulating files */

--- a/src/test/scala/temple/DSL/semantics/SemanticAnalyzerTest.scala
+++ b/src/test/scala/temple/DSL/semantics/SemanticAnalyzerTest.scala
@@ -2,11 +2,11 @@ package temple.DSL.semantics
 
 import org.scalatest.{FlatSpec, Matchers}
 import temple.DSL.semantics.Analyzer.parseSemantics
-import temple.ast.AttributeType._
+import temple.DSL.semantics.SemanticAnalyzerTest._
 import temple.DSL.syntax
 import temple.DSL.syntax.Arg._
 import temple.DSL.syntax.{Args, DSLRootItem, Entry}
-import SemanticAnalyzerTest._
+import temple.ast.AttributeType._
 import temple.ast.{Attribute, ProjectBlock, ServiceBlock, Templefile}
 
 class SemanticAnalyzerTest extends FlatSpec with Matchers {

--- a/src/test/scala/temple/DSL/semantics/TempleBlockTest.scala
+++ b/src/test/scala/temple/DSL/semantics/TempleBlockTest.scala
@@ -1,7 +1,7 @@
 package temple.DSL.semantics
 
 import org.scalatest.{FlatSpec, Matchers}
-import temple.ast.{Metadata, ProjectBlock, ServiceBlock, TargetBlock, Templefile}
+import temple.ast._
 
 class TempleBlockTest extends FlatSpec with Matchers {
 

--- a/src/test/scala/temple/builder/DockerfileBuilderTestData.scala
+++ b/src/test/scala/temple/builder/DockerfileBuilderTestData.scala
@@ -1,7 +1,7 @@
 package temple.builder
 
 import temple.generate.docker.ast.DockerfileRoot
-import temple.generate.docker.ast.Statement.{Copy, Entrypoint, Expose, From, Run, WorkDir}
+import temple.generate.docker.ast.Statement._
 
 object DockerfileBuilderTestData {
 

--- a/src/test/scala/temple/generate/metrics/grafana/GrafanaDashboardGeneratorTest.scala
+++ b/src/test/scala/temple/generate/metrics/grafana/GrafanaDashboardGeneratorTest.scala
@@ -4,7 +4,6 @@ import org.scalatest.{FlatSpec, Matchers}
 import temple.generate.metrics.grafana.GrafanaDashboardGeneratorTestUtils.{makeTarget, _}
 import temple.generate.metrics.grafana.ast.Row.{Metric, Query}
 import temple.generate.metrics.grafana.ast.{Datasource, Row}
-import temple.generate.utils.CodeTerm.mkCode
 
 class GrafanaDashboardGeneratorTest extends FlatSpec with Matchers {
   behavior of "GrafanaDashboardGenerator"

--- a/src/test/scala/temple/generate/metrics/prometheus/PrometheusConfigGeneratorTest.scala
+++ b/src/test/scala/temple/generate/metrics/prometheus/PrometheusConfigGeneratorTest.scala
@@ -1,0 +1,19 @@
+package temple.generate.metrics.prometheus
+
+import org.scalatest.{FlatSpec, Matchers}
+import temple.generate.metrics.prometheus.ast.PrometheusJob
+
+class PrometheusConfigGeneratorTest extends FlatSpec with Matchers {
+  behavior of "PrometheusConfigGenerator"
+
+  it should "generate correct config" in {
+    val generated = PrometheusConfigGenerator.generate(
+      Seq(
+        PrometheusJob("user", "user:2112"),
+        PrometheusJob("match", "match:2113"),
+        PrometheusJob("auth", "auth:2114"),
+      ),
+    )
+    generated shouldBe PrometheusConfigGeneratorTestData.prometheusConfig
+  }
+}

--- a/src/test/scala/temple/generate/metrics/prometheus/PrometheusConfigGeneratorTestData.scala
+++ b/src/test/scala/temple/generate/metrics/prometheus/PrometheusConfigGeneratorTestData.scala
@@ -1,0 +1,23 @@
+package temple.generate.metrics.prometheus
+
+object PrometheusConfigGeneratorTestData {
+
+  val prometheusConfig: String =
+    """global:
+      |  scrape_interval: 15s
+      |  evaluation_interval: 15s
+      |scrape_configs:
+      |- job_name: user
+      |  static_configs:
+      |  - targets:
+      |    - user:2112
+      |- job_name: match
+      |  static_configs:
+      |  - targets:
+      |    - match:2113
+      |- job_name: auth
+      |  static_configs:
+      |  - targets:
+      |    - auth:2114
+      |""".stripMargin
+}

--- a/src/test/scala/temple/utils/StringUtilsTest.scala
+++ b/src/test/scala/temple/utils/StringUtilsTest.scala
@@ -1,7 +1,7 @@
 package temple.utils
 
 import org.scalatest.{FlatSpec, Matchers}
-import temple.utils.StringUtils.{indent, snakeCase, españolQue}
+import temple.utils.StringUtils.{españolQue, indent, snakeCase}
 
 class StringUtilsTest extends FlatSpec with Matchers {
 


### PR DESCRIPTION
Add the final `.yml` file that needs to be generated for metrics: `prometheus.yml`

This PR generates it (essentially following https://github.com/TempleEight/spec-golang/blob/develop/prometheus/prometheus.yml), and the next will add the mapping.

I did have to change the generated file slightly, since the one prometheus gives as a template mixes styles of sequences, so I've stuck to one here.