### PR TITLE
[Validator] Allow metadata to be looked up from struct blocks

### DIFF
--- a/src/main/scala/temple/ast/ServiceBlock.scala
+++ b/src/main/scala/temple/ast/ServiceBlock.scala
@@ -19,8 +19,9 @@ case class ServiceBlock(
   def structIterator(rootName: String): Iterator[(String, Map[String, Attribute])] =
     Iterator((rootName, attributes)) ++ structs.iterator.map { case (str, block) => (str, block.attributes) }
 
-  override private[temple] def setParent(templefile: Templefile): Unit = {
-    super.setParent(templefile)
-    structs.valuesIterator.foreach(_.setParent(templefile))
+  /** Set the parent that this Templefile is within */
+  override private[temple] def setParent(parent: TempleNode): Unit = {
+    super.setParent(parent)
+    structs.valuesIterator.foreach(_.setParent(this))
   }
 }

--- a/src/main/scala/temple/ast/TempleBlock.scala
+++ b/src/main/scala/temple/ast/TempleBlock.scala
@@ -3,26 +3,26 @@ package temple.ast
 import scala.reflect.ClassTag
 
 /** Any of the root blocks in the Templefile */
-abstract class TempleBlock[+M <: Metadata] {
+abstract class TempleBlock[+M <: Metadata] extends TempleNode {
 
   /** The list of metadata items in the block */
   def metadata: Seq[M]
 
   /** The Templefile that this block is within */
-  private var parent: Templefile = _
+  private var parent: TempleNode = _
 
   /** Set the parent that this Templefile is within */
-  private[temple] def setParent(templefile: Templefile): Unit = parent = templefile
+  private[temple] def setParent(parent: TempleNode): Unit = this.parent = parent
 
   /** Fall back to the default metadata for the project */
-  final private def lookupDefaultMetadata[T <: Metadata: ClassTag]: Option[T] = {
+  final protected def lookupDefaultMetadata[T <: Metadata: ClassTag]: Option[T] = {
     if (parent == null) {
       throw new NullPointerException(
         "Cannot lookup metadata: block not registered as part of a Templefile. " +
         "Use lookupLocalMetadata if this was intentional",
       )
     }
-    Option.when(parent.projectBlock != this)(parent) flatMap { _.projectBlock.lookupMetadata[T] }
+    parent.lookupMetadata[T]
   }
 
   /**
@@ -32,12 +32,4 @@ abstract class TempleBlock[+M <: Metadata] {
     */
   final def lookupLocalMetadata[T <: Metadata: ClassTag]: Option[T] =
     metadata.iterator.collectFirst { case m: T => m }
-
-  /**
-    * Find a metadata item by type, defaulting to the value defined at the project level
-    * @tparam T The type of metadata to be provided. This must be explicitly given, in square brackets
-    * @return an option of the metadata item
-    */
-  def lookupMetadata[T <: Metadata: ClassTag]: Option[T] =
-    lookupLocalMetadata[T] orElse lookupDefaultMetadata[T]
 }

--- a/src/main/scala/temple/ast/TempleNode.scala
+++ b/src/main/scala/temple/ast/TempleNode.scala
@@ -1,0 +1,24 @@
+package temple.ast
+
+import scala.reflect.ClassTag
+
+trait TempleNode {
+
+  /** Fall back to the default metadata for the project */
+  protected def lookupDefaultMetadata[T <: Metadata: ClassTag]: Option[T]
+
+  /**
+    * Find a metadata item by type
+    * @tparam T The type of metadata to be provided. This must be explicitly given, in square brackets
+    * @return an option of the metadata item
+    */
+  def lookupLocalMetadata[T <: Metadata: ClassTag]: Option[T]
+
+  /**
+    * Find a metadata item by type, defaulting to the value defined at the project level
+    * @tparam T The type of metadata to be provided. This must be explicitly given, in square brackets
+    * @return an option of the metadata item
+    */
+  final def lookupMetadata[T <: Metadata: ClassTag]: Option[T] =
+    lookupLocalMetadata[T] orElse lookupDefaultMetadata[T]
+}

--- a/src/main/scala/temple/ast/Templefile.scala
+++ b/src/main/scala/temple/ast/Templefile.scala
@@ -2,13 +2,15 @@ package temple.ast
 
 import temple.ast.Templefile.Ports
 
+import scala.reflect.ClassTag
+
 /** The semantic representation of a Templefile */
 case class Templefile(
   projectName: String,
   projectBlock: ProjectBlock = ProjectBlock(),
   targets: Map[String, TargetBlock] = Map(),
   services: Map[String, ServiceBlock] = Map(),
-) {
+) extends TempleNode {
   // Inform every child node of their parent, so that they can access the project information
   for (block <- Iterator(projectBlock) ++ targets.valuesIterator ++ services.valuesIterator) {
     block.setParent(this)
@@ -18,6 +20,17 @@ case class Templefile(
     services
       .zip(Iterator.from(1024, step = 2))
       .map { case ((name, service), port) => (name, service, Ports(port, port + 1)) }
+
+  /** Fall back to the default metadata for the project */
+  override protected def lookupDefaultMetadata[T <: Metadata: ClassTag]: Option[T] = None
+
+  /**
+    * Find a metadata item by type
+    *
+    * @tparam T The type of metadata to be provided. This must be explicitly given, in square brackets
+    * @return an option of the metadata item
+    */
+  override def lookupLocalMetadata[T <: Metadata: ClassTag]: Option[T] = projectBlock.lookupLocalMetadata[T]
 }
 
 object Templefile {

--- a/src/test/scala/temple/DSL/semantics/TempleBlockTest.scala
+++ b/src/test/scala/temple/DSL/semantics/TempleBlockTest.scala
@@ -32,4 +32,16 @@ class TempleBlockTest extends FlatSpec with Matchers {
     serviceBlock.lookupMetadata[Metadata.Database] shouldBe Some(Metadata.Database.Postgres)
     serviceBlock.lookupMetadata[Metadata.Uses] shouldBe None
   }
+
+  it should "lookupMetadata in a struct block in a project file" in {
+    val projectBlock = ProjectBlock(Seq(Metadata.Database.Postgres))
+    val structBlock  = StructBlock(Map.empty)
+    val serviceBlock = ServiceBlock(Map.empty, Seq(Metadata.ServiceLanguage.Go), Map("Struct" -> structBlock))
+
+    Templefile("TestProject", projectBlock, services = Map("Users" -> serviceBlock))
+
+    structBlock.lookupMetadata[Metadata.ServiceLanguage] shouldBe Some(Metadata.ServiceLanguage.Go)
+    structBlock.lookupMetadata[Metadata.Database] shouldBe Some(Metadata.Database.Postgres)
+    structBlock.lookupMetadata[Metadata.Uses] shouldBe None
+  }
 }


### PR DESCRIPTION
This refactor of the struct blocks makes the validator a bit easier. It does come with the caveat that things like `#omit` will be inherited, but for those they shouldn’t be inherited from the project block either so `lookupLocalMetadata` can just be used instead for accessing this property for a struct block. We haven’t yet even implemented struct block handling though, so no big deal