### PR TITLE
[go-gen] Update go main file import generation

### DIFF
--- a/src/main/scala/temple/generate/server/go/service/GoServiceMainGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/GoServiceMainGenerator.scala
@@ -38,13 +38,6 @@ object GoServiceMainGenerator {
       genStruct("env", ListMap("dao" -> "dao.Datastore") ++ when(usesComms) { "comm" -> "comm.Comm" }),
     )
 
-  /** Given a service name and whether the service uses inter-service communication, return global statements */
-  private[service] def generateGlobals(root: ServiceRoot, usesComms: Boolean): String =
-    mkCode.lines(
-      s"var dao ${root.name}DAO.DAO",
-      when(usesComms) { s"var comm ${root.name}Comm.Handler" },
-    )
-
   /** Given a service name, whether the service uses inter-service communication, the operations desired and the port
     * number, generate the main function */
   private[service] def generateMain(root: ServiceRoot, usesComms: Boolean, operations: Set[CRUD]): String =

--- a/src/main/scala/temple/generate/server/go/service/GoServiceMainGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/GoServiceMainGenerator.scala
@@ -5,30 +5,38 @@ import temple.generate.server.ServiceRoot
 import temple.generate.utils.CodeTerm
 import temple.generate.utils.CodeTerm.{CodeWrap, mkCode}
 import temple.utils.StringUtils.doubleQuote
+import temple.generate.server.go.common.GoCommonGenerator._
 
 import scala.Option.when
