### PR TITLE
Auth metric gen

### DIFF
--- a/src/main/scala/temple/generate/server/go/auth/GoAuthServiceGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/auth/GoAuthServiceGenerator.scala
@@ -1,7 +1,6 @@
 package temple.generate.server.go.auth
 
 import temple.generate.FileSystem._
-import temple.generate.server.go.GoCommonMetricGenerator
 import temple.generate.server.go.common._
 import temple.generate.server.{AuthServiceGenerator, AuthServiceRoot}
 import temple.generate.utils.CodeTerm.mkCode

--- a/src/main/scala/temple/generate/server/go/auth/GoAuthServiceGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/auth/GoAuthServiceGenerator.scala
@@ -1,6 +1,7 @@
 package temple.generate.server.go.auth
 
 import temple.generate.FileSystem._
+import temple.generate.server.go.GoCommonMetricGenerator
 import temple.generate.server.go.common._
 import temple.generate.server.{AuthServiceGenerator, AuthServiceRoot}
 import temple.generate.utils.CodeTerm.mkCode
@@ -48,6 +49,11 @@ object GoAuthServiceGenerator extends AuthServiceGenerator {
         GoCommonUtilGenerator.generateConfigStruct(),
         GoCommonUtilGenerator.generateGetConfig(),
         GoCommonUtilGenerator.generateCreateErrorJSON(),
+      ),
+      File("auth/metric", "metric.go") -> mkCode.doubleLines(
+        GoCommonGenerator.generatePackage("metric"),
+        GoCommonMetricGenerator.generateImports(),
+        GoAuthServiceMetricGenerator.generateVars(),
       ),
     ).map { case (path, contents) => path -> (contents + "\n") }
 }

--- a/src/main/scala/temple/generate/server/go/auth/GoAuthServiceMetricGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/auth/GoAuthServiceMetricGenerator.scala
@@ -1,6 +1,6 @@
 package temple.generate.server.go.auth
 
-import temple.generate.server.go.GoCommonMetricGenerator
+import temple.generate.server.go.common.GoCommonMetricGenerator
 import temple.generate.utils.CodeUtils
 import temple.utils.StringUtils.doubleQuote
 

--- a/src/main/scala/temple/generate/server/go/auth/GoAuthServiceMetricGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/auth/GoAuthServiceMetricGenerator.scala
@@ -1,0 +1,16 @@
+package temple.generate.server.go.auth
+
+import temple.generate.server.go.GoCommonMetricGenerator
+import temple.generate.utils.CodeUtils
+import temple.utils.StringUtils.doubleQuote
+
+object GoAuthServiceMetricGenerator {
+
+  private[auth] def generateVars(): String = {
+    val serviceGlobals = CodeUtils.pad(Seq("register", "login").map { operation =>
+      (s"Request${operation.capitalize}", doubleQuote(operation.toLowerCase))
+    }, separator = " = ")
+
+    GoCommonMetricGenerator.generateVars(serviceGlobals, "auth")
+  }
+}

--- a/src/main/scala/temple/generate/server/go/common/GoCommonMetricGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/common/GoCommonMetricGenerator.scala
@@ -57,10 +57,10 @@ object GoCommonMetricGenerator {
       CodeWrap.curly.prefix("[]string").list(tags.map(doubleQuote)),
     )
 
