### PR TITLE
[go-gen][hook] Move common hook logic into shared package

### DIFF
--- a/src/main/scala/temple/generate/server/go/auth/GoAuthServiceGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/auth/GoAuthServiceGenerator.scala
@@ -23,6 +23,12 @@ object GoAuthServiceGenerator extends AuthServiceGenerator {
         GoAuthServiceMainGenerator.generateHandlers(),
         GoAuthServiceMainGenerator.generateCreateToken(),
       ),
+      File("auth", "hook.go") -> mkCode.doubleLines(
+        GoCommonGenerator.generatePackage("main"),
+        GoCommonHookGenerator.generateImports(root.module),
+        GoCommonHookGenerator.generateHookErrorStruct,
+        GoCommonHookGenerator.generateHookErrorFunction,
+      ),
       File("auth/dao", "errors.go") -> GoAuthServiceDAOGenerator.generateErrors(root),
       File("auth/dao", "dao.go") -> mkCode.doubleLines(
         GoCommonGenerator.generatePackage("dao"),

--- a/src/main/scala/temple/generate/server/go/common/GoCommonHookGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/common/GoCommonHookGenerator.scala
@@ -1,0 +1,29 @@
+package temple.generate.server.go.common
+
+import temple.generate.server.go.common.GoCommonGenerator.{genMethod, genReturn, genStruct}
+import temple.generate.utils.CodeTerm.mkCode
+import temple.utils.StringUtils.doubleQuote
+
+import scala.collection.immutable.ListMap
+
+object GoCommonHookGenerator {
+
+  private[go] def generateImports(rootModule: String): String =
+    s"import ${doubleQuote(rootModule + "/dao")}"
+
+  private[go] def generateHookErrorStruct: String =
+    mkCode.lines(
+      "// HookError wraps an existing error with HTTP status code",
+      genStruct("HookError", ListMap("statusCode" -> "int", "error" -> "error")),
+    )
+
+  private[go] def generateHookErrorFunction: String =
+    genMethod(
+      "e",
+      "*HookError",
+      "Error",
+      Seq.empty,
+      Some("string"),
+      genReturn("e.error.Error()"),
+    )
+}

--- a/src/main/scala/temple/generate/server/go/service/GoServiceGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/GoServiceGenerator.scala
@@ -55,10 +55,10 @@ object GoServiceGenerator extends ServiceGenerator {
       ),
       File(root.name, "hook.go") -> mkCode.doubleLines(
         GoCommonGenerator.generatePackage("main"),
-        GoServiceHookGenerator.generateImports(root),
+        GoCommonHookGenerator.generateImports(root.module),
         GoServiceHookGenerator.generateHookStruct(root, operations),
-        GoServiceHookGenerator.generateHookErrorStruct,
-        GoServiceHookGenerator.generateHookErrorFunction,
+        GoCommonHookGenerator.generateHookErrorStruct,
+        GoCommonHookGenerator.generateHookErrorFunction,
         GoServiceHookGenerator.generateAddHookMethods(root, operations),
       ),
       File(s"${root.name}/dao", "errors.go") -> GoServiceDAOGenerator.generateErrors(root),

--- a/src/main/scala/temple/generate/server/go/service/GoServiceHookGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/GoServiceHookGenerator.scala
@@ -6,9 +6,6 @@ import temple.generate.CRUD.presentParticiple
 import temple.generate.server.ServiceRoot
 import temple.generate.server.go.common.GoCommonGenerator._
 import temple.generate.utils.CodeTerm.mkCode
-import temple.utils.StringUtils.doubleQuote
-
-import scala.collection.immutable.ListMap
 
 object GoServiceHookGenerator {
 
@@ -28,9 +25,6 @@ object GoServiceHookGenerator {
       "func(env *env) *HookError"
   }
 
-  private[service] def generateImports(root: ServiceRoot): String =
-    s"import ${doubleQuote(root.module + "/dao")}"
-
   private[service] def generateHookStruct(root: ServiceRoot, operations: Set[CRUD]): String = {
     val beforeCreate = operations.toSeq.sorted.map { op =>
       s"before${op.toString}Hooks" -> s"[]*${generateBeforeHookType(root, op)}"
@@ -46,22 +40,6 @@ object GoServiceHookGenerator {
       genStruct("Hook", beforeCreate ++ afterCreate),
     )
   }
-
-  private[service] def generateHookErrorStruct: String =
-    mkCode.lines(
-      "// HookError wraps an existing error with HTTP status code",
-      genStruct("HookError", ListMap("statusCode" -> "int", "error" -> "error")),
-    )
-
-  private[service] def generateHookErrorFunction: String =
-    genMethod(
-      "e",
-      "*HookError",
-      "Error",
-      Seq.empty,
-      Some("string"),
-      genReturn("e.error.Error()"),
-    )
 
   private def generateAddHookComment(action: String, op: CRUD): String = op match {
     case CRUD.List =>

--- a/src/test/resources/go/auth/hook.go.snippet
+++ b/src/test/resources/go/auth/hook.go.snippet
@@ -1,0 +1,13 @@
+package main
+
+import "github.com/squat/and/dab/auth/dao"
+
+// HookError wraps an existing error with HTTP status code
+type HookError struct {
+	statusCode int
+	error      error
+}
+
+func (e *HookError) Error() string {
+	return e.error.Error()
+}

--- a/src/test/scala/temple/builder/project/ProjectBuilderTest.scala
+++ b/src/test/scala/temple/builder/project/ProjectBuilderTest.scala
@@ -107,6 +107,7 @@ class ProjectBuilderTest extends FlatSpec with Matchers {
       File("complexuser/util", "util.go")                         -> ProjectBuilderTestData.complexTemplefileUtilFile,
       File("complexuser/metric", "metric.go")                     -> ProjectBuilderTestData.complexTemplefileMetricFile,
       File("auth", "auth.go")                                     -> ProjectBuilderTestData.complexTemplefileAuthGoFile,
+      File("auth", "hook.go")                                     -> ProjectBuilderTestData.complexTemplefileAuthHookGoFile,
       File("auth", "go.mod")                                      -> ProjectBuilderTestData.complexTemplefileAuthGoModFile,
       File("auth/util", "util.go")                                -> ProjectBuilderTestData.complexTemplefileAuthUtilFile,
       File("auth/dao", "dao.go")                                  -> ProjectBuilderTestData.complexTemplefileAuthDaoFile,

--- a/src/test/scala/temple/builder/project/ProjectBuilderTestData.scala
+++ b/src/test/scala/temple/builder/project/ProjectBuilderTestData.scala
@@ -1194,6 +1194,7 @@ object ProjectBuilderTestData {
   val complexTemplefileMetricFile: String       = FileUtils.readResources("go/complex-user/metric/metric.go.snippet")
 
   val complexTemplefileAuthGoFile: String      = FileUtils.readResources("go/auth/auth.go.snippet")
+  val complexTemplefileAuthHookGoFile: String  = FileUtils.readResources("go/auth/hook.go.snippet")
   val complexTemplefileAuthGoModFile: String   = FileUtils.readResources("go/auth/go.mod.snippet")
   val complexTemplefileAuthUtilFile: String    = FileUtils.readResources("go/auth/util/util.go.snippet")
   val complexTemplefileAuthDaoFile: String     = FileUtils.readResources("go/auth/dao/dao.go.snippet")

--- a/src/test/scala/temple/generate/server/go/GoAuthServiceGeneratorTestData.scala
+++ b/src/test/scala/temple/generate/server/go/GoAuthServiceGeneratorTestData.scala
@@ -20,6 +20,7 @@ object GoAuthServiceGeneratorTestData {
   val authServiceFiles: Files = Map(
     File("auth", "go.mod")  -> readFile("src/test/scala/temple/generate/server/go/testfiles/auth/go.mod.snippet"),
     File("auth", "auth.go") -> readFile("src/test/scala/temple/generate/server/go/testfiles/auth/auth.go.snippet"),
+    File("auth", "hook.go") -> readFile("src/test/scala/temple/generate/server/go/testfiles/auth/hook.go.snippet"),
     File("auth/dao", "errors.go") -> readFile(
       "src/test/scala/temple/generate/server/go/testfiles/auth/dao/errors.go.snippet",
     ),

--- a/src/test/scala/temple/generate/server/go/testfiles/auth/hook.go.snippet
+++ b/src/test/scala/temple/generate/server/go/testfiles/auth/hook.go.snippet
@@ -1,0 +1,13 @@
+package main
+
+import "github.com/TempleEight/spec-golang/auth/dao"
+
+// HookError wraps an existing error with HTTP status code
+type HookError struct {
+	statusCode int
+	error      error
+}
+
+func (e *HookError) Error() string {
+	return e.error.Error()
+}


### PR DESCRIPTION
Same as #223 but this time for hooks. Move all the common logic into the `common` package, and call this from the `GoAuthServiceGenerator`. Will add the auth specific stuff in the next PR.

Updates tests etc.