+import scala.collection.immutable.ListMap
 
 object GoServiceMainGenerator {
 
-  /** Given a service name, module name and whether the service uses inter-service communication, return the import
-    * block */
-  private[service] def generateImports(root: ServiceRoot, usesComms: Boolean): String = {
-    val standardImports = Seq(
-      //"flag",
-      //"log",
-      "net/http",
-    ).map(doubleQuote)
-
-    val customImports = Seq[CodeTerm](
-      when(usesComms) { s"${root.name}Comm ${doubleQuote(s"${root.module}/comm")}" },
-      s"${root.name}DAO ${doubleQuote(s"${root.module}/dao")}",
-      //doubleQuote(s"$module/util"),
-      //s"valid ${doubleQuote("github.com/asaskevich/govalidator")}",
-      //doubleQuote("github.com/gorilla/mux"),
+  private[service] def generateImports(root: ServiceRoot, usesTime: Boolean, usesComms: Boolean): String =
+    mkCode(
+      "import",
+      CodeWrap.parens.tabbed(
+        //doubleQuote("encoding/json"),
+        //doubleQuote("flag"),
+        //doubleQuote("fmt"),
+        //doubleQuote("log"),
+        //doubleQuote("net/http"),
+        //when(usesTime) { doubleQuote("time") },
+        //"",
+        when(usesComms) { doubleQuote(s"${root.module}/comm") },
+        doubleQuote(s"${root.module}/dao"),
+        //doubleQuote(s"${root.module}/util"),
+        //s"valid ${doubleQuote("github.com/asaskevich/govalidator")}",
+        //doubleQuote("github.com/google/uuid"),
+        //doubleQuote("github.com/gorilla/mux"),
+      ),
     )
 
-    mkCode("import", CodeWrap.parens.tabbed(standardImports, "", customImports))
-  }
+  private[service] def generateEnvStruct(usesComms: Boolean): String =
+    mkCode.lines(
+      "// env defines the environment that requests should be executed within",
+      genStruct("env", ListMap("dao" -> "dao.Datastore") ++ when(usesComms) { "comm" -> "comm.Comm" }),
+    )
 
   /** Given a service name and whether the service uses inter-service communication, return global statements */
   private[service] def generateGlobals(root: ServiceRoot, usesComms: Boolean): String =

--- a/src/main/scala/temple/generate/server/go/service/dao/GoServiceDAOGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/dao/GoServiceDAOGenerator.scala
@@ -14,19 +14,13 @@ import scala.collection.immutable.ListMap
 
 object GoServiceDAOGenerator {
 
-  private[service] def generateImports(root: ServiceRoot): String = {
-    // Check if attributes contains an attribute of type date, time or datetime
-    val containsTime =
-      Set[AttributeType](AttributeType.DateType, AttributeType.TimeType, AttributeType.DateTimeType)
-        .intersect(root.attributes.values.map(_.attributeType).toSet)
-        .nonEmpty
-
+  private[service] def generateImports(root: ServiceRoot, usesTime: Boolean): String =
     mkCode(
       "import",
       CodeWrap.parens.tabbed(
         doubleQuote("database/sql"),
         doubleQuote("fmt"),
-        when(containsTime) { doubleQuote("time") },
+        when(usesTime) { doubleQuote("time") },
         "",
         doubleQuote(s"${root.module}/util"),
         doubleQuote("github.com/google/uuid"),
@@ -35,7 +29,6 @@ object GoServiceDAOGenerator {
         s"_ ${doubleQuote("github.com/lib/pq")}",
       ),
     )
-  }
 
   private[dao] def generateDAOFunctionName(root: ServiceRoot, operation: CRUD): String =
     s"$operation${root.name.capitalize}"

--- a/src/test/scala/temple/generate/server/go/testfiles/match/match.go.snippet
+++ b/src/test/scala/temple/generate/server/go/testfiles/match/match.go.snippet
@@ -1,33 +1,16 @@
 package main
 
 import (
-	"net/http"
-
-	matchComm "github.com/TempleEight/spec-golang/match/comm"
-	matchDAO "github.com/TempleEight/spec-golang/match/dao"
+	"github.com/TempleEight/spec-golang/match/comm"
+	"github.com/TempleEight/spec-golang/match/dao"
 )
 
-var dao matchDAO.DAO
-var comm matchComm.Handler
+// env defines the environment that requests should be executed within
+type env struct {
+	dao  dao.Datastore
+	comm comm.Comm
+}
 
 func main() {
 
 }
-
-func jsonMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// All responses are JSON, set header accordingly
-		w.Header().Set("Content-Type", "application/json")
-		next.ServeHTTP(w, r)
-	})
-}
-
-func matchListHandler(w http.ResponseWriter, r *http.Request) {}
-
-func matchCreateHandler(w http.ResponseWriter, r *http.Request) {}
-
-func matchReadHandler(w http.ResponseWriter, r *http.Request) {}
-
-func matchUpdateHandler(w http.ResponseWriter, r *http.Request) {}
-
-func matchDeleteHandler(w http.ResponseWriter, r *http.Request) {}

--- a/src/test/scala/temple/generate/server/go/testfiles/user/user.go.snippet
+++ b/src/test/scala/temple/generate/server/go/testfiles/user/user.go.snippet
@@ -1,29 +1,14 @@
 package main
 
 import (
-	"net/http"
-
-	userDAO "github.com/TempleEight/spec-golang/user/dao"
+	"github.com/TempleEight/spec-golang/user/dao"
 )
 
-var dao userDAO.DAO
+// env defines the environment that requests should be executed within
+type env struct {
+	dao dao.Datastore
+}
 
 func main() {
 
 }
-
-func jsonMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// All responses are JSON, set header accordingly
-		w.Header().Set("Content-Type", "application/json")
-		next.ServeHTTP(w, r)
-	})
-}
-
-func userCreateHandler(w http.ResponseWriter, r *http.Request) {}
-
-func userReadHandler(w http.ResponseWriter, r *http.Request) {}
-
-func userUpdateHandler(w http.ResponseWriter, r *http.Request) {}
-
-func userDeleteHandler(w http.ResponseWriter, r *http.Request) {}


### PR DESCRIPTION
* Updates import generation in non-auth service main files, i.e. `user.go` and `match.go`
* Updates tests
  * Omits some imports so integration tests pass, will be uncommented at a later date

Small PR because I wanna refactor the attribute types in `IDAttribute` and `CreatedByAttribute` before I generate the structs in these files, which will also need to update Lewis' recent mapping code.