### PR TITLE
[semantics] Add temple validate command

### DIFF
--- a/src/main/scala/temple/Application.scala
+++ b/src/main/scala/temple/Application.scala
@@ -1,7 +1,7 @@
 package temple
 
 import temple.DSL.DSLProcessor
-import temple.DSL.semantics.Analyzer
+import temple.DSL.semantics.{Analyzer, SemanticParsingException}
 import temple.builder.project.ProjectBuilder
 import temple.utils.FileUtils
 import temple.utils.MonadUtils.FromEither
@@ -28,5 +28,19 @@ object Application {
         )
     }
     println(s"Generated project in $outputDirectory")
+  }
+
+  def validate(config: TempleConfig): Unit = {
+    val fileContents = FileUtils.readFile(config.Validate.filename())
+    val data = DSLProcessor.parse(fileContents) fromEither { error =>
+      throw new RuntimeException("Templefile could not be parsed\n" + error)
+    }
+    try {
+      Analyzer.parseAndValidate(data)
+      println(s"Templefile validated correctly")
+    } catch {
+      case error: SemanticParsingException =>
+        throw new RuntimeException("Templefile could not be validated\n" + error.getMessage, error)
+    }
   }
 }

--- a/src/main/scala/temple/Main.scala
+++ b/src/main/scala/temple/Main.scala
@@ -2,8 +2,6 @@ package temple
 
 import java.nio.file.FileAlreadyExistsException
 
-import temple.DSL.semantics.SemanticParsingException
-
 /** Main entry point into the application */
 object Main extends App {
 
@@ -16,13 +14,13 @@ object Main extends App {
     val config = new TempleConfig(args)
     config.subcommand match {
       case Some(config.Generate) => Application.generate(config)
+      case Some(config.Validate) => Application.validate(config)
       case Some(_)               => throw new TempleConfig.UnhandledArgumentException
       case None                  => config.printHelp()
     }
   } catch {
-    case error: IllegalArgumentException   => exit(error.getMessage)
     case error: FileAlreadyExistsException => exit(s"File already exists: ${error.getMessage}")
-    case error: SemanticParsingException   => exit(error.getMessage)
+    case error: Exception                  => exit(error.getMessage)
   }
 
 }

--- a/src/main/scala/temple/TempleConfig.scala
+++ b/src/main/scala/temple/TempleConfig.scala
@@ -24,6 +24,11 @@ class TempleConfig(arguments: CSeq[String]) extends ScallopConf(arguments) {
       opt[String]("output", 'o', "Output directory to place generated files")
   }
   addSubcommand(Generate)
+
+  object Validate extends Subcommand("validate") {
+    val filename: ScallopOption[String] = trailArg[String]("filename", "Templefile to validate")
+  }
+  addSubcommand(Validate)
   verify()
 }
 

--- a/src/test/scala/temple/testfiles/badSemantics.temple
+++ b/src/test/scala/temple/testfiles/badSemantics.temple
@@ -1,0 +1,7 @@
+BadSemanticsTest: project {}
+
+TempleUser: service {
+  username: string;
+  email: string(40,5);
+  #omit [badKey];
+}

--- a/src/test/scala/temple/testfiles/badSyntax.temple
+++ b/src/test/scala/temple/testfiles/badSyntax.temple
@@ -1,0 +1,3 @@
+BadSyntaxTest: project {}
+
+TempleUser: bob;

--- a/src/test/scala/temple/testfiles/badValidation.temple
+++ b/src/test/scala/temple/testfiles/badValidation.temple
@@ -1,0 +1,26 @@
+BadValidationTest: project {}
+
+TempleUser: service {
+  username: string;
+  email: string(40,5);
+  firstName: string;
+  lastName: string;
+  createdAt: datetime;
+  numberOfDogs: int;
+  yeets: bool @unique @server; // Don't send this to the client
+  currentBankBalance: float(min: 0.0, precision: 16);
+  birthDate: date;
+  breakfastTime: time;
+
+  Fred: struct {
+    field: Box @client;
+    #readable(by: this);
+    #readable(by: all);
+  };
+
+
+  #readable(by: this);
+  #writable(by: all);
+  #auth(email);
+  #uses [Booking, /* Reservations */];
+}


### PR DESCRIPTION
Sample runs:

```
› ./temple validate src/test/scala/temple/testfiles/badSemantics.temple
Templefile could not be validated
Entry not found: badKey. Valid entries are Vector(create, read, update, delete). in omit, in TempleUser service

Exception: sbt.TrapExitSecurityException thrown from the UncaughtExceptionHandler in thread "run-main-0"
[error] Nonzero exit code: 1
[error] (Compile / runMain) Nonzero exit code: 1


› ./temple validate src/test/scala/temple/testfiles/badSyntax.temple
Templefile could not be parsed
'{' expected but ';' found
3 | TempleUser: bob;
                   ^

Exception: sbt.TrapExitSecurityException thrown from the UncaughtExceptionHandler in thread "run-main-0"
[error] Nonzero exit code: 1
[error] (Compile / runMain) Nonzero exit code: 1


› ./temple validate src/test/scala/temple/testfiles/badValidation.temple
Templefile could not be validated
5 errors were encountered while validating the Templefile
#writable(all) is not compatible with #readable(this) in TempleUser
FloatType precision not between 1 and 8 in currentBankBalance, in TempleUser
Invalid foreign key Box in field, in Fred, in TempleUser
Multiple occurrences of Readable metadata in Fred, in TempleUser
No such service Booking referenced in #uses in TempleUser

Exception: sbt.TrapExitSecurityException thrown from the UncaughtExceptionHandler in thread "run-main-0"
[error] Nonzero exit code: 1
[error] (Compile / runMain) Nonzero exit code: 1
```