-  private[go] def generateVars(serviceGlobals: Iterable[String], root: ServiceRoot): String = {
+  private[go] def generateVars(serviceGlobals: Iterable[String], rootName: String): String = {
     val successCounter = genAssign(
       generatePrometheusCounter(
-        name = s"${root.name.toLowerCase}_request_success_total",
+        name = s"${rootName.toLowerCase}_request_success_total",
         help = "The total number of successful requests",
         tags = Seq("request_type"),
       ),
@@ -69,7 +69,7 @@ object GoCommonMetricGenerator {
 
     val failureCounter = genAssign(
       generatePrometheusCounter(
-        name = s"${root.name.toLowerCase}_request_failure_total",
+        name = s"${rootName.toLowerCase}_request_failure_total",
         help = "The total number of failed requests",
         tags = Seq("request_type", "error_code"),
       ),
@@ -78,7 +78,7 @@ object GoCommonMetricGenerator {
 
     val databaseSummary = genAssign(
       generatePrometheusSummary(
-        name = s"${root.name.toLowerCase}_database_request_seconds",
+        name = s"${rootName.toLowerCase}_database_request_seconds",
         help = "The time spent executing database requests in seconds",
         objectives = Seq(0.5 -> 0.05, 0.9 -> 0.01, 0.95 -> 0.005, 0.99 -> 0.001),
         tags = Seq("query_type"),

--- a/src/main/scala/temple/generate/server/go/common/GoCommonMetricGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/common/GoCommonMetricGenerator.scala
@@ -1,6 +1,5 @@
-package temple.generate.server.go
+package temple.generate.server.go.common
 
-import temple.generate.server.ServiceRoot
 import temple.generate.server.go.common.GoCommonGenerator.{genAssign, genFunctionCall, genPopulateStruct}
 import temple.generate.utils.CodeTerm.{CodeWrap, mkCode}
 import temple.utils.StringUtils.doubleQuote

--- a/src/main/scala/temple/generate/server/go/service/GoServiceGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/GoServiceGenerator.scala
@@ -3,7 +3,6 @@ package temple.generate.server.go.service
 import temple.ast.{Annotation, AttributeType}
 import temple.generate.CRUD
 import temple.generate.FileSystem._
-import temple.generate.server.go.GoCommonMetricGenerator
 import temple.generate.server.go.common._
 import temple.generate.server.go.service.dao._
 import temple.generate.server.go.service.main.{GoServiceMainGenerator, GoServiceMainHandlersGenerator, GoServiceMainStructGenerator}

--- a/src/main/scala/temple/generate/server/go/service/GoServiceMetricGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/GoServiceMetricGenerator.scala
@@ -15,6 +15,6 @@ object GoServiceMetricGenerator {
       (s"Request${operation.toString.capitalize}", doubleQuote(operation.toString.toLowerCase))
     }, separator = " = ")
 
-    GoCommonMetricGenerator.generateVars(serviceGlobals, root)
+    GoCommonMetricGenerator.generateVars(serviceGlobals, root.name)
   }
 }

--- a/src/main/scala/temple/generate/server/go/service/GoServiceMetricGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/GoServiceMetricGenerator.scala
@@ -2,7 +2,7 @@ package temple.generate.server.go.service
 
 import temple.generate.CRUD.CRUD
 import temple.generate.server.ServiceRoot
-import temple.generate.server.go.GoCommonMetricGenerator
+import temple.generate.server.go.common.GoCommonMetricGenerator
 import temple.utils.StringUtils.doubleQuote
 import temple.generate.utils.CodeUtils
 

--- a/src/test/resources/go/auth/metric/metric.go.snippet
+++ b/src/test/resources/go/auth/metric/metric.go.snippet
@@ -1,0 +1,27 @@
+package metric
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	RequestRegister = "register"
+	RequestLogin    = "login"
+
+	RequestSuccess = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "auth_request_success_total",
+		Help: "The total number of successful requests",
+	}, []string{"request_type"})
+
+	RequestFailure = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "auth_request_failure_total",
+		Help: "The total number of failed requests",
+	}, []string{"request_type", "error_code"})
+
+	DatabaseRequestDuration = promauto.NewSummaryVec(prometheus.SummaryOpts{
+		Name:       "auth_database_request_seconds",
+		Help:       "The time spent executing database requests in seconds",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.95: 0.005, 0.99: 0.001},
+	}, []string{"query_type"})
+)

