### PR TITLE
[project-test] Add tests for read, update and delete endpoints

### DIFF
--- a/src/main/scala/temple/test/internal/CRUDServiceTest.scala
+++ b/src/main/scala/temple/test/internal/CRUDServiceTest.scala
@@ -11,26 +11,57 @@ class CRUDServiceTest(name: String, service: ServiceBlock, allServices: Map[Stri
     testEndpoint("create") { test =>
       val requestBody =
         ServiceTestUtils.constructRequestBody(test, service.attributes, allServices, baseURL, accessToken)
-      val createJSON = ServiceTestUtils
-        .postRequest(
+      val createJSON =
+        ServiceTestUtils.postRequest(test, s"http://$baseURL/api/${name.toLowerCase}", requestBody, accessToken)
+      test.validateResponseBody(requestBody.asObject, createJSON, service.attributes)
+    }
+
+  private def testReadEndpoint(accessToken: String): Unit =
+    testEndpoint("read") { test =>
+      val createResponse = ServiceTestUtils.create(test, name, allServices, baseURL, accessToken)
+      val getJSON = ServiceTestUtils
+        .getRequest(test, s"http://$baseURL/api/${name.toLowerCase}/${createResponse.id}", createResponse.accessToken)
+      test.validateResponseBody(None, getJSON, service.attributes)
+    }
+
+  private def testUpdateEndpoint(accessToken: String): Unit =
+    testEndpoint("update") { test =>
+      val createResponse = ServiceTestUtils.create(test, name, allServices, baseURL, accessToken)
+      val requestBody =
+        ServiceTestUtils
+          .constructRequestBody(test, service.attributes, allServices, baseURL, createResponse.accessToken)
+      val updateJSON =
+        ServiceTestUtils.putRequest(
           test,
-          s"http://$baseURL/api/${name.toLowerCase}",
+          s"http://$baseURL/api/${name.toLowerCase}/${createResponse.id}",
           requestBody,
-          accessToken,
+          createResponse.accessToken,
         )
-      test.validateResponseBody(
-        requestBody.asObject.getOrElse(test.fail(s"Request was not a JSON object")),
-        createJSON,
-        service.attributes,
-      )
+      test.validateResponseBody(requestBody.asObject, updateJSON, service.attributes)
+    }
+
+  private def testDeleteEndpoint(accessToken: String): Unit =
+    testEndpoint("delete") { test =>
+      val createResponse = ServiceTestUtils.create(test, name, allServices, baseURL, accessToken)
+      val deleteJSON =
+        ServiceTestUtils.deleteRequest(
+          test,
+          s"http://$baseURL/api/${name.toLowerCase}/${createResponse.id}",
+          createResponse.accessToken,
+        )
+      test.assert(deleteJSON.isEmpty, "delete response was not empty")
     }
 
   // Test each type of endpoint that is present in the service
   def test(): Unit = {
     val accessToken = ServiceTestUtils.getAuthTokenWithEmail(name, baseURL)
-    val endpoints   = ProjectBuilder.endpoints(service)
-    if (endpoints.contains(CRUD.Create)) testCreateEndpoint(accessToken)
-    // TODO: Read, Update, Delete, List
+    ProjectBuilder.endpoints(service).foreach {
+      case CRUD.List   => // TODO
+      case CRUD.Create => testCreateEndpoint(accessToken)
+      case CRUD.Read   => testReadEndpoint(accessToken)
+      case CRUD.Update => testUpdateEndpoint(accessToken)
+      case CRUD.Delete => testDeleteEndpoint(accessToken)
+    }
   }
 }
 


### PR DESCRIPTION
Add additional tests for the read, update and delete endpoints of each service: 


`spec-golang` with `tinder.temple`:
```
🍪 Spinning up Kubernetes infrastructure...
🧪 Testing Auth service
    ✅ Auth register
    ✅ Auth login
🧪 Testing User service
    ✅ User create
    ✅ User read
    ✅ User update
    ✅ User delete
🧪 Testing Match service
    ✅ Match create
    ✅ Match read
    ✅ Match update
    ✅ Match delete
💀 Shutting down Kubernetes infrastructure...
```