### PR TITLE
[prom] Map into prometheus configuration generator

### DIFF
--- a/src/e2e/scala/temple/SimpleE2ETest.scala
+++ b/src/e2e/scala/temple/SimpleE2ETest.scala
@@ -26,7 +26,7 @@ class SimpleE2ETest extends FlatSpec with Matchers {
 
     // Exactly these folders should have been generated
     val expectedFolders =
-      Set("templeuser-db", "templeuser", "kong", "kube", "grafana").map(dir => basePath.resolve(dir))
+      Set("templeuser-db", "templeuser", "kong", "kube", "grafana", "prometheus").map(dir => basePath.resolve(dir))
     Files.list(basePath).toScala(Set) shouldBe expectedFolders
 
     // Only one file should be present in the templeuser-db folder
@@ -147,5 +147,13 @@ class SimpleE2ETest extends FlatSpec with Matchers {
       Files.readString(basePath.resolve("grafana/provisioning/datasources").resolve("datasource.yml"))
     templeUserGrafanaDatasourceConfig shouldBe SimpleE2ETestData.grafanaDatasourceConfig
 
+    // Only these files should be present in the prometheus folder
+    val expectedPrometheusFolders = Set("prometheus.yml").map(dir => basePath.resolve("prometheus").resolve(dir))
+    Files.list(basePath.resolve("prometheus")).toScala(Set) shouldBe expectedPrometheusFolders
+
+    // The content of the prometheus/prometheus.yml file should be correct
+    val templeUserPrometheusConfig =
+      Files.readString(basePath.resolve("prometheus").resolve("prometheus.yml"))
+    templeUserPrometheusConfig shouldBe SimpleE2ETestData.prometheusConfig
   }
 }

