### PR TITLE
[go-gen][hooks] Add Hook and HookError structs

### DIFF
--- a/src/e2e/resources/go/user/hook.go.snippet
+++ b/src/e2e/resources/go/user/hook.go.snippet
@@ -1,3 +1,26 @@
 package main
 
 import "github.com/squat/and/dab/templeuser/dao"
+
+// Hook allows additional code to be executed before and after every datastore interaction
+// Hooks are executed in the order they are defined, such that if any hook errors, future hooks are not executed and the request is terminated
+type Hook struct {
+	beforeListHooks   []*func(env *env, input *dao.ListTempleuserInput) *HookError
+	beforeCreateHooks []*func(env *env, req createTempleuserRequest, input *dao.CreateTempleuserInput) *HookError
+	beforeReadHooks   []*func(env *env, input *dao.ReadTempleuserInput) *HookError
+	beforeUpdateHooks []*func(env *env, req updateTempleuserRequest, input *dao.UpdateTempleuserInput) *HookError
+	afterListHooks    []*func(env *env, templeuserList *[]dao.Templeuser) *HookError
+	afterCreateHooks  []*func(env *env, templeuser *dao.Templeuser) *HookError
+	afterReadHooks    []*func(env *env, templeuser *dao.Templeuser) *HookError
+	afterUpdateHooks  []*func(env *env, templeuser *dao.Templeuser) *HookError
+}
+
+// HookError wraps an existing error with HTTP status code
+type HookError struct {
+	statusCode int
+	error      error
+}
+
+func (e *HookError) Error() string {
+	return e.error.Error()
+}

--- a/src/it/scala/temple/containers/GolangSpec.scala
+++ b/src/it/scala/temple/containers/GolangSpec.scala
@@ -22,6 +22,7 @@ abstract class GolangSpec extends DockerShell2HttpService(8081) with DockerTestK
     val json = files.map { case (file, contents) => (file.folder + "/" + file.filename, contents) }.asJson.toString()
     Http(golangVerifyUrl)
       .params(Map("src" -> json, "root" -> entryFile.folder, "entrypoint" -> entryFile.filename))
+      .timeout(connTimeoutMs = 1000, readTimeoutMs = 10000)
       .asString
       .body
   }

