### PR TITLE
[go-gen] Refactor to pass around service root rather than deconstructing

### DIFF
--- a/src/main/scala/temple/generate/server/go/auth/GoAuthServiceCommGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/auth/GoAuthServiceCommGenerator.scala
@@ -1,14 +1,15 @@
 package temple.generate.server.go.auth
 
+import temple.generate.server.AuthServiceRoot
 import temple.generate.utils.CodeTerm.{CodeWrap, mkCode}
 import temple.utils.FileUtils
 import temple.utils.StringUtils.doubleQuote
 
 object GoAuthServiceCommGenerator {
 
-  private[auth] def generateImports(module: String): String = {
+  private[auth] def generateImports(root: AuthServiceRoot): String = {
     val standardImports = Seq("encoding/json", "errors", "fmt", "io/ioutil", "net/http", "net/url").map(doubleQuote)
-    val customImports   = doubleQuote(s"$module/util")
+    val customImports   = doubleQuote(s"${root.module}/util")
     mkCode("import", CodeWrap.parens.tabbed(standardImports, "", customImports))
   }
 

--- a/src/main/scala/temple/generate/server/go/auth/GoAuthServiceGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/auth/GoAuthServiceGenerator.scala
@@ -7,19 +7,17 @@ import temple.generate.utils.CodeTerm.mkCode
 
 object GoAuthServiceGenerator extends AuthServiceGenerator {
 
-  override def generate(authServiceRoot: AuthServiceRoot): Files =
+  override def generate(root: AuthServiceRoot): Files =
     /* TODO
      * auth.go main
      * dao.go
      * config.json
      */
     Map(
-      File("auth", "go.mod") -> GoCommonGenerator.generateMod(authServiceRoot.module),
+      File("auth", "go.mod") -> GoCommonGenerator.generateMod(root.module),
       File("auth", "auth.go") -> mkCode.doubleLines(
         GoCommonGenerator.generatePackage("main"),
-        GoAuthServiceMainGenerator.generateImports(
-          authServiceRoot.module,
-        ),
+        GoAuthServiceMainGenerator.generateImports(root),
         GoAuthServiceMainGenerator.generateStructs(),
         GoAuthServiceMainGenerator.generateRouter(),
         GoAuthServiceMainGenerator.generateMain(),
@@ -30,7 +28,7 @@ object GoAuthServiceGenerator extends AuthServiceGenerator {
       File("auth/dao", "errors.go") -> GoAuthServiceDAOGenerator.generateErrors(),
       File("auth/comm", "handler.go") -> mkCode.doubleLines(
         GoCommonGenerator.generatePackage("comm"),
-        GoAuthServiceCommGenerator.generateImports(authServiceRoot.module),
+        GoAuthServiceCommGenerator.generateImports(root),
         GoAuthServiceCommGenerator.generateStructs(),
         GoCommonCommGenerator.generateInit(),
         GoAuthServiceCommGenerator.generateCreateJWTCredential(),

--- a/src/main/scala/temple/generate/server/go/auth/GoAuthServiceMainGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/auth/GoAuthServiceMainGenerator.scala
@@ -1,20 +1,21 @@
 package temple.generate.server.go.auth
 
+import temple.generate.server.AuthServiceRoot
 import temple.generate.utils.CodeTerm.{CodeWrap, mkCode}
 import temple.utils.FileUtils
 import temple.utils.StringUtils.doubleQuote
 
 object GoAuthServiceMainGenerator {
 
-  private[auth] def generateImports(module: String): String = {
+  private[auth] def generateImports(root: AuthServiceRoot): String = {
     val standardImports = Seq("encoding/json", "flag", "fmt", "log", "net/http", "time").map(doubleQuote)
 
     val officialImports = doubleQuote("golang.org/x/crypto/bcrypt")
 
     val customImports = Seq(
-      doubleQuote(s"$module/comm"),
-      doubleQuote(s"$module/dao"),
-      doubleQuote(s"$module/util"),
+      doubleQuote(s"${root.module}/comm"),
+      doubleQuote(s"${root.module}/dao"),
+      doubleQuote(s"${root.module}/util"),
       s"valid ${doubleQuote("github.com/asaskevich/govalidator")}",
       doubleQuote("github.com/dgrijalva/jwt-go"),
       doubleQuote("github.com/google/uuid"),

--- a/src/main/scala/temple/generate/server/go/common/GoCommonGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/common/GoCommonGenerator.scala
@@ -2,6 +2,7 @@ package temple.generate.server.go.common
 
 import temple.ast.AttributeType
 import temple.ast.AttributeType._
+import temple.generate.server.ServiceRoot
 import temple.generate.utils.CodeTerm.{CodeWrap, mkCode}
 
 object GoCommonGenerator {

--- a/src/main/scala/temple/generate/server/go/service/GoServiceCommGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/GoServiceCommGenerator.scala
@@ -1,13 +1,14 @@
 package temple.generate.server.go.service
 
+import temple.generate.server.ServiceRoot
 import temple.generate.utils.CodeTerm.{CodeWrap, mkCode}
 
 object GoServiceCommGenerator {
 
-  private[service] def generateImports(module: String): String = mkCode(
+  private[service] def generateImports(root: ServiceRoot): String = mkCode(
     "import",
     CodeWrap.parens.tabbed(
-      s""""$module/util"""",
+      s""""${root.module}/util"""",
     ),
   )
 

--- a/src/main/scala/temple/generate/server/go/service/dao/GoServiceDAOGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/dao/GoServiceDAOGenerator.scala
@@ -4,7 +4,7 @@ import temple.ast.{Attribute, AttributeType}
 import temple.generate.CRUD._
 import temple.generate.server.go.common.GoCommonDAOGenerator
 import temple.generate.server.go.common.GoCommonGenerator.generateGoType
-import temple.generate.server.{CreatedByAttribute, IDAttribute}
+import temple.generate.server.{CreatedByAttribute, IDAttribute, ServiceRoot}
 import temple.generate.utils.CodeTerm.{CodeWrap, mkCode}
 import temple.generate.utils.CodeUtils
 import temple.utils.StringUtils.doubleQuote
@@ -14,11 +14,11 @@ import scala.collection.immutable.ListMap
 
 object GoServiceDAOGenerator {
 
-  private[service] def generateImports(attributes: Map[String, Attribute], module: String): String = {
+  private[service] def generateImports(root: ServiceRoot): String = {
     // Check if attributes contains an attribute of type date, time or datetime
     val containsTime =
       Set[AttributeType](AttributeType.DateType, AttributeType.TimeType, AttributeType.DateTimeType)
-        .intersect(attributes.values.map(_.attributeType).toSet)
+        .intersect(root.attributes.values.map(_.attributeType).toSet)
         .nonEmpty
 
     mkCode(
@@ -28,7 +28,7 @@ object GoServiceDAOGenerator {
         doubleQuote("fmt"),
         when(containsTime) { doubleQuote("time") },
         "",
-        doubleQuote(s"$module/util"),
+        doubleQuote(s"${root.module}/util"),
         doubleQuote("github.com/google/uuid"),
         "",
         "// pq acts as the driver for SQL requests",
@@ -37,30 +37,25 @@ object GoServiceDAOGenerator {
     )
   }
 
-  private[dao] def generateDAOFunctionName(operation: CRUD, serviceName: String): String =
-    s"$operation${serviceName.capitalize}"
+  private[dao] def generateDAOFunctionName(root: ServiceRoot, operation: CRUD): String =
+    s"$operation${root.name.capitalize}"
 
-  private[service] def generateDatastoreObjectStruct(
-    serviceName: String,
-    idAttribute: IDAttribute,
-    createdByAttribute: CreatedByAttribute,
-    attributes: ListMap[String, Attribute],
-  ): String = {
-    val idMap = ListMap(idAttribute.name.toUpperCase -> generateGoType(idAttribute.attributeType))
-    val createdByMap = createdByAttribute match {
+  private[service] def generateDatastoreObjectStruct(root: ServiceRoot): String = {
+    val idMap = ListMap(root.idAttribute.name.toUpperCase -> generateGoType(root.idAttribute.attributeType))
+    val createdByMap = root.createdByAttribute match {
       case CreatedByAttribute.None =>
         ListMap.empty
       case enumerating: CreatedByAttribute.Enumerating =>
         ListMap(enumerating.name.capitalize -> generateGoType(enumerating.attributeType))
     }
-    val attributesMap = attributes.map {
+    val attributesMap = root.attributes.map {
       case (name, attribute) => (name.capitalize -> generateGoType(attribute.attributeType))
     }
 
     mkCode.lines(
-      s"// ${serviceName.capitalize} encapsulates the object stored in the datastore",
+      s"// ${root.name.capitalize} encapsulates the object stored in the datastore",
       mkCode(
-        s"type ${serviceName.capitalize} struct",
+        s"type ${root.name.capitalize} struct",
         CodeWrap.curly.tabbed(
           // Compose struct fields
           CodeUtils.pad(idMap ++ createdByMap ++ attributesMap),
@@ -78,16 +73,16 @@ object GoServiceDAOGenerator {
       when(operations.contains(Delete)) { GoCommonDAOGenerator.generateExecuteQuery() },
     )
 
-  private[service] def generateErrors(serviceName: String): String =
+  private[service] def generateErrors(root: ServiceRoot): String =
     mkCode.lines(
       "package dao",
       "",
       """import "fmt"""",
       "",
-      s"// Err${serviceName.capitalize}NotFound is returned when a $serviceName for the provided ID was not found",
-      s"type Err${serviceName.capitalize}NotFound string",
+      s"// Err${root.name.capitalize}NotFound is returned when a ${root.name} for the provided ID was not found",
+      s"type Err${root.name.capitalize}NotFound string",
       "",
-      s"func (e Err${serviceName.capitalize}NotFound) Error() string ${CodeWrap.curly
-        .tabbed(s"""return fmt.Sprintf("$serviceName not found with ID %d", string(e))""")}",
+      s"func (e Err${root.name.capitalize}NotFound) Error() string ${CodeWrap.curly
+        .tabbed(s"""return fmt.Sprintf("${root.name} not found with ID %d", string(e))""")}",
     )
 }

--- a/src/main/scala/temple/generate/server/go/service/dao/GoServiceDAOInterfaceGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/dao/GoServiceDAOInterfaceGenerator.scala
@@ -2,48 +2,40 @@ package temple.generate.server.go.service.dao
 
 import temple.generate.CRUD
 import temple.generate.CRUD.{CRUD, Create, Delete, List, Read, Update}
-import temple.generate.server.CreatedByAttribute
+import temple.generate.server.{CreatedByAttribute, ServiceRoot}
 import temple.generate.server.go.service.dao.GoServiceDAOGenerator.generateDAOFunctionName
 import temple.generate.utils.CodeTerm.{CodeWrap, mkCode}
 
 object GoServiceDAOInterfaceGenerator {
 
-  private def generateInterfaceFunctionReturnType(serviceName: String, operation: CRUD): String =
+  private def generateInterfaceFunctionReturnType(root: ServiceRoot, operation: CRUD): String =
     operation match {
-      case List                   => s"(*[]${serviceName.capitalize}, error)"
-      case Create | Read | Update => s"(*${serviceName.capitalize}, error)"
+      case List                   => s"(*[]${root.name.capitalize}, error)"
+      case Create | Read | Update => s"(*${root.name.capitalize}, error)"
       case Delete                 => "error"
     }
 
-  private[dao] def generateInterfaceFunction(
-    serviceName: String,
-    operation: CRUD,
-    createdByAttribute: CreatedByAttribute,
-  ): String = {
-    val functionName = generateDAOFunctionName(operation, serviceName)
-    val enumeratingByCreator = createdByAttribute match {
+  private[dao] def generateInterfaceFunction(root: ServiceRoot, operation: CRUD): String = {
+    val functionName = generateDAOFunctionName(root, operation)
+    val enumeratingByCreator = root.createdByAttribute match {
       case _: CreatedByAttribute.EnumerateByCreator => true
       case _                                        => false
     }
     val functionArgs = if (enumeratingByCreator || operation != CRUD.List) s"input ${functionName}Input" else ""
     mkCode(
       s"$functionName($functionArgs)",
-      generateInterfaceFunctionReturnType(serviceName, operation),
+      generateInterfaceFunctionReturnType(root, operation),
     )
   }
 
-  private[service] def generateInterface(
-    serviceName: String,
-    operations: Set[CRUD],
-    createdByAttribute: CreatedByAttribute,
-  ): String =
+  private[service] def generateInterface(root: ServiceRoot, operations: Set[CRUD]): String =
     mkCode.lines(
       "// Datastore provides the interface adopted by the DAO, allowing for mocking",
       mkCode(
         "type Datastore interface",
         CodeWrap.curly.tabbed(
           for (operation <- operations.toSeq.sorted)
-            yield generateInterfaceFunction(serviceName, operation, createdByAttribute),
+            yield generateInterfaceFunction(root, operation),
         ),
       ),
     )


### PR DESCRIPTION
* Refactors to passing around the service root, rather than parts of it
  * Makes the code less verbose

Shout out to the Holy Church of the Squat and Dab who were relocated from their homeland this week