### PR TITLE
[Go-Map] Build go level SQL statements

### DIFF
--- a/src/main/scala/temple/ast/ServiceBlock.scala
+++ b/src/main/scala/temple/ast/ServiceBlock.scala
@@ -25,9 +25,6 @@ case class ServiceBlock(
     */
   val primitiveAttributes: Map[String, Attribute] = attributes.filter {
     case (_, attr) =>
-      attr.attributeType match {
-        case _: PrimitiveAttributeType => true
-        case _                         => false
-      }
+      attr.attributeType.isInstanceOf[PrimitiveAttributeType]
   }
 }

--- a/src/main/scala/temple/ast/ServiceBlock.scala
+++ b/src/main/scala/temple/ast/ServiceBlock.scala
@@ -1,5 +1,6 @@
 package temple.ast
 
+import temple.ast.AttributeType.PrimitiveAttributeType
 import temple.ast.Metadata.ServiceMetadata
 
 /** A service block, representing one microservice on its own isolated server */
@@ -11,10 +12,22 @@ case class ServiceBlock(
 
   /**
     * Flatten a service block into a sequence of structs, including the service’s root struct.
+    *
     * @param rootName The name of the root struct, typically the name of the service.
     * @return An iterator of pairs of names and struct blocks,
     *         represented as an iterator of pairs of names and attributes
     */
   def structIterator(rootName: String): Iterator[(String, Map[String, Attribute])] =
     Iterator((rootName, attributes)) ++ structs.iterator.map { case (str, block) => (str, block.attributes) }
+
+  /**
+    * The attributes of this service that are of primitive types - i.e not foreign keys.
+    */
+  val primitiveAttributes: Map[String, Attribute] = attributes.filter {
+    case (_, attr) =>
+      attr.attributeType match {
+        case _: PrimitiveAttributeType => true
+        case _                         => false
+      }
+  }
 }

--- a/src/main/scala/temple/builder/DatabaseBuilder.scala
+++ b/src/main/scala/temple/builder/DatabaseBuilder.scala
@@ -2,9 +2,15 @@ package temple.builder
 
 import temple.ast.Annotation.Nullable
 import temple.ast.{Annotation, Attribute, AttributeType, ServiceBlock}
+import temple.generate.CRUD.{CRUD, Create, Delete, List, Read, Update}
 import temple.generate.database.ast.ColumnConstraint.Check
+import temple.generate.database.ast.Condition.PreparedComparison
+import temple.generate.database.ast.Expression.PreparedValue
 import temple.generate.database.ast._
+import temple.generate.server.{CreatedByAttribute, IDAttribute}
 import temple.utils.StringUtils
