### PR TITLE
[go-gen] Add main function generation

### DIFF
--- a/src/e2e/resources/go/user/user.go.snippet
+++ b/src/e2e/resources/go/user/user.go.snippet
@@ -1,10 +1,14 @@
 package main
 
 import (
+	"flag"
+	"log"
 	"net/http"
 	"time"
 
 	"github.com/squat/and/dab/templeuser/dao"
+	"github.com/squat/and/dab/templeuser/util"
+	valid "github.com/asaskevich/govalidator"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 )
@@ -114,7 +118,25 @@ func (env *env) router() *mux.Router {
 }
 
 func main() {
+	configPtr := flag.String("config", "/etc/templeuser-service/config.json", "configuration filepath")
+	flag.Parse()
 
+	// Require all struct fields by default
+	valid.SetFieldsRequiredByDefault(true)
+
+	config, err := util.GetConfig(*configPtr)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	d, err := dao.Init(config)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	env := env{d}
+
+	log.Fatal(http.ListenAndServe(":1024", env.router()))
 }
 
 func jsonMiddleware(next http.Handler) http.Handler {

--- a/src/main/scala/temple/generate/server/go/auth/GoAuthServiceGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/auth/GoAuthServiceGenerator.scala
@@ -18,7 +18,7 @@ object GoAuthServiceGenerator extends AuthServiceGenerator {
         GoAuthServiceMainGenerator.generateImports(root),
         GoAuthServiceMainGenerator.generateStructs(),
         GoAuthServiceMainGenerator.generateRouter(),
-        GoCommonMainGenerator.generateMain(isAuth = true, "auth", root.port, usesComms = true),
+        GoCommonMainGenerator.generateMain("auth", root.port, usesComms = true, isAuth = true),
         GoCommonMainGenerator.generateJsonMiddleware(),
         GoAuthServiceMainGenerator.generateHandlers(),
         GoAuthServiceMainGenerator.generateCreateToken(),

--- a/src/main/scala/temple/generate/server/go/auth/GoAuthServiceGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/auth/GoAuthServiceGenerator.scala
@@ -19,7 +19,7 @@ object GoAuthServiceGenerator extends AuthServiceGenerator {
         GoAuthServiceMainGenerator.generateImports(root),
         GoAuthServiceMainGenerator.generateStructs(),
         GoAuthServiceMainGenerator.generateRouter(),
-        GoAuthServiceMainGenerator.generateMain(),
+        GoCommonMainGenerator.generateMain(isAuth = true, "auth", root.port, usesComms = true),
         GoCommonMainGenerator.generateJsonMiddleware(),
         GoAuthServiceMainGenerator.generateHandlers(),
         GoAuthServiceMainGenerator.generateCreateToken(),

--- a/src/main/scala/temple/generate/server/go/auth/GoAuthServiceGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/auth/GoAuthServiceGenerator.scala
@@ -9,7 +9,6 @@ object GoAuthServiceGenerator extends AuthServiceGenerator {
 
   override def generate(root: AuthServiceRoot): Files =
     /* TODO
-     * auth.go main
      * config.json
      */
     Map(

--- a/src/main/scala/temple/generate/server/go/auth/GoAuthServiceMainGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/auth/GoAuthServiceMainGenerator.scala
@@ -31,16 +31,6 @@ object GoAuthServiceMainGenerator {
   private[auth] def generateRouter(): String =
     FileUtils.readResources("go/genFiles/auth/main/router.go.snippet").stripLineEnd
 
-  private[auth] def generateMain(): String =
-    mkCode(
-      "func main() ",
-      CodeWrap.curly.tabbed(
-        mkCode.lines(
-          "",
-        ),
-      ),
-    )
-
   private[auth] def generateHandlers(): String =
     FileUtils.readResources("go/genFiles/auth/main/handlers.go.snippet").stripLineEnd
 

--- a/src/main/scala/temple/generate/server/go/common/GoCommonGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/common/GoCommonGenerator.scala
@@ -48,6 +48,14 @@ object GoCommonGenerator {
       ),
     )
 
+  private[go] def genIfErr(body: String): String =
+    mkCode(
+      "if err != nil",
+      CodeWrap.curly.tabbed(
+        body,
+      ),
+    )
+
   /** Generate constant */
   private[go] def genConst(identifier: String, expr: String): String =
     mkCode(
@@ -113,6 +121,10 @@ object GoCommonGenerator {
   /** Generate function call */
   private[go] def genFunctionCall(name: String, args: String*): String =
     CodeWrap.parens.prefix(name).list(args)
+
+  /** Generate method call */
+  private[go] def genMethodCall(objectName: String, methodName: String, args: String*): String =
+    s"$objectName.${genFunctionCall(methodName, args: _*)}"
 
   /** Generate if statement */
   private[go] def genIf(expr: String, body: String): String =

--- a/src/main/scala/temple/generate/server/go/common/GoCommonMainGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/common/GoCommonMainGenerator.scala
@@ -28,7 +28,7 @@ object GoCommonMainGenerator {
       ),
     )
 
-  private[go] def generateMain(isAuth: Boolean, serviceName: String, port: Int, usesComms: Boolean): String =
+  private[go] def generateMain(serviceName: String, port: Int, usesComms: Boolean, isAuth: Boolean): String =
     mkCode(
       "func main()",
       CodeWrap.curly.tabbed(

--- a/src/main/scala/temple/generate/server/go/service/GoServiceGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/GoServiceGenerator.scala
@@ -49,7 +49,7 @@ object GoServiceGenerator extends ServiceGenerator {
         },
         GoServiceMainStructGenerator.generateResponseStructs(root, operations),
         GoServiceMainGenerator.generateRouter(root, operations),
-        GoCommonMainGenerator.generateMain(isAuth = false, root.name, root.port, usesComms),
+        GoCommonMainGenerator.generateMain(root.name, root.port, usesComms, isAuth = false),
         GoCommonMainGenerator.generateJsonMiddleware(),
         GoServiceMainGenerator.generateHandlers(root, operations),
       ),

--- a/src/main/scala/temple/generate/server/go/service/GoServiceGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/GoServiceGenerator.scala
@@ -50,7 +50,7 @@ object GoServiceGenerator extends ServiceGenerator {
         },
         GoServiceMainStructGenerator.generateResponseStructs(root, operations),
         GoServiceMainGenerator.generateRouter(root, operations),
-        GoServiceMainGenerator.generateMain(root, usesComms, operations),
+        GoCommonMainGenerator.generateMain(isAuth = false, root.name, root.port, usesComms),
         GoCommonMainGenerator.generateJsonMiddleware(),
         GoServiceMainGenerator.generateHandlers(root, operations),
       ),

--- a/src/main/scala/temple/generate/server/go/service/GoServiceGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/GoServiceGenerator.scala
@@ -16,7 +16,6 @@ object GoServiceGenerator extends ServiceGenerator {
 
   override def generate(root: ServiceRoot): Files = {
     /* TODO
-     * main in <>.go
      * handlers in <>.go
      * config.json
      */

--- a/src/main/scala/temple/generate/server/go/service/main/GoServiceMainGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/main/GoServiceMainGenerator.scala
@@ -23,9 +23,9 @@ object GoServiceMainGenerator {
       "import",
       CodeWrap.parens.tabbed(
         //doubleQuote("encoding/json"),
-        //doubleQuote("flag"),
+        doubleQuote("flag"),
         //doubleQuote("fmt"),
-        //doubleQuote("log"),
+        doubleQuote("log"),
         doubleQuote("net/http"),
         // TODO: This check is temporary to make the integration tests pass
         when(
@@ -41,8 +41,8 @@ object GoServiceMainGenerator {
         "",
         when(usesComms) { doubleQuote(s"${root.module}/comm") },
         doubleQuote(s"${root.module}/dao"),
-        //doubleQuote(s"${root.module}/util"),
-        //s"valid ${doubleQuote("github.com/asaskevich/govalidator")}",
+        doubleQuote(s"${root.module}/util"),
+        s"valid ${doubleQuote("github.com/asaskevich/govalidator")}",
         doubleQuote("github.com/google/uuid"),
         doubleQuote("github.com/gorilla/mux"),
       ),
@@ -78,62 +78,6 @@ object GoServiceMainGenerator {
       ),
     )
   }
-
-  /** Given a service name, whether the service uses inter-service communication, the operations desired and the port
-    * number, generate the main function */
-  private[service] def generateMain(root: ServiceRoot, usesComms: Boolean, operations: Set[CRUD]): String =
-    mkCode(
-      "func main() ",
-      CodeWrap.curly.tabbed(
-        mkCode.lines(
-          "",
-          /*
-          s"""configPtr := flag.String("config", "/etc/$serviceName-service/config.json", "configuration filepath")""",
-          "flag.Parse()",
-          "",
-          "// Require all struct fields by default",
-          "valid.SetFieldsRequiredByDefault(true)",
-          "",
-          "config, err := util.GetConfig(*configPtr)",
-          "if err != nil " + CodeWrap.curly.tabbed("log.Fatal(err)"),
-          "",
-          s"dao = ${serviceName}DAO.DAO{}",
-          "err = dao.Init(config)",
-          "if err != nil " + CodeWrap.curly.tabbed("log.Fatal(err)"),
-          "",
-          when(usesComms) {
-            mkCode.lines(
-              s"comm = ${serviceName}Comm.Handler{}",
-              "comm.Init(config)",
-              "",
-            )
-          },
-          "r := mux.NewRouter()",
-          when(operations.contains(CRUD.List)) {
-            mkCode.lines(
-              "// Mux directs to first matching route, i.e. the order matters",
-              s"""r.HandleFunc("/$serviceName/all", ${serviceName}ListHandler).Methods(http.MethodGet)""",
-            )
-          },
-          when(operations.contains(CRUD.Create)) {
-            s"""r.HandleFunc("/$serviceName", ${serviceName}CreateHandler).Methods(http.MethodPost)"""
-          },
-          when(operations.contains(CRUD.Read)) {
-            s"""r.HandleFunc("/$serviceName/{id}", ${serviceName}ReadHandler).Methods(http.MethodGet)"""
-          },
-          when(operations.contains(CRUD.Update)) {
-            s"""r.HandleFunc("/$serviceName/{id}", ${serviceName}UpdateHandler).Methods(http.MethodPut)"""
-          },
-          when(operations.contains(CRUD.Delete)) {
-            s"""r.HandleFunc("/$serviceName/{id}", ${serviceName}DeleteHandler).Methods(http.MethodDelete)"""
-          },
-          "r.Use(jsonMiddleware)",
-          "",
-          s"""log.Fatal(http.ListenAndServe(":$port", r))""",
-         */
-        ),
-      ),
-    )
 
   private def generateHandler(root: ServiceRoot, operation: CRUD): String =
     s"func (env *env) ${operation.toString.toLowerCase}${root.name.capitalize}Handler(w http.ResponseWriter, r *http.Request) {}"

--- a/src/test/resources/go/complex-user/complexuser.go.snippet
+++ b/src/test/resources/go/complex-user/complexuser.go.snippet
@@ -1,10 +1,14 @@
 package main
 
 import (
+	"flag"
+	"log"
 	"net/http"
 	"time"
 
 	"github.com/squat/and/dab/complexuser/dao"
+	"github.com/squat/and/dab/complexuser/util"
+	valid "github.com/asaskevich/govalidator"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 )
@@ -110,7 +114,25 @@ func (env *env) router() *mux.Router {
 }
 
 func main() {
+	configPtr := flag.String("config", "/etc/complexuser-service/config.json", "configuration filepath")
+	flag.Parse()
 
+	// Require all struct fields by default
+	valid.SetFieldsRequiredByDefault(true)
+
+	config, err := util.GetConfig(*configPtr)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	d, err := dao.Init(config)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	env := env{d}
+
+	log.Fatal(http.ListenAndServe(":1024", env.router()))
 }
 
 func jsonMiddleware(next http.Handler) http.Handler {

--- a/src/test/resources/go/simple-user/user.go.snippet
+++ b/src/test/resources/go/simple-user/user.go.snippet
@@ -1,10 +1,14 @@
 package main
 
 import (
+	"flag"
+	"log"
 	"net/http"
 	"time"
 
 	"github.com/squat/and/dab/templeuser/dao"
+	"github.com/squat/and/dab/templeuser/util"
+	valid "github.com/asaskevich/govalidator"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 )
@@ -90,7 +94,25 @@ func (env *env) router() *mux.Router {
 }
 
 func main() {
+	configPtr := flag.String("config", "/etc/templeuser-service/config.json", "configuration filepath")
+	flag.Parse()
 
+	// Require all struct fields by default
+	valid.SetFieldsRequiredByDefault(true)
+
+	config, err := util.GetConfig(*configPtr)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	d, err := dao.Init(config)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	env := env{d}
+
+	log.Fatal(http.ListenAndServe(":1024", env.router()))
 }
 
 func jsonMiddleware(next http.Handler) http.Handler {

--- a/src/test/scala/temple/generate/server/go/testfiles/auth/auth.go.snippet
+++ b/src/test/scala/temple/generate/server/go/testfiles/auth/auth.go.snippet
@@ -58,7 +58,32 @@ func (env *env) router() *mux.Router {
 }
 
 func main() {
+	configPtr := flag.String("config", "/etc/auth-service/config.json", "configuration filepath")
+	flag.Parse()
 
+	// Require all struct fields by default
+	valid.SetFieldsRequiredByDefault(true)
+
+	config, err := util.GetConfig(*configPtr)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	d, err := dao.Init(config)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	c := comm.Init(config)
+
+	jwtCredential, err := c.CreateJWTCredential()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	env := env{d, c, jwtCredential}
+
+	log.Fatal(http.ListenAndServe(":82", env.router()))
 }
 
 func jsonMiddleware(next http.Handler) http.Handler {

--- a/src/test/scala/temple/generate/server/go/testfiles/match/match.go.snippet
+++ b/src/test/scala/temple/generate/server/go/testfiles/match/match.go.snippet
@@ -1,10 +1,14 @@
 package main
 
 import (
+	"flag"
+	"log"
 	"net/http"
 
 	"github.com/TempleEight/spec-golang/match/comm"
 	"github.com/TempleEight/spec-golang/match/dao"
+	"github.com/TempleEight/spec-golang/match/util"
+	valid "github.com/asaskevich/govalidator"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 )
@@ -78,7 +82,27 @@ func (env *env) router() *mux.Router {
 }
 
 func main() {
+	configPtr := flag.String("config", "/etc/match-service/config.json", "configuration filepath")
+	flag.Parse()
 
+	// Require all struct fields by default
+	valid.SetFieldsRequiredByDefault(true)
+
+	config, err := util.GetConfig(*configPtr)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	d, err := dao.Init(config)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	c := comm.Init(config)
+
+	env := env{d, c}
+
+	log.Fatal(http.ListenAndServe(":81", env.router()))
 }
 
 func jsonMiddleware(next http.Handler) http.Handler {

--- a/src/test/scala/temple/generate/server/go/testfiles/user/user.go.snippet
+++ b/src/test/scala/temple/generate/server/go/testfiles/user/user.go.snippet
@@ -1,9 +1,13 @@
 package main
 
 import (
+	"flag"
+	"log"
 	"net/http"
 
 	"github.com/TempleEight/spec-golang/user/dao"
+	"github.com/TempleEight/spec-golang/user/util"
+	valid "github.com/asaskevich/govalidator"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 )
@@ -54,7 +58,25 @@ func (env *env) router() *mux.Router {
 }
 
 func main() {
+	configPtr := flag.String("config", "/etc/user-service/config.json", "configuration filepath")
+	flag.Parse()
 
+	// Require all struct fields by default
+	valid.SetFieldsRequiredByDefault(true)
+
+	config, err := util.GetConfig(*configPtr)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	d, err := dao.Init(config)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	env := env{d}
+
+	log.Fatal(http.ListenAndServe(":80", env.router()))
 }
 
 func jsonMiddleware(next http.Handler) http.Handler {


### PR DESCRIPTION
* Adds generation of the main function for both auth and non-auth services
  * Uses the same function for both since they're very similar, does mean deconstructing the root though
* Updates tests

This completes the `Auth` service! Should be ready to run aside from the `config.json`, which I'll do before the non-auth handlers.