--- a/src/main/scala/temple/generate/server/go/common/GoCommonGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/common/GoCommonGenerator.scala
@@ -126,6 +126,23 @@ object GoCommonGenerator {
   private[go] def genMethodCall(objectName: String, methodName: String, args: String*): String =
     s"$objectName.${genFunctionCall(methodName, args: _*)}"
 
+  /** Generate method definition */
+  private[go] def genMethod(
+    objectName: String,
+    objectType: String,
+    methodName: String,
+    methodArgs: Seq[String],
+    methodReturn: Option[String],
+    methodBody: String,
+  ): String =
+    mkCode(
+      "func",
+      CodeWrap.parens(objectName, objectType),
+      CodeWrap.parens.prefix(methodName)(methodArgs),
+      methodReturn,
+      CodeWrap.curly.tabbed(methodBody),
+    )
+
   /** Generate if statement */
   private[go] def genIf(expr: String, body: String): String =
     mkCode(

--- a/src/main/scala/temple/generate/server/go/service/GoServiceGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/GoServiceGenerator.scala
@@ -56,6 +56,9 @@ object GoServiceGenerator extends ServiceGenerator {
       File(root.name, "hook.go") -> mkCode.doubleLines(
         GoCommonGenerator.generatePackage("main"),
         GoServiceHookGenerator.generateImports(root),
+        GoServiceHookGenerator.generateHookStruct(root, operations),
+        GoServiceHookGenerator.generateHookErrorStruct,
+        GoServiceHookGenerator.generateHookErrorFunction,
       ),
       File(s"${root.name}/dao", "errors.go") -> GoServiceDAOGenerator.generateErrors(root),
       File(s"${root.name}/dao", "dao.go") -> mkCode.doubleLines(

--- a/src/main/scala/temple/generate/server/go/service/GoServiceHookGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/GoServiceHookGenerator.scala
@@ -1,10 +1,56 @@
 package temple.generate.server.go.service
 
+import temple.generate.CRUD
+import temple.generate.CRUD.CRUD
 import temple.generate.server.ServiceRoot
+import temple.generate.server.go.common.GoCommonGenerator.{genStruct, genMethod, genReturn}
+import temple.generate.utils.CodeTerm.mkCode
 import temple.utils.StringUtils.doubleQuote
+
+import scala.collection.immutable.ListMap
 
 object GoServiceHookGenerator {
 
   private[service] def generateImports(root: ServiceRoot): String =
     s"import ${doubleQuote(root.module + "/dao")}"
+
+  private[service] def generateHookStruct(root: ServiceRoot, operations: Set[CRUD]): String = {
+    val beforeCreate = operations.toSeq.sorted.map {
+      case op @ (CRUD.List | CRUD.Read | CRUD.Delete) =>
+        s"before${op.toString}Hooks" -> s"[]*func(env *env, input *dao.${op.toString}${root.name.capitalize}Input) *HookError"
+      case op @ (CRUD.Create | CRUD.Update) =>
+        s"before${op.toString}Hooks" -> s"[]*func(env *env, req ${op.toString.toLowerCase}${root.name.capitalize}Request, input *dao.${op.toString}${root.name.capitalize}Input) *HookError"
+    }
+
+    val afterCreate = operations.toSeq.sorted.map {
+      case CRUD.List =>
+        "afterListHooks" -> s"[]*func(env *env, ${root.name}List *[]dao.${root.name.capitalize}) *HookError"
+      case op @ (CRUD.Create | CRUD.Read | CRUD.Update) =>
+        s"after${op.toString}Hooks" -> s"[]*func(env *env, ${root.name} *dao.${root.name.capitalize}) *HookError"
+      case CRUD.Delete =>
+        s"afterDeleteHooks" -> s"[]*func(env *env) *HookError"
+    }
+
+    mkCode.lines(
+      "// Hook allows additional code to be executed before and after every datastore interaction",
+      "// Hooks are executed in the order they are defined, such that if any hook errors, future hooks are not executed and the request is terminated",
+      genStruct("Hook", beforeCreate ++ afterCreate),
+    )
+  }
+
+  private[service] def generateHookErrorStruct: String =
+    mkCode.lines(
+      "// HookError wraps an existing error with HTTP status code",
+      genStruct("HookError", ListMap("statusCode" -> "int", "error" -> "error")),
+    )
+
+  private[service] def generateHookErrorFunction: String =
+    genMethod(
+      "e",
+      "*HookError",
+      "Error",
+      Seq.empty,
+      Some("string"),
+      genReturn("e.error.Error()"),
+    )
 }

--- a/src/test/resources/go/complex-user/hook.go.snippet
+++ b/src/test/resources/go/complex-user/hook.go.snippet
@@ -1,3 +1,26 @@
 package main
 
 import "github.com/squat/and/dab/complexuser/dao"
+
+// Hook allows additional code to be executed before and after every datastore interaction
+// Hooks are executed in the order they are defined, such that if any hook errors, future hooks are not executed and the request is terminated
+type Hook struct {
+	beforeCreateHooks []*func(env *env, req createComplexuserRequest, input *dao.CreateComplexuserInput) *HookError
+	beforeReadHooks   []*func(env *env, input *dao.ReadComplexuserInput) *HookError
+	beforeUpdateHooks []*func(env *env, req updateComplexuserRequest, input *dao.UpdateComplexuserInput) *HookError
+	beforeDeleteHooks []*func(env *env, input *dao.DeleteComplexuserInput) *HookError
+	afterCreateHooks  []*func(env *env, complexuser *dao.Complexuser) *HookError
+	afterReadHooks    []*func(env *env, complexuser *dao.Complexuser) *HookError
+	afterUpdateHooks  []*func(env *env, complexuser *dao.Complexuser) *HookError
+	afterDeleteHooks  []*func(env *env) *HookError
+}
+
+// HookError wraps an existing error with HTTP status code
+type HookError struct {
+	statusCode int
+	error      error
+}
+
+func (e *HookError) Error() string {
+	return e.error.Error()
+}

--- a/src/test/resources/go/simple-user/hook.go.snippet
+++ b/src/test/resources/go/simple-user/hook.go.snippet
@@ -1,3 +1,26 @@
 package main
 
 import "github.com/squat/and/dab/templeuser/dao"
+
+// Hook allows additional code to be executed before and after every datastore interaction
+// Hooks are executed in the order they are defined, such that if any hook errors, future hooks are not executed and the request is terminated
+type Hook struct {
+	beforeCreateHooks []*func(env *env, req createTempleuserRequest, input *dao.CreateTempleuserInput) *HookError
+	beforeReadHooks   []*func(env *env, input *dao.ReadTempleuserInput) *HookError
+	beforeUpdateHooks []*func(env *env, req updateTempleuserRequest, input *dao.UpdateTempleuserInput) *HookError
+	beforeDeleteHooks []*func(env *env, input *dao.DeleteTempleuserInput) *HookError
+	afterCreateHooks  []*func(env *env, templeuser *dao.Templeuser) *HookError
+	afterReadHooks    []*func(env *env, templeuser *dao.Templeuser) *HookError
+	afterUpdateHooks  []*func(env *env, templeuser *dao.Templeuser) *HookError
+	afterDeleteHooks  []*func(env *env) *HookError
+}
+
+// HookError wraps an existing error with HTTP status code
+type HookError struct {
+	statusCode int
+	error      error
+}
+
+func (e *HookError) Error() string {
+	return e.error.Error()
+}

--- a/src/test/scala/temple/generate/server/go/testfiles/match/hook.go.snippet
+++ b/src/test/scala/temple/generate/server/go/testfiles/match/hook.go.snippet
@@ -1,3 +1,28 @@
 package main
 
 import "github.com/TempleEight/spec-golang/match/dao"
+
+// Hook allows additional code to be executed before and after every datastore interaction
+// Hooks are executed in the order they are defined, such that if any hook errors, future hooks are not executed and the request is terminated
+type Hook struct {
+	beforeListHooks   []*func(env *env, input *dao.ListMatchInput) *HookError
+	beforeCreateHooks []*func(env *env, req createMatchRequest, input *dao.CreateMatchInput) *HookError
+	beforeReadHooks   []*func(env *env, input *dao.ReadMatchInput) *HookError
+	beforeUpdateHooks []*func(env *env, req updateMatchRequest, input *dao.UpdateMatchInput) *HookError
+	beforeDeleteHooks []*func(env *env, input *dao.DeleteMatchInput) *HookError
+	afterListHooks    []*func(env *env, matchList *[]dao.Match) *HookError
+	afterCreateHooks  []*func(env *env, match *dao.Match) *HookError
+	afterReadHooks    []*func(env *env, match *dao.Match) *HookError
+	afterUpdateHooks  []*func(env *env, match *dao.Match) *HookError
+	afterDeleteHooks  []*func(env *env) *HookError
+}
+
+// HookError wraps an existing error with HTTP status code
+type HookError struct {
+	statusCode int
+	error      error
+}
+
+func (e *HookError) Error() string {
+	return e.error.Error()
+}

--- a/src/test/scala/temple/generate/server/go/testfiles/user/hook.go.snippet
+++ b/src/test/scala/temple/generate/server/go/testfiles/user/hook.go.snippet
@@ -1,3 +1,26 @@
 package main
 
 import "github.com/TempleEight/spec-golang/user/dao"
+
+// Hook allows additional code to be executed before and after every datastore interaction
+// Hooks are executed in the order they are defined, such that if any hook errors, future hooks are not executed and the request is terminated
+type Hook struct {
+	beforeCreateHooks []*func(env *env, req createUserRequest, input *dao.CreateUserInput) *HookError
+	beforeReadHooks   []*func(env *env, input *dao.ReadUserInput) *HookError
+	beforeUpdateHooks []*func(env *env, req updateUserRequest, input *dao.UpdateUserInput) *HookError
+	beforeDeleteHooks []*func(env *env, input *dao.DeleteUserInput) *HookError
+	afterCreateHooks  []*func(env *env, user *dao.User) *HookError
+	afterReadHooks    []*func(env *env, user *dao.User) *HookError
+	afterUpdateHooks  []*func(env *env, user *dao.User) *HookError
+	afterDeleteHooks  []*func(env *env) *HookError
+}
+
+// HookError wraps an existing error with HTTP status code
+type HookError struct {
+	statusCode int
+	error      error
+}
+
+func (e *HookError) Error() string {
+	return e.error.Error()
+}


### PR DESCRIPTION
Generate `Hook` struct, in addition to `HookError` and associated `Error` method.

Updates E2E, integration & unit tests.
