### PR TITLE
[Validator] Test sets of errors rather than strings

### DIFF
--- a/src/main/scala/temple/DSL/semantics/Validator.scala
+++ b/src/main/scala/temple/DSL/semantics/Validator.scala
@@ -144,6 +144,12 @@ private class Validator private (templefile: Templefile) {
 
 object Validator {
 
+  def validationErrors(templefile: Templefile): Set[String] = {
+    val validator = new Validator(templefile)
+    validator.validate()
+    validator.errors.toSet
+  }
+
   def validate(templefile: Templefile): Templefile = {
     val validator   = new Validator(templefile)
     val parseErrors = validator.validate()


### PR DESCRIPTION
The test messages were annoying me, so I’ve switched to testing the sets of error strings rather than the resulting error message. Don’t worry, the old method is still tested as before

Turn off whitespace to shrink the diff to a more manageable +90–69