--- a/src/test/scala/temple/builder/project/ProjectBuilderTest.scala
+++ b/src/test/scala/temple/builder/project/ProjectBuilderTest.scala
@@ -112,6 +112,7 @@ class ProjectBuilderTest extends FlatSpec with Matchers {
       File("auth/dao", "dao.go")                                  -> ProjectBuilderTestData.complexTemplefileAuthDaoFile,
       File("auth/dao", "errors.go")                               -> ProjectBuilderTestData.complexTemplefileAuthErrorsFile,
       File("auth/comm", "handler.go")                             -> ProjectBuilderTestData.complexTemplefileAuthHandlerFile,
+      File("auth/metric", "metric.go")                            -> ProjectBuilderTestData.complexTemplefileAuthMetricFile,
       File("kube/complex-user", "deployment.yaml")                -> ProjectBuilderTestData.complexTemplefileKubeDeployment,
       File("kube/complex-user", "db-deployment.yaml")             -> ProjectBuilderTestData.complexTemplefileKubeDbDeployment,
       File("kube/complex-user", "service.yaml")                   -> ProjectBuilderTestData.complexTemplefileKubeService,

--- a/src/test/scala/temple/builder/project/ProjectBuilderTestData.scala
+++ b/src/test/scala/temple/builder/project/ProjectBuilderTestData.scala
@@ -1199,6 +1199,7 @@ object ProjectBuilderTestData {
   val complexTemplefileAuthDaoFile: String     = FileUtils.readResources("go/auth/dao/dao.go.snippet")
   val complexTemplefileAuthErrorsFile: String  = FileUtils.readResources("go/auth/dao/errors.go.snippet")
   val complexTemplefileAuthHandlerFile: String = FileUtils.readResources("go/auth/comm/handler.go.snippet")
+  val complexTemplefileAuthMetricFile: String  = FileUtils.readResources("go/auth/metric/metric.go.snippet")
 
   val complexTemplefileGrafanaDatasourceConfig: String =
     """apiVersion: 1

--- a/src/test/scala/temple/generate/server/go/GoAuthServiceGeneratorTestData.scala
+++ b/src/test/scala/temple/generate/server/go/GoAuthServiceGeneratorTestData.scala
@@ -32,5 +32,8 @@ object GoAuthServiceGeneratorTestData {
     File("auth/util", "util.go") -> readFile(
       "src/test/scala/temple/generate/server/go/testfiles/auth/util/util.go.snippet",
     ),
+    File("auth/metric", "metric.go") -> readFile(
+      "src/test/scala/temple/generate/server/go/testfiles/auth/metric/metric.go.snippet",
+    ),
   )
 }

--- a/src/test/scala/temple/generate/server/go/testfiles/auth/metric/metric.go.snippet
+++ b/src/test/scala/temple/generate/server/go/testfiles/auth/metric/metric.go.snippet
@@ -1,0 +1,27 @@
+package metric
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	RequestRegister = "register"
+	RequestLogin    = "login"
+
+	RequestSuccess = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "auth_request_success_total",
+		Help: "The total number of successful requests",
+	}, []string{"request_type"})
+
+	RequestFailure = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "auth_request_failure_total",
+		Help: "The total number of failed requests",
+	}, []string{"request_type", "error_code"})
+
+	DatabaseRequestDuration = promauto.NewSummaryVec(prometheus.SummaryOpts{
+		Name:       "auth_database_request_seconds",
+		Help:       "The time spent executing database requests in seconds",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.95: 0.005, 0.99: 0.001},
+	}, []string{"query_type"})
+)


### PR DESCRIPTION
Pretty easy one - generate metrics for `auth` service. They differ from the main metrics in the globals exposed: for standard services we have:

```
var RequestCreate = "create"
...
```
For auth services, these are replaced with:

```
var RequestRegister = "register"
var RequestLogin      = "login"
```


The tests files were taken directly from `spec-golang`, so pretty confident the generation is correct :) 