### PR TITLE
[go-gen] Fix foreign keys being passed in as UUID type

### DIFF
--- a/src/it/scala/temple/generate/server/GoGeneratorIntegrationTestData.scala
+++ b/src/it/scala/temple/generate/server/GoGeneratorIntegrationTestData.scala
@@ -40,8 +40,8 @@ object GoGeneratorIntegrationTestData {
     IDAttribute("id"),
     CreatedByAttribute.EnumerateByCreator("authID", "createdBy"),
     ListMap(
-      "userOne"   -> Attribute(AttributeType.UUIDType),
-      "userTwo"   -> Attribute(AttributeType.UUIDType),
+      "userOne"   -> Attribute(AttributeType.ForeignKey("User")),
+      "userTwo"   -> Attribute(AttributeType.ForeignKey("User")),
       "matchedOn" -> Attribute(AttributeType.DateTimeType, Some(Annotation.ServerSet)),
     ),
     Postgres,

--- a/src/main/scala/temple/builder/ServerBuilder.scala
+++ b/src/main/scala/temple/builder/ServerBuilder.scala
@@ -66,12 +66,6 @@ object ServerBuilder {
       case (_, Attribute(x: ForeignKey, _, _)) => x.references
     }.toSeq
 
-    // In the server code all foreign keys are stored as UUID types - map into the correct type
-    val attributes: ListMap[String, Attribute] = ListMap.from(serviceBlock.attributes.map {
-      case (str, Attribute(_: ForeignKey, access, value)) => (str, Attribute(AttributeType.UUIDType, access, value))
-      case default                                        => default
-    })
-
     // TODO: Auth
 
     ServiceRoot(
@@ -82,7 +76,7 @@ object ServerBuilder {
       port = port,
       idAttribute = idAttribute,
       createdByAttribute = createdBy,
-      attributes = attributes,
+      attributes = ListMap.from(serviceBlock.attributes),
       datastore = serviceBlock.lookupMetadata[Metadata.Database].getOrElse(ProjectConfig.defaultDatabase),
     )
   }

--- a/src/main/scala/temple/generate/server/go/common/GoCommonGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/common/GoCommonGenerator.scala
@@ -17,6 +17,7 @@ object GoCommonGenerator {
 
   private[go] def generateGoType(attributeType: AttributeType): String =
     attributeType match {
+      case ForeignKey(_)                                  => "uuid.UUID"
       case UUIDType                                       => "uuid.UUID"
       case IntType(_, Some(min), p) if p <= 1 && min >= 0 => "uint8"
       case IntType(_, Some(min), p) if p <= 2 && min >= 0 => "uint16"

--- a/src/main/scala/temple/generate/server/go/common/GoCommonGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/common/GoCommonGenerator.scala
@@ -17,8 +17,7 @@ object GoCommonGenerator {
 
   private[go] def generateGoType(attributeType: AttributeType): String =
     attributeType match {
-      case ForeignKey(_)                                  => "uuid.UUID"
-      case UUIDType                                       => "uuid.UUID"
+      case ForeignKey(_) | UUIDType                       => "uuid.UUID"
       case IntType(_, Some(min), p) if p <= 1 && min >= 0 => "uint8"
       case IntType(_, Some(min), p) if p <= 2 && min >= 0 => "uint16"
       case IntType(_, Some(min), p) if p <= 4 && min >= 0 => "uint32"
@@ -31,9 +30,7 @@ object GoCommonGenerator {
       case FloatType(_, _, _)                             => "float64"
       case StringType(_, _)                               => "string"
       case BoolType                                       => "bool"
-      case DateType                                       => "time.Time"
-      case TimeType                                       => "time.Time"
-      case DateTimeType                                   => "time.Time"
+      case DateType | TimeType | DateTimeType             => "time.Time"
       case BlobType(Some(size))                           => s"[$size]byte"
       case BlobType(_)                                    => "[]byte"
     }

--- a/src/test/scala/temple/generate/server/go/GoServiceGeneratorTestData.scala
+++ b/src/test/scala/temple/generate/server/go/GoServiceGeneratorTestData.scala
@@ -62,8 +62,8 @@ object GoServiceGeneratorTestData {
       IDAttribute("id"),
       CreatedByAttribute.EnumerateByCreator("authID", "createdBy"),
       ListMap(
-        "userOne"   -> Attribute(AttributeType.UUIDType),
-        "userTwo"   -> Attribute(AttributeType.UUIDType),
+        "userOne"   -> Attribute(AttributeType.ForeignKey("User")),
+        "userTwo"   -> Attribute(AttributeType.ForeignKey("User")),
         "matchedOn" -> Attribute(AttributeType.DateTimeType, Some(Annotation.ServerSet)),
       ),
       Postgres,


### PR DESCRIPTION
* Changes foreign keys to be passed in as the foreign key type, rather than the UUID type
  * Needed to switch on, so as to know which inter-service communication function to call when checking incoming foreign key parameters in the create handlers

This should remove the assumption that UUIDs in the user-defined attributes are always foreign keys, but there might be a check left in that I can't find. I need this change to carry on handler generation :) 