### PR TITLE
[Validator] Add decapitalize function

### DIFF
--- a/src/main/scala/temple/utils/StringUtils.scala
+++ b/src/main/scala/temple/utils/StringUtils.scala
@@ -38,6 +38,7 @@ object StringUtils {
 
   /** Convert the first character/acronym of a string to lowercase */
   def decapitalize(string: String): String =
+    // The first capital of the string, optionally followed by any subsequent capitals except for those starting a word
     """^[A-Z]([A-Z]+(?=[^a-z]))?""".r.replaceAllIn(string, leadingCapitals => leadingCapitals.group(0).toLowerCase)
 
   type StringWrap = String => String

--- a/src/main/scala/temple/utils/StringUtils.scala
+++ b/src/main/scala/temple/utils/StringUtils.scala
@@ -36,6 +36,10 @@ object StringUtils {
   def randomString(length: Int): String =
     new Random().alphanumeric.take(length).mkString
 
+  /** Convert the first character/acronym of a string to lowercase */
+  def decapitalize(string: String): String =
+    """^[A-Z]([A-Z]+(?=[^a-z]))?""".r.replaceAllIn(string, leadingCapitals => leadingCapitals.group(0).toLowerCase)
+
   type StringWrap = String => String
 
   private def stringWrap(start: String, end: String)(string: String): String = start + string + end

--- a/src/test/scala/temple/utils/StringUtilsTest.scala
+++ b/src/test/scala/temple/utils/StringUtilsTest.scala
@@ -1,7 +1,7 @@
 package temple.utils
 
 import org.scalatest.{FlatSpec, Matchers}
-import temple.utils.StringUtils.{españolQue, indent, snakeCase}
+import temple.utils.StringUtils._
 
 class StringUtilsTest extends FlatSpec with Matchers {
 
@@ -24,6 +24,15 @@ class StringUtilsTest extends FlatSpec with Matchers {
   it should "add spaces on each line except for blank lines" in {
     indent("abcd\nefg", 1) shouldEqual " abcd\n efg"
     indent("abcd\n\nefg\n", 1) shouldEqual " abcd\n\n efg\n"
+  }
+
+  behavior of "decapitalize"
+
+  it should "convert leading capital or acronyms" in {
+    decapitalize("ThisThing") shouldEqual "thisThing"
+    decapitalize("A_Box") shouldEqual "a_Box"
+    decapitalize("AB_Box") shouldEqual "ab_Box"
+    decapitalize("ABBox") shouldEqual "abBox"
   }
 
   behavior of "snakeCase"


### PR DESCRIPTION
This is for adding the project name to the start of attributes with illegal names in the database. If any language doesn’t like a variable name, it gets renamed everywhere, so if Postgres doesn’t like a name, a prefix will be added, and this will still need to start with a lower-case name for Go