### PR TITLE
[go-gen][metrics] Populate metric.go

### DIFF
--- a/src/e2e/resources/go/user/metric/metric.go.snippet
+++ b/src/e2e/resources/go/user/metric/metric.go.snippet
@@ -1,1 +1,29 @@
 package metric
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	RequestList   = "list"
+	RequestCreate = "create"
+	RequestRead   = "read"
+	RequestUpdate = "update"
+
+	RequestSuccess = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "templeuser_request_success_total",
+		Help: "The total number of successful requests",
+	}, []string{"request_type"})
+
+	RequestFailure = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "templeuser_request_failure_total",
+		Help: "The total number of failed requests",
+	}, []string{"request_type", "error_code"})
+
+	DatabaseRequestDuration = promauto.NewSummaryVec(prometheus.SummaryOpts{
+		Name:       "templeuser_database_request_seconds",
+		Help:       "The time spent executing database requests in seconds",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.95: 0.005, 0.99: 0.001},
+	}, []string{"query_type"})
+)

--- a/src/main/scala/temple/generate/server/go/common/GoCommonGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/common/GoCommonGenerator.scala
@@ -148,4 +148,10 @@ object GoCommonGenerator {
       "return",
       mkCode.list(exprs),
     )
+
+  /** Generate a populated struct */
+  private[go] def genPopulateStruct(name: String, body: ListMap[String, String]): String =
+    CodeWrap.curly
+      .prefix(name)
+      .tabbedTrailingList(CodeUtils.pad(body.map { case (k, v) => (k + ":", v) }))
 }

