### PR TITLE
[fix] Map foreign keys to uuid types in server builder

### DIFF
--- a/src/main/scala/temple/builder/ServerBuilder.scala
+++ b/src/main/scala/temple/builder/ServerBuilder.scala
@@ -68,8 +68,8 @@ object ServerBuilder {
 
     // In the server code all foreign keys are stored as UUID types - map into the correct type
     val attributes: ListMap[String, Attribute] = ListMap.from(serviceBlock.attributes.map {
-      case (str, Attribute(_: ForeignKey, y, z)) => (str, Attribute(AttributeType.UUIDType, y, z))
-      case default                               => default
+      case (str, Attribute(_: ForeignKey, access, value)) => (str, Attribute(AttributeType.UUIDType, access, value))
+      case default                                        => default
     })
 
     // TODO: Auth

--- a/src/main/scala/temple/builder/ServerBuilder.scala
+++ b/src/main/scala/temple/builder/ServerBuilder.scala
@@ -66,6 +66,12 @@ object ServerBuilder {
       case (_, Attribute(x: ForeignKey, _, _)) => x.references
     }.toSeq
 
+    // In the server code all foreign keys are stored as UUID types - map into the correct type
+    val attributes: ListMap[String, Attribute] = ListMap.from(serviceBlock.attributes.map {
+      case (str, Attribute(_: ForeignKey, y, z)) => (str, Attribute(AttributeType.UUIDType, y, z))
+      case default                               => default
+    })
+
     // TODO: Auth
 
     ServiceRoot(
@@ -76,7 +82,7 @@ object ServerBuilder {
       port = port,
       idAttribute = idAttribute,
       createdByAttribute = createdBy,
-      attributes = ListMap.from(serviceBlock.attributes),
+      attributes = attributes,
       datastore = serviceBlock.lookupMetadata[Metadata.Database].getOrElse(ProjectConfig.defaultDatabase),
     )
   }


### PR DESCRIPTION
I forgot that the server code requires the ForeignKey attributes to be turned into UUIDs at the builder stage - This fixes that

n.b we should probably update the tests to include some templefiles with foreign keys (though this sounds like a whole lot of work)