### PR TITLE
Service tester crud

### DIFF
--- a/src/main/scala/temple/test/ProjectTester.scala
+++ b/src/main/scala/temple/test/ProjectTester.scala
@@ -2,7 +2,7 @@ package temple.test
 
 import temple.ast.Metadata.ServiceAuth
 import temple.ast.Templefile
-import temple.test.internal.{AuthServiceTest, ProjectConfig}
+import temple.test.internal.{AuthServiceTest, CRUDServiceTest, ProjectConfig}
 
 import scala.sys.process._
 
@@ -45,6 +45,10 @@ object ProjectTester {
     val serviceAuths = templefile.services.values.flatMap(_.lookupMetadata[ServiceAuth]).toSet
     if (serviceAuths.nonEmpty) {
       AuthServiceTest.test(serviceAuths, url)
+    }
+    templefile.services.foreach {
+      case (name, block) =>
+        CRUDServiceTest.test(name, block, templefile.services, url)
     }
   }
 

--- a/src/main/scala/temple/test/internal/AuthServiceTest.scala
+++ b/src/main/scala/temple/test/internal/AuthServiceTest.scala
@@ -4,7 +4,7 @@ import temple.ast.Metadata.ServiceAuth
 import temple.utils.StringUtils
 import io.circe.syntax._
 