--- a/src/main/scala/temple/generate/server/go/service/GoServiceGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/GoServiceGenerator.scala
@@ -74,6 +74,8 @@ object GoServiceGenerator extends ServiceGenerator {
       ),
       File(s"${root.name}/metric", "metric.go") -> mkCode.doubleLines(
         GoCommonGenerator.generatePackage("metric"),
+        GoServiceMetricGenerator.generateImports(),
+        GoServiceMetricGenerator.generateVars(root, operations),
       ),
     ) ++ when(usesComms)(
       File(s"${root.name}/comm", "handler.go") -> mkCode.doubleLines(

--- a/src/main/scala/temple/generate/server/go/service/GoServiceMetricGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/GoServiceMetricGenerator.scala
@@ -2,10 +2,9 @@ package temple.generate.server.go.service
 
 import temple.generate.CRUD.CRUD
 import temple.generate.server.ServiceRoot
-import temple.generate.server.go.common.GoCommonGenerator
+import temple.generate.server.go.common.GoCommonGenerator._
 import temple.generate.utils.CodeTerm.{CodeWrap, mkCode}
 import temple.utils.StringUtils.doubleQuote
-import temple.generate.server.go.common.GoCommonGenerator.genAssign
 import temple.generate.utils.CodeUtils
 
 import scala.collection.immutable.ListMap
@@ -24,9 +23,9 @@ object GoServiceMetricGenerator {
     )
 
   private def generatePrometheusCounter(name: String, help: String, tags: Seq[String]): String =
-    GoCommonGenerator.genFunctionCall(
+    genFunctionCall(
       "promauto.NewCounterVec",
-      GoCommonGenerator.genPopulateStruct(
+      genPopulateStruct(
         "prometheus.CounterOpts",
         ListMap(
           "Name" -> doubleQuote(name),
@@ -42,9 +41,9 @@ object GoServiceMetricGenerator {
     objectives: Seq[(Double, Double)],
     tags: Seq[String],
   ): String =
-    GoCommonGenerator.genFunctionCall(
+    genFunctionCall(
       "promauto.NewSummaryVec",
-      GoCommonGenerator.genPopulateStruct(
+      genPopulateStruct(
         "prometheus.SummaryOpts",
         ListMap(
           "Name" -> doubleQuote(name),

--- a/src/main/scala/temple/generate/server/go/service/GoServiceMetricGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/GoServiceMetricGenerator.scala
@@ -1,3 +1,101 @@
 package temple.generate.server.go.service
 
-class GoServiceMetricGenerator {}
+import temple.generate.CRUD.CRUD
+import temple.generate.server.ServiceRoot
+import temple.generate.server.go.common.GoCommonGenerator
+import temple.generate.utils.CodeTerm.{CodeWrap, mkCode}
+import temple.utils.StringUtils.doubleQuote
+import temple.generate.server.go.common.GoCommonGenerator.genAssign
+import temple.generate.utils.CodeUtils
+
+import scala.collection.immutable.ListMap
+
+object GoServiceMetricGenerator {
+
+  private[service] def generateImports(): String =
+    mkCode(
+      "import",
+      CodeWrap.parens.tabbed(
+        Seq(
+          "github.com/prometheus/client_golang/prometheus",
+          "github.com/prometheus/client_golang/prometheus/promauto",
+        ).map(doubleQuote),
+      ),
+    )
+
+  private def generatePrometheusCounter(name: String, help: String, tags: Seq[String]): String =
+    GoCommonGenerator.genFunctionCall(
+      "promauto.NewCounterVec",
+      GoCommonGenerator.genPopulateStruct(
+        "prometheus.CounterOpts",
+        ListMap(
+          "Name" -> doubleQuote(name),
+          "Help" -> doubleQuote(help),
+        ),
+      ),
+      CodeWrap.curly.prefix("[]string").list(tags.map(doubleQuote)),
+    )
+
+  private def generatePrometheusSummary(
+    name: String,
+    help: String,
+    objectives: Seq[(Double, Double)],
+    tags: Seq[String],
+  ): String =
+    GoCommonGenerator.genFunctionCall(
+      "promauto.NewSummaryVec",
+      GoCommonGenerator.genPopulateStruct(
+        "prometheus.SummaryOpts",
+        ListMap(
+          "Name" -> doubleQuote(name),
+          "Help" -> doubleQuote(help),
+          "Objectives" -> CodeWrap.curly
+            .prefix("map[float64]float64")
+            .list(objectives.map {
+              case (k, v) =>
+                s"$k: $v"
+            }),
+        ),
+      ),
+      CodeWrap.curly.prefix("[]string").list(tags.map(doubleQuote)),
+    )
+
+  // Generate global variables for metrics, including string identifiers and metric objects
+  private[service] def generateVars(root: ServiceRoot, operations: Set[CRUD]): String = {
+    // Assign strings to variables of form `RequestCreate = "create"`
+    val serviceStrings = CodeUtils.pad(operations.toSeq.sorted.map { operation =>
+      (s"Request${operation.toString.capitalize}", doubleQuote(operation.toString.toLowerCase))
+    }, separator = " = ")
+
+    val successCounter = genAssign(
+      generatePrometheusCounter(
+        name = s"${root.name.toLowerCase}_request_success_total",
+        help = "The total number of successful requests",
+        tags = Seq("request_type"),
+      ),
+      "RequestSuccess",
+    )
+
+    val failureCounter = genAssign(
+      generatePrometheusCounter(
+        name = s"${root.name.toLowerCase}_request_failure_total",
+        help = "The total number of failed requests",
+        tags = Seq("request_type", "error_code"),
+      ),
+      "RequestFailure",
+    )
+
+    val databaseSummary = genAssign(
+      generatePrometheusSummary(
+        name = s"${root.name.toLowerCase}_database_request_seconds",
+        help = "The time spent executing database requests in seconds",
+        objectives = Seq(0.5 -> 0.05, 0.9 -> 0.01, 0.95 -> 0.005, 0.99 -> 0.001),
+        tags = Seq("query_type"),
+      ),
+      "DatabaseRequestDuration",
+    )
+
+    // Wrap all assignments in a `var` block
+    mkCode("var", CodeWrap.parens.tabbed(serviceStrings, "", successCounter, "", failureCounter, "", databaseSummary))
+  }
+}

--- a/src/main/scala/temple/generate/utils/CodeTerm.scala
+++ b/src/main/scala/temple/generate/utils/CodeTerm.scala
@@ -129,6 +129,14 @@ object CodeTerm {
 
     /** Wrap a (newline-separated list of) code snippet in parentheses, with no indent */
     def noIndent(string: CodeTerm*): String = mkCode(start, "\n", mkCode.lines(string), "\n", end)
+
+    /** Wrap a (trailing-comma-separated list of) code snippet in parentheses, indenting with spaces */
+    def spacedTrailingList(string: CodeTerm*): String =
+      mkCode(start, "\n", indent(mkCode.spacedList(string)), ",\n", end)
+
+    /** Wrap a (trailing-comma-separated list of) code snippet in parentheses, indenting with tabs */
+    def tabbedTrailingList(string: CodeTerm*): String =
+      mkCode(start, "\n", tabIndent(mkCode.spacedList(string)), ",\n", end)
   }
 
   object CodeWrap {

--- a/src/main/scala/temple/generate/utils/CodeUtils.scala
+++ b/src/main/scala/temple/generate/utils/CodeUtils.scala
@@ -6,9 +6,9 @@ object CodeUtils {
 
   /** Takes an iterable collection of string tuples and pads the first element of each tuple to the length of the
     * longest first element in the collection, returning each */
-  def pad(tuples: Iterable[(String, String)]): Iterable[String] = {
+  def pad(tuples: Iterable[(String, String)], separator: String = " "): Iterable[String] = {
     val padLength = tuples.map(_._1.length).max
-    tuples.map { case (first, second) => first.padTo(padLength, ' ') + " " + second }
+    tuples.map { case (first, second) => first.padTo(padLength, ' ') + separator + second }
   }
 
   def padThree(tuples: Iterable[(String, String, String)]): Iterable[String] = {

--- a/src/test/resources/go/complex-user/metric/metric.go.snippet
+++ b/src/test/resources/go/complex-user/metric/metric.go.snippet
@@ -1,1 +1,29 @@
 package metric
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	RequestCreate = "create"
+	RequestRead   = "read"
+	RequestUpdate = "update"
+	RequestDelete = "delete"
+
+	RequestSuccess = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "complexuser_request_success_total",
+		Help: "The total number of successful requests",
+	}, []string{"request_type"})
+
+	RequestFailure = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "complexuser_request_failure_total",
+		Help: "The total number of failed requests",
+	}, []string{"request_type", "error_code"})
+
+	DatabaseRequestDuration = promauto.NewSummaryVec(prometheus.SummaryOpts{
+		Name:       "complexuser_database_request_seconds",
+		Help:       "The time spent executing database requests in seconds",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.95: 0.005, 0.99: 0.001},
+	}, []string{"query_type"})
+)

--- a/src/test/resources/go/simple-user/metric/metric.go.snippet
+++ b/src/test/resources/go/simple-user/metric/metric.go.snippet
@@ -1,1 +1,29 @@
 package metric
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	RequestCreate = "create"
+	RequestRead   = "read"
+	RequestUpdate = "update"
+	RequestDelete = "delete"
+
+	RequestSuccess = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "templeuser_request_success_total",
+		Help: "The total number of successful requests",
+	}, []string{"request_type"})
+
+	RequestFailure = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "templeuser_request_failure_total",
+		Help: "The total number of failed requests",
+	}, []string{"request_type", "error_code"})
+
+	DatabaseRequestDuration = promauto.NewSummaryVec(prometheus.SummaryOpts{
+		Name:       "templeuser_database_request_seconds",
+		Help:       "The time spent executing database requests in seconds",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.95: 0.005, 0.99: 0.001},
+	}, []string{"query_type"})
+)

--- a/src/test/scala/temple/generate/server/go/testfiles/match/metric/metric.go.snippet
+++ b/src/test/scala/temple/generate/server/go/testfiles/match/metric/metric.go.snippet
@@ -1,1 +1,30 @@
 package metric
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	RequestList   = "list"
+	RequestCreate = "create"
+	RequestRead   = "read"
+	RequestUpdate = "update"
+	RequestDelete = "delete"
+
+	RequestSuccess = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "match_request_success_total",
+		Help: "The total number of successful requests",
+	}, []string{"request_type"})
+
+	RequestFailure = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "match_request_failure_total",
+		Help: "The total number of failed requests",
+	}, []string{"request_type", "error_code"})
+
+	DatabaseRequestDuration = promauto.NewSummaryVec(prometheus.SummaryOpts{
+		Name:       "match_database_request_seconds",
+		Help:       "The time spent executing database requests in seconds",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.95: 0.005, 0.99: 0.001},
+	}, []string{"query_type"})
+)

--- a/src/test/scala/temple/generate/server/go/testfiles/user/metric/metric.go.snippet
+++ b/src/test/scala/temple/generate/server/go/testfiles/user/metric/metric.go.snippet
@@ -1,1 +1,29 @@
 package metric
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	RequestCreate = "create"
+	RequestRead   = "read"
+	RequestUpdate = "update"
+	RequestDelete = "delete"
+
+	RequestSuccess = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "user_request_success_total",
+		Help: "The total number of successful requests",
+	}, []string{"request_type"})
+
+	RequestFailure = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "user_request_failure_total",
+		Help: "The total number of failed requests",
+	}, []string{"request_type", "error_code"})
+
+	DatabaseRequestDuration = promauto.NewSummaryVec(prometheus.SummaryOpts{
+		Name:       "user_database_request_seconds",
+		Help:       "The time spent executing database requests in seconds",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.95: 0.005, 0.99: 0.001},
+	}, []string{"query_type"})
+)


### PR DESCRIPTION
Populate `metric.go`, in accordance with latest `spec-golang`. Haven't dealt with structs yet, since this was getting fairly big anyway.

Updated unit, e2e & integration test 