--- a/src/e2e/scala/temple/SimpleE2ETestData.scala
+++ b/src/e2e/scala/temple/SimpleE2ETestData.scala
@@ -245,4 +245,15 @@ object SimpleE2ETestData {
       |  isDefault: true
       |  editable: true
       |""".stripMargin
+
+  val prometheusConfig: String =
+    """global:
+    |  scrape_interval: 15s
+    |  evaluation_interval: 15s
+    |scrape_configs:
+    |- job_name: templeuser
+    |  static_configs:
+    |  - targets:
+    |    - templeuser:1025
+    |""".stripMargin
 }

--- a/src/main/scala/temple/ast/Templefile.scala
+++ b/src/main/scala/temple/ast/Templefile.scala
@@ -1,5 +1,7 @@
 package temple.ast
 
+import temple.ast.Templefile.Ports
+
 /** The semantic representation of a Templefile */
 case class Templefile(
   projectName: String,
@@ -12,8 +14,12 @@ case class Templefile(
     block.setParent(this)
   }
 
-  def servicesWithPorts: Iterable[(String, ServiceBlock, Int)] =
+  def servicesWithPorts: Iterable[(String, ServiceBlock, Ports)] =
     services
-      .zip(Iterator from 1024)
-      .map { case ((name, service), port) => (name, service, port) }
+      .zip(Iterator.from(1024, step = 2))
+      .map { case ((name, service), port) => (name, service, Ports(port, port + 1)) }
+}
+
+object Templefile {
+  case class Ports(service: Int, metrics: Int)
 }

--- a/src/test/scala/temple/builder/project/ProjectBuilderTest.scala
+++ b/src/test/scala/temple/builder/project/ProjectBuilderTest.scala
@@ -21,6 +21,7 @@ class ProjectBuilderTest extends FlatSpec with Matchers {
         File("grafana/provisioning/dashboards", "templeuser.json") -> ProjectBuilderTestData.simpleTemplefileGrafanaDashboard,
         File("grafana/provisioning/dashboards", "dashboards.yml")  -> ProjectBuilderTestData.simpleTemplefileGrafanaDashboardConfig,
         File("grafana/provisioning/datasources", "datasource.yml") -> ProjectBuilderTestData.simpleTemplefileGrafanaDatasourceConfig,
+        File("prometheus", "prometheus.yml")                       -> ProjectBuilderTestData.simpleTemplefilePrometheusConfig,
       ) ++ ProjectBuilderTestData.kongFiles
     project.files shouldBe expected
   }
@@ -39,6 +40,7 @@ class ProjectBuilderTest extends FlatSpec with Matchers {
         File("grafana/provisioning/dashboards", "templeuser.json") -> ProjectBuilderTestData.simpleTemplefileGrafanaDashboard,
         File("grafana/provisioning/dashboards", "dashboards.yml")  -> ProjectBuilderTestData.simpleTemplefileGrafanaDashboardConfig,
         File("grafana/provisioning/datasources", "datasource.yml") -> ProjectBuilderTestData.simpleTemplefileGrafanaDatasourceConfig,
+        File("prometheus", "prometheus.yml")                       -> ProjectBuilderTestData.simpleTemplefilePrometheusConfig,
       ) ++ ProjectBuilderTestData.kongFiles
     project.files shouldBe expected
   }
@@ -57,6 +59,7 @@ class ProjectBuilderTest extends FlatSpec with Matchers {
         File("grafana/provisioning/dashboards", "templeuser.json") -> ProjectBuilderTestData.simpleTemplefileGrafanaDashboard,
         File("grafana/provisioning/dashboards", "dashboards.yml")  -> ProjectBuilderTestData.simpleTemplefileGrafanaDashboardConfig,
         File("grafana/provisioning/datasources", "datasource.yml") -> ProjectBuilderTestData.simpleTemplefileGrafanaDatasourceConfig,
+        File("prometheus", "prometheus.yml")                       -> ProjectBuilderTestData.simpleTemplefilePrometheusConfig,
       ) ++ ProjectBuilderTestData.kongFiles
     project.files shouldBe expected
   }
@@ -75,6 +78,7 @@ class ProjectBuilderTest extends FlatSpec with Matchers {
       File("grafana/provisioning/dashboards", "complexuser.json") -> ProjectBuilderTestData.complexTemplefileGrafanaDashboard,
       File("grafana/provisioning/dashboards", "dashboards.yml")   -> ProjectBuilderTestData.complexTemplefileGrafanaDashboardConfig,
       File("grafana/provisioning/datasources", "datasource.yml")  -> ProjectBuilderTestData.complexTemplefileGrafanaDatasourceConfig,
+      File("prometheus", "prometheus.yml")                        -> ProjectBuilderTestData.complexTemplefilePrometheusConfig,
     ) ++ ProjectBuilderTestData.kongFiles
   }
 }

--- a/src/test/scala/temple/builder/project/ProjectBuilderTestData.scala
+++ b/src/test/scala/temple/builder/project/ProjectBuilderTestData.scala
@@ -305,6 +305,17 @@ object ProjectBuilderTestData {
       |  editable: true
       |""".stripMargin
 
+  val simpleTemplefilePrometheusConfig: String =
+    """global:
+      |  scrape_interval: 15s
+      |  evaluation_interval: 15s
+      |scrape_configs:
+      |- job_name: templeuser
+      |  static_configs:
+      |  - targets:
+      |    - templeuser:1025
+      |""".stripMargin
+
   val complexTemplefile: Templefile = Templefile(
     "SampleComplexProject",
     ProjectBlock(),
@@ -554,4 +565,15 @@ object ProjectBuilderTestData {
       |  isDefault: true
       |  editable: true
       |""".stripMargin
+
+  val complexTemplefilePrometheusConfig: String =
+    """global:
+    |  scrape_interval: 15s
+    |  evaluation_interval: 15s
+    |scrape_configs:
+    |- job_name: complexuser
+    |  static_configs:
+    |  - targets:
+    |    - complexuser:1025
+    |""".stripMargin
 }


### PR DESCRIPTION
Final one for the prometheus/grafana config - we now generate the `.yml` file from the types in #178, and pop it in the right place.

Nothing too crazy here, although thoughts on the `Ports` type?