+
+import scala.collection.immutable.ListMap
 
 /** Construct database queries from a Templefile structure */
 object DatabaseBuilder {
@@ -43,10 +49,66 @@ object DatabaseBuilder {
     ColumnDef(name, colType, typeConstraints ++ valueConstraints)
   }
 
+  def buildQuery(
+    serviceName: String,
+    service: ServiceBlock,
+    endpoints: Set[CRUD],
+    iDAttribute: IDAttribute,
+    createdByAttribute: CreatedByAttribute,
+  ): ListMap[CRUD, Statement] = {
+    val tableName = StringUtils.snakeCase(serviceName)
+    val columns   = service.primitiveAttributes.map { case (name, _) => Column(name) }.toSeq
+    ListMap.from(
+      endpoints.map {
+        case Create =>
+          Create -> Statement.Insert(
+            tableName,
+            assignment = columns.map(col => Assignment(col, PreparedValue)),
+            returnColumns = columns,
+          )
+        case Read =>
+          Read -> Statement.Read(
+            tableName,
+            columns = columns,
+            condition = Some(PreparedComparison(iDAttribute.name, ComparisonOperator.Equal)),
+          )
+        case Update =>
+          Update -> Statement.Update(
+            tableName,
+            assignments = columns.map {
+              Assignment(_, PreparedValue)
+            },
+            condition = Some(PreparedComparison(iDAttribute.name, ComparisonOperator.Equal)),
+            returnColumns = columns,
+          )
+        case Delete =>
+          Delete -> Statement.Delete(
+            tableName,
+            condition = Some(PreparedComparison(iDAttribute.name, ComparisonOperator.Equal)),
+          )
+        case List =>
+          createdByAttribute match {
+            case CreatedByAttribute.EnumerateByCreator(_, _, _) =>
+              List -> Statement.Read(
+                tableName,
+                columns = columns,
+                condition = Some(PreparedComparison("created_by", ComparisonOperator.Equal)),
+              )
+            case CreatedByAttribute.EnumerateByAll(_, _, _) | CreatedByAttribute.None =>
+              List -> Statement.Read(
+                tableName,
+                columns = columns,
+              )
+          }
+      },
+    )
+  }
+
   /**
     * Converts a service block to an associated list of database table create statement
+    *
     * @param serviceName The service name
-    * @param service The ServiceBlock to generate
+    * @param service     The ServiceBlock to generate
     * @return the associated create statement
     */
   def createServiceTables(serviceName: String, service: ServiceBlock): Seq[Statement.Create] = {

--- a/src/main/scala/temple/generate/database/ast/Assignment.scala
+++ b/src/main/scala/temple/generate/database/ast/Assignment.scala
@@ -1,4 +1,6 @@
 package temple.generate.database.ast
 
+import temple.generate.database.ast.Expression.PreparedValue
+
 /** AST representation for assignments */
-sealed case class Assignment(column: Column, expression: Expression)
+sealed case class Assignment(column: Column, expression: Expression = PreparedValue)

--- a/src/test/scala/temple/builder/DatabaseBuilderTest.scala
+++ b/src/test/scala/temple/builder/DatabaseBuilderTest.scala
@@ -2,12 +2,7 @@ package temple.builder
 
 import org.scalatest.{FlatSpec, Matchers}
 import temple.ast.AttributeType
-import temple.generate
 import temple.generate.CRUD
-import temple.generate.CRUD._
-import temple.generate.database.ast.Statement._
-import temple.generate.database.ast.Expression.PreparedValue
-import temple.generate.database.ast.{Assignment, Column}
 import temple.generate.server.{CreatedByAttribute, IDAttribute}
 
 class DatabaseBuilderTest extends FlatSpec with Matchers {
@@ -26,85 +21,85 @@ class DatabaseBuilderTest extends FlatSpec with Matchers {
 
   it should "correctly build endpoint create queries" in {
     val queries = DatabaseBuilder.buildQuery(
-      "test-service",
+      "test_service",
       BuilderTestData.sampleService,
       Set(CRUD.Create),
       IDAttribute("id", AttributeType.UUIDType),
       CreatedByAttribute.None,
     )
     queries.keys should contain(CRUD.Create)
-    queries(CRUD.Create) should be(DatabaseBuilderTestData.sampleInsertStatement)
+    queries(CRUD.Create) shouldBe DatabaseBuilderTestData.sampleInsertStatement
   }
 
   it should "correctly build endpoint read queries" in {
     val queries = DatabaseBuilder.buildQuery(
-      "test-service",
+      "test_service",
       BuilderTestData.sampleService,
       Set(CRUD.Read),
       IDAttribute("id", AttributeType.UUIDType),
       CreatedByAttribute.None,
     )
     queries.keys should contain(CRUD.Read)
-    queries(CRUD.Read) should be(DatabaseBuilderTestData.sampleReadStatement)
+    queries(CRUD.Read) shouldBe DatabaseBuilderTestData.sampleReadStatement
   }
 
   it should "correctly build endpoint update queries" in {
     val queries = DatabaseBuilder.buildQuery(
-      "test-service",
+      "test_service",
       BuilderTestData.sampleService,
       Set(CRUD.Update),
       IDAttribute("id", AttributeType.UUIDType),
       CreatedByAttribute.None,
     )
     queries.keys should contain(CRUD.Update)
-    queries(CRUD.Update) should be(DatabaseBuilderTestData.sampleUpdateStatement)
+    queries(CRUD.Update) shouldBe DatabaseBuilderTestData.sampleUpdateStatement
   }
 
   it should "correctly build endpoint delete queries" in {
     val queries = DatabaseBuilder.buildQuery(
-      "test-service",
+      "test_service",
       BuilderTestData.sampleService,
       Set(CRUD.Delete),
       IDAttribute("id", AttributeType.UUIDType),
       CreatedByAttribute.None,
     )
     queries.keys should contain(CRUD.Delete)
-    queries(CRUD.Delete) should be(DatabaseBuilderTestData.sampleDeleteStatement)
+    queries(CRUD.Delete) shouldBe DatabaseBuilderTestData.sampleDeleteStatement
   }
 
   it should "correctly build endpoint list CreatedByNone queries" in {
     val queries = DatabaseBuilder.buildQuery(
-      "test-service",
+      "test_service",
       BuilderTestData.sampleService,
       Set(CRUD.List),
       IDAttribute("id", AttributeType.UUIDType),
       CreatedByAttribute.None,
     )
     queries.keys should contain(CRUD.List)
-    queries(CRUD.List) should be(DatabaseBuilderTestData.sampleListStatementEnumerateByAll)
+    queries(CRUD.List) shouldBe DatabaseBuilderTestData.sampleListStatementEnumerateByAll
   }
 
   it should "correctly build endpoint list EnumerateByAll queries" in {
     val queries = DatabaseBuilder.buildQuery(
-      "test-service",
+      "test_service",
       BuilderTestData.sampleService,
       Set(CRUD.List),
       IDAttribute("id", AttributeType.UUIDType),
       CreatedByAttribute.EnumerateByAll("created_by", "created_by", AttributeType.UUIDType),
     )
     queries.keys should contain(CRUD.List)
-    queries(CRUD.List) should be(DatabaseBuilderTestData.sampleListStatementEnumerateByAll)
+    queries(CRUD.List) shouldBe DatabaseBuilderTestData.sampleListStatementEnumerateByAll
   }
 
   it should "correctly build endpoint list EnumerateByCreator queries" in {
     val queries = DatabaseBuilder.buildQuery(
-      "test-service",
+      "test_service",
       BuilderTestData.sampleService,
       Set(CRUD.List),
       IDAttribute("id", AttributeType.UUIDType),
       CreatedByAttribute.EnumerateByCreator("created_by", "created_by", AttributeType.UUIDType),
     )
     queries.keys should contain(CRUD.List)
-    queries(CRUD.List) should be(DatabaseBuilderTestData.sampleListStatementEnumerateByCreator)
+    queries(CRUD.List) shouldBe DatabaseBuilderTestData.sampleListStatementEnumerateByCreator
   }
 }

--- a/src/test/scala/temple/builder/DatabaseBuilderTest.scala
+++ b/src/test/scala/temple/builder/DatabaseBuilderTest.scala
@@ -1,6 +1,14 @@
 package temple.builder
 
 import org.scalatest.{FlatSpec, Matchers}
+import temple.ast.AttributeType
+import temple.generate
+import temple.generate.CRUD
+import temple.generate.CRUD._
+import temple.generate.database.ast.Statement._
+import temple.generate.database.ast.Expression.PreparedValue
+import temple.generate.database.ast.{Assignment, Column}
+import temple.generate.server.{CreatedByAttribute, IDAttribute}
 
 class DatabaseBuilderTest extends FlatSpec with Matchers {
 
@@ -14,5 +22,89 @@ class DatabaseBuilderTest extends FlatSpec with Matchers {
   it should "correctly create a complex users table" in {
     val createQuery = DatabaseBuilder.createServiceTables("temple_user", BuilderTestData.sampleComplexService)
     createQuery shouldBe DatabaseBuilderTestData.sampleComplexServiceCreate
+  }
+
+  it should "correctly build endpoint create queries" in {
+    val queries = DatabaseBuilder.buildQuery(
+      "test-service",
+      BuilderTestData.sampleService,
+      Set(CRUD.Create),
+      IDAttribute("id", AttributeType.UUIDType),
+      CreatedByAttribute.None,
+    )
+    queries.keys should contain(CRUD.Create)
+    queries(CRUD.Create) should be(DatabaseBuilderTestData.sampleInsertStatement)
+  }
+
+  it should "correctly build endpoint read queries" in {
+    val queries = DatabaseBuilder.buildQuery(
+      "test-service",
+      BuilderTestData.sampleService,
+      Set(CRUD.Read),
+      IDAttribute("id", AttributeType.UUIDType),
+      CreatedByAttribute.None,
+    )
+    queries.keys should contain(CRUD.Read)
+    queries(CRUD.Read) should be(DatabaseBuilderTestData.sampleReadStatement)
+  }
+
+  it should "correctly build endpoint update queries" in {
+    val queries = DatabaseBuilder.buildQuery(
+      "test-service",
+      BuilderTestData.sampleService,
+      Set(CRUD.Update),
+      IDAttribute("id", AttributeType.UUIDType),
+      CreatedByAttribute.None,
+    )
+    queries.keys should contain(CRUD.Update)
+    queries(CRUD.Update) should be(DatabaseBuilderTestData.sampleUpdateStatement)
+  }
+
+  it should "correctly build endpoint delete queries" in {
+    val queries = DatabaseBuilder.buildQuery(
+      "test-service",
+      BuilderTestData.sampleService,
+      Set(CRUD.Delete),
+      IDAttribute("id", AttributeType.UUIDType),
+      CreatedByAttribute.None,
+    )
+    queries.keys should contain(CRUD.Delete)
+    queries(CRUD.Delete) should be(DatabaseBuilderTestData.sampleDeleteStatement)
+  }
+
+  it should "correctly build endpoint list CreatedByNone queries" in {
+    val queries = DatabaseBuilder.buildQuery(
+      "test-service",
+      BuilderTestData.sampleService,
+      Set(CRUD.List),
+      IDAttribute("id", AttributeType.UUIDType),
+      CreatedByAttribute.None,
+    )
+    queries.keys should contain(CRUD.List)
+    queries(CRUD.List) should be(DatabaseBuilderTestData.sampleListStatementEnumerateByAll)
+  }
+
+  it should "correctly build endpoint list EnumerateByAll queries" in {
+    val queries = DatabaseBuilder.buildQuery(
+      "test-service",
+      BuilderTestData.sampleService,
+      Set(CRUD.List),
+      IDAttribute("id", AttributeType.UUIDType),
+      CreatedByAttribute.EnumerateByAll("created_by", "created_by", AttributeType.UUIDType),
+    )
+    queries.keys should contain(CRUD.List)
+    queries(CRUD.List) should be(DatabaseBuilderTestData.sampleListStatementEnumerateByAll)
+  }
+
+  it should "correctly build endpoint list EnumerateByCreator queries" in {
+    val queries = DatabaseBuilder.buildQuery(
+      "test-service",
+      BuilderTestData.sampleService,
+      Set(CRUD.List),
+      IDAttribute("id", AttributeType.UUIDType),
+      CreatedByAttribute.EnumerateByCreator("created_by", "created_by", AttributeType.UUIDType),
+    )
+    queries.keys should contain(CRUD.List)
+    queries(CRUD.List) should be(DatabaseBuilderTestData.sampleListStatementEnumerateByCreator)
   }
 }

--- a/src/test/scala/temple/builder/DatabaseBuilderTestData.scala
+++ b/src/test/scala/temple/builder/DatabaseBuilderTestData.scala
@@ -3,8 +3,10 @@ package temple.builder
 import temple.generate.database.ast.ColType._
 import temple.generate.database.ast.ColumnConstraint.{Check, NonNull, Unique}
 import temple.generate.database.ast.ComparisonOperator.{GreaterEqual, LessEqual}
-import temple.generate.database.ast.Statement.Create
-import temple.generate.database.ast.{ColumnDef, Statement}
+import temple.generate.database.ast.Condition.PreparedComparison
+import temple.generate.database.ast.Expression.PreparedValue
+import temple.generate.database.ast.Statement._
+import temple.generate.database.ast.{Assignment, Column, ColumnDef, ComparisonOperator, Condition, Statement}
 
 object DatabaseBuilderTestData {
 
@@ -73,4 +75,102 @@ object DatabaseBuilderTestData {
         ),
       ),
     )
+
+  val sampleInsertStatement: Statement = Insert(
+    "test-service",
+    Seq(
+      Assignment(Column("id"), PreparedValue),
+      Assignment(Column("bankBalance"), PreparedValue),
+      Assignment(Column("name"), PreparedValue),
+      Assignment(Column("isStudent"), PreparedValue),
+      Assignment(Column("dateOfBirth"), PreparedValue),
+      Assignment(Column("timeOfDay"), PreparedValue),
+      Assignment(Column("expiry"), PreparedValue),
+      Assignment(Column("image"), PreparedValue),
+    ),
+    returnColumns = Seq(
+      Column("id"),
+      Column("bankBalance"),
+      Column("name"),
+      Column("isStudent"),
+      Column("dateOfBirth"),
+      Column("timeOfDay"),
+      Column("expiry"),
+      Column("image"),
+    ),
+  )
+
+  val sampleReadStatement: Statement = Read(
+    "test-service",
+    Seq(
+      Column("id"),
+      Column("bankBalance"),
+      Column("name"),
+      Column("isStudent"),
+      Column("dateOfBirth"),
+      Column("timeOfDay"),
+      Column("expiry"),
+      Column("image"),
+    ),
+    Some(PreparedComparison("id", ComparisonOperator.Equal)),
+  )
+
+  val sampleUpdateStatement: Statement = Update(
+    "test-service",
+    Seq(
+      Assignment(Column("id"), PreparedValue),
+      Assignment(Column("bankBalance"), PreparedValue),
+      Assignment(Column("name"), PreparedValue),
+      Assignment(Column("isStudent"), PreparedValue),
+      Assignment(Column("dateOfBirth"), PreparedValue),
+      Assignment(Column("timeOfDay"), PreparedValue),
+      Assignment(Column("expiry"), PreparedValue),
+      Assignment(Column("image"), PreparedValue),
+    ),
+    Some(PreparedComparison("id", ComparisonOperator.Equal)),
+    returnColumns = Seq(
+      Column("id"),
+      Column("bankBalance"),
+      Column("name"),
+      Column("isStudent"),
+      Column("dateOfBirth"),
+      Column("timeOfDay"),
+      Column("expiry"),
+      Column("image"),
+    ),
+  )
+
+  val sampleDeleteStatement: Statement = Delete(
+    "test-service",
+    Some(PreparedComparison("id", ComparisonOperator.Equal)),
+  )
+
+  val sampleListStatementEnumerateByCreator: Statement = Read(
+    "test-service",
+    Seq(
+      Column("id"),
+      Column("bankBalance"),
+      Column("name"),
+      Column("isStudent"),
+      Column("dateOfBirth"),
+      Column("timeOfDay"),
+      Column("expiry"),
+      Column("image"),
+    ),
+    Some(PreparedComparison("created_by", ComparisonOperator.Equal)),
+  )
+
+  val sampleListStatementEnumerateByAll: Statement = Read(
+    "test-service",
+    Seq(
+      Column("id"),
+      Column("bankBalance"),
+      Column("name"),
+      Column("isStudent"),
+      Column("dateOfBirth"),
+      Column("timeOfDay"),
+      Column("expiry"),
+      Column("image"),
+    ),
+  )
 }

--- a/src/test/scala/temple/builder/DatabaseBuilderTestData.scala
+++ b/src/test/scala/temple/builder/DatabaseBuilderTestData.scala
@@ -4,9 +4,8 @@ import temple.generate.database.ast.ColType._
 import temple.generate.database.ast.ColumnConstraint.{Check, NonNull, Unique}
 import temple.generate.database.ast.ComparisonOperator.{GreaterEqual, LessEqual}
 import temple.generate.database.ast.Condition.PreparedComparison
-import temple.generate.database.ast.Expression.PreparedValue
 import temple.generate.database.ast.Statement._
-import temple.generate.database.ast.{Assignment, Column, ColumnDef, ComparisonOperator, Condition, Statement}
+import temple.generate.database.ast._
 
 object DatabaseBuilderTestData {
 
@@ -77,16 +76,16 @@ object DatabaseBuilderTestData {
     )
 
   val sampleInsertStatement: Statement = Insert(
-    "test-service",
+    "test_service",
     Seq(
-      Assignment(Column("id"), PreparedValue),
-      Assignment(Column("bankBalance"), PreparedValue),
-      Assignment(Column("name"), PreparedValue),
-      Assignment(Column("isStudent"), PreparedValue),
-      Assignment(Column("dateOfBirth"), PreparedValue),
-      Assignment(Column("timeOfDay"), PreparedValue),
-      Assignment(Column("expiry"), PreparedValue),
-      Assignment(Column("image"), PreparedValue),
+      Assignment(Column("id")),
+      Assignment(Column("bankBalance")),
+      Assignment(Column("name")),
+      Assignment(Column("isStudent")),
+      Assignment(Column("dateOfBirth")),
+      Assignment(Column("timeOfDay")),
+      Assignment(Column("expiry")),
+      Assignment(Column("image")),
     ),
     returnColumns = Seq(
       Column("id"),
@@ -101,7 +100,7 @@ object DatabaseBuilderTestData {
   )
 
   val sampleReadStatement: Statement = Read(
-    "test-service",
+    "test_service",
     Seq(
       Column("id"),
       Column("bankBalance"),
@@ -116,16 +115,16 @@ object DatabaseBuilderTestData {
   )
 
   val sampleUpdateStatement: Statement = Update(
-    "test-service",
+    "test_service",
     Seq(
-      Assignment(Column("id"), PreparedValue),
-      Assignment(Column("bankBalance"), PreparedValue),
-      Assignment(Column("name"), PreparedValue),
-      Assignment(Column("isStudent"), PreparedValue),
-      Assignment(Column("dateOfBirth"), PreparedValue),
-      Assignment(Column("timeOfDay"), PreparedValue),
-      Assignment(Column("expiry"), PreparedValue),
-      Assignment(Column("image"), PreparedValue),
+      Assignment(Column("id")),
+      Assignment(Column("bankBalance")),
+      Assignment(Column("name")),
+      Assignment(Column("isStudent")),
+      Assignment(Column("dateOfBirth")),
+      Assignment(Column("timeOfDay")),
+      Assignment(Column("expiry")),
+      Assignment(Column("image")),
     ),
     Some(PreparedComparison("id", ComparisonOperator.Equal)),
     returnColumns = Seq(
@@ -141,12 +140,12 @@ object DatabaseBuilderTestData {
   )
 
   val sampleDeleteStatement: Statement = Delete(
-    "test-service",
+    "test_service",
     Some(PreparedComparison("id", ComparisonOperator.Equal)),
   )
 
   val sampleListStatementEnumerateByCreator: Statement = Read(
-    "test-service",
+    "test_service",
     Seq(
       Column("id"),
       Column("bankBalance"),
@@ -161,7 +160,7 @@ object DatabaseBuilderTestData {
   )
 
   val sampleListStatementEnumerateByAll: Statement = Read(
-    "test-service",
+    "test_service",
     Seq(
       Column("id"),
       Column("bankBalance"),


### PR DESCRIPTION
The first of the three PRs for Go mapping - this adds the ability for the DatabaseBuilder to build the SQL statements used at the go Dao level