### PR TITLE
[project-test] Add Auth Service Tests

### DIFF
--- a/src/main/scala/temple/test/ProjectTester.scala
+++ b/src/main/scala/temple/test/ProjectTester.scala
@@ -22,9 +22,10 @@ object ProjectTester {
     exec(s"sh $generatedPath/deploy.sh")
 
     // Grab Kong's URL for future requests
-    val urls   = exec("minikube service kong --url").split("\n")
-    val baseIP = urls(0).replaceAll("http[s]*://", "")
-    val config = ProjectConfig(baseIP, urls(1))
+    val minikubeURLString = exec("minikube service kong --url")
+    val urls              = minikubeURLString.split("\n")
+    val baseIP            = urls(0).replaceAll("http[s]*://", "")
+    val config            = ProjectConfig(baseIP, urls(1))
 
     // Running deploy.sh doesn't set Kong up correctly for some reason. I couldn't figure it out, so manually call that part
     exec(

--- a/src/main/scala/temple/test/ProjectTester.scala
+++ b/src/main/scala/temple/test/ProjectTester.scala
@@ -22,10 +22,9 @@ object ProjectTester {
     exec(s"sh $generatedPath/deploy.sh")
 
     // Grab Kong's URL for future requests
-    val minikubeURLString = exec("minikube service kong --url")
-    val urls              = minikubeURLString.split("\n")
-    val baseIP            = urls(0).replaceAll("http[s]*://", "")
-    val config            = ProjectConfig(baseIP, urls(1))
+    val Array(baseURL, kongAdmin, _*) = exec("minikube service kong --url").split("\n")
+    val baseIP                        = baseURL.replaceAll("http[s]*://", "")
+    val config                        = ProjectConfig(baseIP, kongAdmin)
 
     // Running deploy.sh doesn't set Kong up correctly for some reason. I couldn't figure it out, so manually call that part
     exec(

--- a/src/main/scala/temple/test/ProjectTester.scala
+++ b/src/main/scala/temple/test/ProjectTester.scala
@@ -1,10 +1,10 @@
 package temple.test
 
+import temple.ast.Metadata.ServiceAuth
 import temple.ast.Templefile
+import temple.test.internal.{AuthServiceTest, ProjectConfig}
 
-import sys.process._
-import scalaj.http.Http
-import temple.test.internal.EndpointConfig
+import scala.sys.process._
 
 object ProjectTester {
 
@@ -16,7 +16,7 @@ object ProjectTester {
     s"sh -c '$command'".!!
 
   /** Configure the infrastructure for testing */
-  private def performSetup(templefile: Templefile, generatedPath: String): EndpointConfig = {
+  private def performSetup(templefile: Templefile, generatedPath: String): ProjectConfig = {
     println("🍪 Spinning up Kubernetes infrastructure...")
     // Deploy Kubernetes
     exec(s"sh $generatedPath/deploy.sh")
@@ -24,7 +24,7 @@ object ProjectTester {
     // Grab Kong's URL for future requests
     val urls   = exec("minikube service kong --url").split("\n")
     val baseIP = urls(0).replaceAll("http[s]*://", "")
-    val config = EndpointConfig(baseIP, urls(1))
+    val config = ProjectConfig(baseIP, urls(1))
 
     // Running deploy.sh doesn't set Kong up correctly for some reason. I couldn't figure it out, so manually call that part
     exec(
@@ -42,9 +42,10 @@ object ProjectTester {
 
   /** Execute the tests on each generated service */
   private def performTests(templefile: Templefile, generatedPath: String, url: String): Unit = {
-    println(s"🧪 Testing user service at $url/api/user...")
-    val sampleRequest = Http(s"http://$url/api/user/1").asString.body
-    println(sampleRequest)
+    val serviceAuths = templefile.services.values.flatMap(_.lookupMetadata[ServiceAuth]).toSet
+    if (serviceAuths.nonEmpty) {
+      AuthServiceTest.test(serviceAuths, url)
+    }
   }
 
   /**

--- a/src/main/scala/temple/test/internal/AuthServiceTest.scala
+++ b/src/main/scala/temple/test/internal/AuthServiceTest.scala
@@ -1,0 +1,41 @@
+package temple.test.internal
+
+import temple.ast.Metadata.ServiceAuth
+import temple.utils.StringUtils
+import io.circe.syntax._
+
+object AuthServiceTest extends ServiceTest("auth") {
+
+  private def testEmailAuth(baseURL: String): Unit = {
+    val email    = ServiceTestUtils.randomEmail()
+    val password = StringUtils.randomString(10)
+
+    // Register endpoint
+    testEndpoint("register") { test =>
+      val registerJson = ServiceTestUtils
+        .postRequest(
+          s"http://$baseURL/api/auth/register",
+          Map("email" -> email, "password" -> password).asJson,
+          test,
+        )
+      test.assert(registerJson.contains("AccessToken"), "response didn't contain the key AccessToken")
+    }
+
+    // Login endpoint
+    testEndpoint("login") { test =>
+      val loginJson = ServiceTestUtils
+        .postRequest(
+          s"http://$baseURL/api/auth/login",
+          Map("email" -> email, "password" -> password).asJson,
+          test,
+        )
+      test.assert(loginJson.contains("AccessToken"), "response didn't contain the key AccessToken")
+    }
+  }
+
+  // Test each type of auth that is present in the project
+  def test(auths: Set[ServiceAuth], baseURL: String): Unit =
+    auths.foreach {
+      case ServiceAuth.Email => testEmailAuth(baseURL)
+    }
+}

--- a/src/main/scala/temple/test/internal/EndpointConfig.scala
+++ b/src/main/scala/temple/test/internal/EndpointConfig.scala
@@ -1,3 +1,0 @@
-package temple.test.internal
-
-private[test] case class EndpointConfig(baseIP: String, kongAdminURL: String)

--- a/src/main/scala/temple/test/internal/EndpointTest.scala
+++ b/src/main/scala/temple/test/internal/EndpointTest.scala
@@ -1,5 +1,7 @@
 package temple.test.internal
 
+import temple.utils.StringUtils
+
 private[internal] class EndpointTest(service: String, endpointName: String) {
   class TestFailedException(msg: String) extends RuntimeException(msg)
 
@@ -11,8 +13,8 @@ private[internal] class EndpointTest(service: String, endpointName: String) {
     if (!value) fail(failMsg)
 
   def pass(): Unit =
-    println(s"\t✅ $service $endpointName")
+    println(StringUtils.indent(s"✅ $service $endpointName", 4))
 
   def fail(message: String): Nothing =
-    throw new TestFailedException(s"\t❌ $service $endpointName: $message")
+    throw new TestFailedException(StringUtils.indent(s"❌ $service $endpointName: $message", 4))
 }

--- a/src/main/scala/temple/test/internal/EndpointTest.scala
+++ b/src/main/scala/temple/test/internal/EndpointTest.scala
@@ -1,0 +1,18 @@
+package temple.test.internal
+
+private[internal] class EndpointTest(service: String, endpointName: String) {
+  class TestFailedException(msg: String) extends RuntimeException(msg)
+
+  def assertEqual(expected: Any, found: Any): Unit =
+    if (!expected.equals(found))
+      fail(s"Expected $expected but found $found")
+
+  def assert(value: Boolean, failMsg: String): Unit =
+    if (!value) fail(failMsg)
+
+  def pass(): Unit =
+    println(s"\t✅ $service $endpointName")
+
+  def fail(message: String): Nothing =
+    throw new TestFailedException(s"\t❌ $service $endpointName: $message")
+}

--- a/src/main/scala/temple/test/internal/ProjectConfig.scala
+++ b/src/main/scala/temple/test/internal/ProjectConfig.scala
@@ -1,0 +1,3 @@
+package temple.test.internal
+
+private[test] case class ProjectConfig(baseIP: String, kongAdminURL: String)

--- a/src/main/scala/temple/test/internal/ServiceTest.scala
+++ b/src/main/scala/temple/test/internal/ServiceTest.scala
@@ -1,0 +1,12 @@
+package temple.test.internal
+
+abstract class ServiceTest(service: String) {
+  println(s"🧪 Testing $service service")
+
+  def testEndpoint(endpointName: String)(testFn: EndpointTest => Unit): Unit = {
+    val endpointTest = new EndpointTest(service, endpointName)
+    testFn(endpointTest)
+    // If we successfully get here then tests have not thrown, so we've passed
+    endpointTest.pass()
+  }
+}

--- a/src/main/scala/temple/test/internal/ServiceTestUtils.scala
+++ b/src/main/scala/temple/test/internal/ServiceTestUtils.scala
@@ -1,0 +1,40 @@
+package temple.test.internal
+
+import io.circe.parser.parse
+import io.circe.{Json, JsonObject}
+import scalaj.http.Http
+import temple.utils.StringUtils
+
+object ServiceTestUtils {
+
+  /**
+    * Execute a POST request, where the response body is expected to be a JSON object
+    * @param url The URL to send the request to, prefixed with the protocol
+    * @param body The JSON body to send along with the request
+    * @param test The endpoint under test
+    * @return The decoded JSON response from the request
+    */
+  def postRequest(url: String, body: Json, test: EndpointTest): JsonObject = {
+    val response = Http(url).postData(body.toString).method("POST").asString
+    test.assertEqual(200, response.code)
+
+    parse(response.body) match {
+      case Left(value) =>
+        test.fail(s"response was not valid JSON: ${value.message}")
+      case Right(value) =>
+        value.asObject match {
+          case Some(value) => value
+          case None        => test.fail("response was not a JSON object")
+        }
+    }
+  }
+
+  /**
+    * Generate a random email address
+    */
+  def randomEmail(): String = {
+    val name   = StringUtils.randomString(10)
+    val domain = StringUtils.randomString(8)
+    s"$name@$domain.com"
+  }
+}


### PR DESCRIPTION
If a project has an auth service with email, test the `register` and `auth` endpoints.

Test plan:
```
$ temple test -d ../spec-golang ../example-templefiles/tinder.temple
...
🍪 Spinning up Kubernetes infrastructure...
🧪 Testing auth service
    ✅ auth register
    ✅ auth login
💀 Shutting down Kubernetes infrastructure...
```