### PR TITLE
[endpoint-test] Add test CLI mode

### DIFF
--- a/src/main/scala/temple/Application.scala
+++ b/src/main/scala/temple/Application.scala
@@ -3,6 +3,7 @@ package temple
 import temple.DSL.DSLProcessor
 import temple.DSL.semantics.Analyzer
 import temple.builder.project.ProjectBuilder
+import temple.test.EndpointTester
 import temple.utils.FileUtils
 import temple.utils.MonadUtils.FromEither
 
@@ -28,5 +29,15 @@ object Application {
         )
     }
     println(s"Generated project in $outputDirectory")
+  }
+
+  def test(config: TempleConfig): Unit = {
+    val generatedDirectory = config.Test.generatedDirectory.getOrElse(System.getProperty("user.dir"))
+    val fileContents       = FileUtils.readFile(config.Test.filename())
+    val data = DSLProcessor.parse(fileContents) fromEither { error =>
+      throw new RuntimeException(error)
+    }
+    val analyzedTemplefile = Analyzer.parseAndValidate(data)
+    EndpointTester.test(analyzedTemplefile, generatedDirectory)
   }
 }

--- a/src/main/scala/temple/Main.scala
+++ b/src/main/scala/temple/Main.scala
@@ -16,6 +16,7 @@ object Main extends App {
     val config = new TempleConfig(args)
     config.subcommand match {
       case Some(config.Generate) => Application.generate(config)
+      case Some(config.Test)     => Application.test(config)
       case Some(_)               => throw new TempleConfig.UnhandledArgumentException
       case None                  => config.printHelp()
     }

--- a/src/main/scala/temple/TempleConfig.scala
+++ b/src/main/scala/temple/TempleConfig.scala
@@ -34,7 +34,7 @@ class TempleConfig(arguments: CSeq[String]) extends ScallopConf(arguments) {
     val filename: ScallopOption[String] = trailArg[String]("filename", "Templefile to test against")
 
     val generatedDirectory: ScallopOption[String] =
-      opt[String]("generated", 'g', "Root directory where files have been generated")
+      opt[String]("dir", 'd', "Root directory where files have been generated")
   }
   addSubcommand(Test)
   verify()

--- a/src/main/scala/temple/TempleConfig.scala
+++ b/src/main/scala/temple/TempleConfig.scala
@@ -24,6 +24,14 @@ class TempleConfig(arguments: CSeq[String]) extends ScallopConf(arguments) {
       opt[String]("output", 'o', "Output directory to place generated files")
   }
   addSubcommand(Generate)
+
+  object Test extends Subcommand("test") {
+    val filename: ScallopOption[String] = trailArg[String]("filename", "Templefile to test against")
+
+    val generatedDirectory: ScallopOption[String] =
+      opt[String]("generated", 'g', "Root directory where files have been generated")
+  }
+  addSubcommand(Test)
   verify()
 }
 

--- a/src/main/scala/temple/test/EndpointTester.scala
+++ b/src/main/scala/temple/test/EndpointTester.scala
@@ -1,0 +1,9 @@
+package temple.test
+
+import temple.ast.Templefile
+
+object EndpointTester {
+
+  def test(templefile: Templefile, generatedPath: String): Unit =
+    println("Testing templefile...")
+}


### PR DESCRIPTION
I'm going to do this one in reverse from how we would normally - starting with the CLI and then adding more features from there.

Not sure I like `-g` for `--generated`, thoughts?