### PR TITLE
[config] Add config JSON generator

### DIFF
--- a/src/main/scala/temple/generate/server/config/ServerConfigGenerator.scala
+++ b/src/main/scala/temple/generate/server/config/ServerConfigGenerator.scala
@@ -1,0 +1,16 @@
+package temple.generate.server.config
+
+import io.circe.syntax._
+import temple.ast.Metadata.Database
+import temple.ast.Templefile.Ports
+import temple.generate.server.config.ast.{PostgresConfig, ServerConfig}
+
+object ServerConfigGenerator {
+
+  def generate(serviceName: String, database: Database, services: Map[String, String], ports: Ports): String = {
+    val databaseConfig = database match {
+      case Database.Postgres => PostgresConfig(serviceName + "-db")
+    }
+    ServerConfig(databaseConfig, services, ports).asJson.toString
+  }
+}

--- a/src/main/scala/temple/generate/server/config/ast/DatabaseConfig.scala
+++ b/src/main/scala/temple/generate/server/config/ast/DatabaseConfig.scala
@@ -1,0 +1,16 @@
+package temple.generate.server.config.ast
+
+import io.circe.Json
+import temple.generate.JsonEncodable
+
+trait DatabaseConfig extends JsonEncodable.Object
+
+case class PostgresConfig(host: String) extends DatabaseConfig {
+
+  override def jsonEntryIterator: IterableOnce[(String, Json)] = Seq(
+    "user"    ~> "postgres",
+    "dbName"  ~> "postgres",
+    "host"    ~> host,
+    "sslMode" ~> "disable",
+  )
+}

--- a/src/main/scala/temple/generate/server/config/ast/ServerConfig.scala
+++ b/src/main/scala/temple/generate/server/config/ast/ServerConfig.scala
@@ -1,0 +1,21 @@
+package temple.generate.server.config.ast
+
+import io.circe.Json
+import temple.ast.Templefile.Ports
+import temple.generate.JsonEncodable
+
+import scala.collection.immutable.ListMap
+
+case class ServerConfig(databaseConfig: DatabaseConfig, services: Map[String, String], ports: Ports)
+    extends JsonEncodable.Object {
+
+  override def jsonEntryIterator: IterableOnce[(String, Json)] =
+    databaseConfig.jsonEntryIterator.iterator.toSeq ++
+    Seq(
+      "services" ~> services,
+      "ports" ~> ListMap(
+        "service"    ~> ports.service,
+        "prometheus" ~> ports.metrics,
+      ),
+    )
+}

--- a/src/test/scala/temple/generate/server/config/ServerConfigGeneratorTest.scala
+++ b/src/test/scala/temple/generate/server/config/ServerConfigGeneratorTest.scala
@@ -1,0 +1,15 @@
+package temple.generate.server.config
+
+import org.scalatest.{FlatSpec, Matchers}
+import temple.ast.Metadata.Database
+import temple.ast.Templefile.Ports
+
+class ServerConfigGeneratorTest extends FlatSpec with Matchers {
+  behavior of "ServerConfigGenerator"
+
+  it should "generate correct config" in {
+    val generated =
+      ServerConfigGenerator.generate("match", Database.Postgres, Map("user" -> "http://user:80/user"), Ports(81, 2113))
+    generated shouldBe ServerConfigGeneratorTestData.serverConfig
+  }
+}

--- a/src/test/scala/temple/generate/server/config/ServerConfigGeneratorTestData.scala
+++ b/src/test/scala/temple/generate/server/config/ServerConfigGeneratorTestData.scala
@@ -1,0 +1,19 @@
+package temple.generate.server.config
+
+object ServerConfigGeneratorTestData {
+
+  val serverConfig: String =
+    """{
+      |  "user" : "postgres",
+      |  "dbName" : "postgres",
+      |  "host" : "match-db",
+      |  "sslMode" : "disable",
+      |  "services" : {
+      |    "user" : "http://user:80/user"
+      |  },
+      |  "ports" : {
+      |    "service" : 81,
+      |    "prometheus" : 2113
+      |  }
+      |}""".stripMargin
+}


### PR DESCRIPTION
Add a generator for `config.json` from spec-golang.

Nothing too exciting - will do the mapping after because of all tests that will need updating