-object AuthServiceTest extends ServiceTest("auth") {
+object AuthServiceTest extends ServiceTest("Auth") {
 
   private def testEmailAuth(baseURL: String): Unit = {
     val email    = ServiceTestUtils.randomEmail()
@@ -14,9 +14,9 @@ object AuthServiceTest extends ServiceTest("auth") {
     testEndpoint("register") { test =>
       val registerJson = ServiceTestUtils
         .postRequest(
+          test,
           s"http://$baseURL/api/auth/register",
           Map("email" -> email, "password" -> password).asJson,
-          test,
         )
       test.assert(registerJson.contains("AccessToken"), "response didn't contain the key AccessToken")
     }
@@ -25,9 +25,9 @@ object AuthServiceTest extends ServiceTest("auth") {
     testEndpoint("login") { test =>
       val loginJson = ServiceTestUtils
         .postRequest(
+          test,
           s"http://$baseURL/api/auth/login",
           Map("email" -> email, "password" -> password).asJson,
-          test,
         )
       test.assert(loginJson.contains("AccessToken"), "response didn't contain the key AccessToken")
     }

--- a/src/main/scala/temple/test/internal/CRUDServiceTest.scala
+++ b/src/main/scala/temple/test/internal/CRUDServiceTest.scala
@@ -1,0 +1,41 @@
+package temple.test.internal
+
+import temple.ast.ServiceBlock
+import temple.builder.project.ProjectBuilder
+import temple.generate.CRUD
+
+class CRUDServiceTest(name: String, service: ServiceBlock, allServices: Map[String, ServiceBlock], baseURL: String)
+    extends ServiceTest(name) {
+
+  private def testCreateEndpoint(accessToken: String): Unit =
+    testEndpoint("create") { test =>
+      val requestBody =
+        ServiceTestUtils.constructRequestBody(test, service.attributes, allServices, baseURL, accessToken)
+      val createJSON = ServiceTestUtils
+        .postRequest(
+          test,
+          s"http://$baseURL/api/${name.toLowerCase}",
+          requestBody,
+          accessToken,
+        )
+      test.validateResponseBody(
+        requestBody.asObject.getOrElse(test.fail(s"Request was not a JSON object")),
+        createJSON,
+        service.attributes,
+      )
+    }
+
+  // Test each type of endpoint that is present in the service
+  def test(): Unit = {
+    val accessToken = ServiceTestUtils.getAuthTokenWithEmail(name, baseURL)
+    val endpoints   = ProjectBuilder.endpoints(service)
+    if (endpoints.contains(CRUD.Create)) testCreateEndpoint(accessToken)
+    // TODO: Read, Update, Delete, List
+  }
+}
+
+object CRUDServiceTest {
+
+  def test(name: String, service: ServiceBlock, allServices: Map[String, ServiceBlock], baseURL: String): Unit =
+    new CRUDServiceTest(name, service, allServices, baseURL).test()
+}

--- a/src/main/scala/temple/test/internal/EndpointTest.scala
+++ b/src/main/scala/temple/test/internal/EndpointTest.scala
@@ -1,9 +1,97 @@
 package temple.test.internal
 
+import java.text.SimpleDateFormat
+import java.util.UUID
+
+import io.circe.{Json, JsonObject}
+import temple.ast.{Annotation, Attribute, AttributeType}
 import temple.utils.StringUtils
+
+import scala.util.Try
 
 private[internal] class EndpointTest(service: String, endpointName: String) {
   class TestFailedException(msg: String) extends RuntimeException(msg)
+
+  // Validate that the response JSON for the provided key matches the Attribute
+  private def validateResponseType(key: String, responseForKey: Json, attribute: Attribute): Unit =
+    attribute.attributeType match {
+      case AttributeType.ForeignKey(_) | AttributeType.UUIDType =>
+        val stringValue = responseForKey.asString.getOrElse(fail(s"$key is not a valid string"))
+        assert(Try(UUID.fromString(stringValue)).isSuccess, s"$key is not a valid UUID")
+      case AttributeType.BoolType =>
+        assert(responseForKey.isBoolean, s"$key is not of type bool")
+      case AttributeType.DateType =>
+        val stringValue = responseForKey.asString.getOrElse(fail(s"$key is not a valid string"))
+        assert(Try(new SimpleDateFormat("yyyy-MM-dd").parse(stringValue)).isSuccess, s"$key is not a valid date")
+      case AttributeType.DateTimeType =>
+        val stringValue = responseForKey.asString.getOrElse(fail(s"$key is not a valid string"))
+        assert(
+          Try(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX").parse(stringValue)).isSuccess,
+          s"$key is not a valid datetime",
+        )
+      case AttributeType.TimeType =>
+        val stringValue = responseForKey.asString.getOrElse(fail(s"$key is not a valid string"))
+        assert(Try(new SimpleDateFormat("HH:mm:ssXXX").parse(stringValue)).isSuccess, s"$key is not a valid time")
+      case AttributeType.BlobType(_) =>
+        assert(responseForKey.isString, s"$key is not a valid string")
+      case AttributeType.StringType(max, min) =>
+        val stringValue = responseForKey.asString.getOrElse(fail(s"$key is not a valid string"))
+        min.foreach { minValue =>
+          assert(stringValue.length >= minValue, s"$key does not satisfy min bound of $minValue")
+        }
+        max.foreach { maxValue =>
+          assert(stringValue.length <= maxValue, s"$key does not satisfy max bound of $maxValue")
+        }
+      case AttributeType.IntType(max, min, _) =>
+        // TODO: precision
+        val intValue = responseForKey.asNumber.flatMap(_.toInt).getOrElse(fail(s"$key is not a valid number"))
+        min.foreach { minValue =>
+          assert(intValue >= minValue, s"$key does not satisfy min bound of $minValue")
+        }
+        max.foreach { maxValue =>
+          assert(intValue <= maxValue, s"$key does not satisfy max bound of $maxValue")
+        }
+      case AttributeType.FloatType(max, min, _) =>
+        // TODO: precision
+        val floatValue = responseForKey.asNumber.map(_.toFloat).getOrElse(fail(s"$key is not a valid float"))
+        min.foreach { minValue =>
+          assert(floatValue >= minValue, s"$key does not satisfy min bound of $minValue")
+        }
+        max.foreach { maxValue =>
+          assert(floatValue <= maxValue, s"$key does not satisfy max bound of $maxValue")
+        }
+    }
+
+  def validateResponseBody(request: JsonObject, response: JsonObject, attributes: Map[String, Attribute]): Unit = {
+    // The response should contain exactly the keys in attributes, PLUS an ID attribute, MINUS anything that is @server
+    val expectedAttributes = attributes.filter {
+      case (_, attribute) =>
+        attribute.accessAnnotation.fold(true) {
+          case Annotation.Server                        => false
+          case Annotation.ServerSet | Annotation.Client => true
+        }
+    }
+    val expectedAttributeNames = (expectedAttributes.keys ++ Seq("ID")).map(_.capitalize).toSet
+    val foundAttributeNames    = response.keys.toSet
+    assertEqual(expectedAttributeNames, foundAttributeNames)
+
+    expectedAttributes.foreach {
+      case (name, attribute) =>
+        // Validate that the response JSON is of the expected types
+        val responseForKey = response(name.capitalize).getOrElse(fail(s"could not find key $name in response body"))
+        validateResponseType(name, responseForKey, attribute)
+
+        // Where the attribute is not @serverSet, validate that what was sent is exactly what is returned
+        val shouldValidateRequest = attribute.accessAnnotation.fold(true) {
+          case Annotation.Server | Annotation.ServerSet => false
+          case Annotation.Client                        => true
+        }
+        if (shouldValidateRequest) {
+          val requestForKey = request(name).getOrElse(fail(s"request was expected to contain key $name, but didn't"))
+          assertEqual(requestForKey, responseForKey)
+        }
+    }
+  }
 
   def assertEqual(expected: Any, found: Any): Unit =
     if (!expected.equals(found))

--- a/src/main/scala/temple/test/internal/ServiceTestUtils.scala
+++ b/src/main/scala/temple/test/internal/ServiceTestUtils.scala
@@ -1,10 +1,17 @@
 package temple.test.internal
 
+import java.sql.{Date, Time, Timestamp}
+import java.util.UUID
+
 import io.circe.parser.parse
 import io.circe.{Json, JsonObject}
 import scalaj.http.Http
 import temple.utils.StringUtils
 import temple.utils.MonadUtils.FromEither
+import io.circe.syntax._
+import temple.ast.{Attribute, AttributeType, Metadata, ServiceBlock}
+
+import scala.util.Random
 
 object ServiceTestUtils {
 
@@ -15,8 +22,9 @@ object ServiceTestUtils {
     * @param test The endpoint under test
     * @return The decoded JSON response from the request
     */
-  def postRequest(url: String, body: Json, test: EndpointTest): JsonObject = {
-    val response = Http(url).postData(body.toString).method("POST").asString
+  def postRequest(test: EndpointTest, url: String, body: Json, token: String = ""): JsonObject = {
+    val response = Http(url).postData(body.toString).method("POST").header("Authorization", s"Bearer $token").asString
+    if (response.code != 200) println(response.body)
     test.assertEqual(200, response.code)
 
     val parsedBody = parse(response.body) fromEither { failure =>
@@ -28,6 +36,103 @@ object ServiceTestUtils {
     }
 
     jsonObject
+  }
+
+  /**
+    * Create an access token for use by the provided service
+    * @param service The service the access token is required for
+    * @param baseURL The base URL to execute requests
+    * @return The access token, as a string
+    */
+  def getAuthTokenWithEmail(service: String, baseURL: String): String = {
+    val test = new EndpointTest(service, "fetch auth token")
+    val registerJson = ServiceTestUtils
+      .postRequest(
+        test,
+        s"http://$baseURL/api/auth/register",
+        Map("email" -> randomEmail(), "password" -> StringUtils.randomString(10)).asJson,
+      )
+    registerJson("AccessToken").flatMap(_.asString).getOrElse(test.fail("access token was not a valid string"))
+  }
+
+  /**
+    * Construct a valid request body for the provided attributes
+    * @param test The endpoint under test
+    * @param attributes The attributes to be included in the body
+    * @param allServices All other services in the system - needed if any foreign keys are present
+    * @param baseURL The base URL where requests should be executed
+    * @param accessToken The access token used for requests
+    * @return
+    */
+  def constructRequestBody(
+    test: EndpointTest,
+    attributes: Map[String, Attribute],
+    allServices: Map[String, ServiceBlock],
+    baseURL: String,
+    accessToken: String,
+  ): Json =
+    attributes.map {
+      case (name, attribute) =>
+        val value: Json = attribute.attributeType match {
+          case AttributeType.ForeignKey(references) =>
+            create(test, references, allServices, baseURL, accessToken).asJson
+          case AttributeType.UUIDType =>
+            UUID.randomUUID().asJson
+          case AttributeType.BoolType =>
+            Random.nextBoolean().asJson
+          case AttributeType.DateType =>
+            new Date(Random.nextLong()).toString.asJson
+          case AttributeType.DateTimeType =>
+            new Timestamp(Random.nextLong()).toString.asJson
+          case AttributeType.TimeType =>
+            new Time(Random.nextLong()).toString.asJson
+          case AttributeType.BlobType(_) =>
+            // TODO
+            "todo".asJson
+          case AttributeType.StringType(max, min) =>
+            val maxValue: Long = max.getOrElse(20)
+            val minValue: Int  = min.getOrElse(0)
+            val random         = Random.between(minValue, maxValue)
+            StringUtils.randomString(random.toInt).asJson
+          case AttributeType.IntType(max, min, _) =>
+            // TODO: Switch on precision
+            val maxValue: Long = max.getOrElse(Long.MaxValue)
+            val minValue: Long = min.getOrElse(Long.MinValue)
+            Random.between(minValue, maxValue).asJson
+          case AttributeType.FloatType(max, min, _) =>
+            // TODO: Switch on precision
+            val maxValue = max.getOrElse(Double.MaxValue)
+            val minValue = min.getOrElse(Double.MinValue)
+            Random.between(minValue, maxValue).asJson
+        }
+        (name, value)
+    }.asJson
+
+  // Create a new object in a given service, returning the ID field
+  private def create(
+    test: EndpointTest,
+    serviceName: String,
+    allServices: Map[String, ServiceBlock],
+    baseURL: String,
+    accessToken: String,
+  ): String = {
+    val service = allServices.getOrElse(serviceName, test.fail(s"service $serviceName does not exist"))
+    // If this service is an auth service, the same access token cannot be used twice, so make a new one to be safe...
+    // This is so that services that reference 2+ auth'd services can be successfully tested
+    val newAccessToken = service.lookupMetadata[Metadata.ServiceAuth].fold(accessToken) { _ =>
+      ServiceTestUtils.getAuthTokenWithEmail(serviceName, baseURL)
+    }
+
+    val requestBody = constructRequestBody(test, service.attributes, allServices, baseURL, newAccessToken)
+    val createJSON = ServiceTestUtils
+      .postRequest(
+        test,
+        s"http://$baseURL/api/${serviceName.toLowerCase}",
+        requestBody,
+        newAccessToken,
+      )
+    val idJSON = createJSON("ID").getOrElse(test.fail(s"response to create $serviceName did not contain an ID key"))
+    idJSON.asString.getOrElse(test.fail(s"response to create $serviceName contained field ID, but was not a string"))
   }
 
   /**

--- a/src/main/scala/temple/test/internal/ServiceTestUtils.scala
+++ b/src/main/scala/temple/test/internal/ServiceTestUtils.scala
@@ -107,7 +107,7 @@ object ServiceTestUtils {
         (name, value)
     }.asJson
 
-  // Create a new object in a given service, returning the ID field
+  /** Create a new object in a given service, returning the ID field */
   private def create(
     test: EndpointTest,
     serviceName: String,

--- a/src/main/scala/temple/test/internal/ServiceTestUtils.scala
+++ b/src/main/scala/temple/test/internal/ServiceTestUtils.scala
@@ -24,7 +24,6 @@ object ServiceTestUtils {
     */
   def postRequest(test: EndpointTest, url: String, body: Json, token: String = ""): JsonObject = {
     val response = Http(url).postData(body.toString).method("POST").header("Authorization", s"Bearer $token").asString
-    if (response.code != 200) println(response.body)
     test.assertEqual(200, response.code)
 
     val parsedBody = parse(response.body) fromEither { failure =>


### PR DESCRIPTION
Test the `CREATE` endpoint of each service by mocking a request body, then validating the response is what we expect:

Again running with `spec-golang` and `tinder.temple`
```
🍪 Spinning up Kubernetes infrastructure...
🧪 Testing Auth service
    ✅ Auth register
    ✅ Auth login
🧪 Testing User service
    ✅ User create
🧪 Testing Match service
    ✅ Match create
💀 Shutting down Kubernetes infrastructure...
```