### PR TITLE
[go-gen] Add generation of create handler

### DIFF
--- a/src/e2e/resources/go/user/user.go.snippet
+++ b/src/e2e/resources/go/user/user.go.snippet
@@ -180,7 +180,72 @@ func (env *env) listTempleuserHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (env *env) createTempleuserHandler(w http.ResponseWriter, r *http.Request) {
+	auth, err := util.ExtractAuthIDFromRequest(r.Header)
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Could not authorize request: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusUnauthorized)
+		return
+	}
 
+	var req createTempleuserRequest
+	err = json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Invalid request parameters: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusBadRequest)
+		return
+	}
+
+	if req.Username == nil || req.Email == nil || req.FirstName == nil || req.LastName == nil || req.CreatedAt == nil || req.NumberOfDogs == nil || req.CurrentBankBalance == nil || req.BirthDate == nil || req.BreakfastTime == nil {
+		errMsg := util.CreateErrorJSON("Missing request parameter(s)")
+		http.Error(w, errMsg, http.StatusBadRequest)
+		return
+	}
+
+	_, err = valid.ValidateStruct(req)
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Invalid request parameters: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusBadRequest)
+		return
+	}
+
+	uuid, err := uuid.NewUUID()
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Could not create UUID: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusInternalServerError)
+		return
+	}
+
+	templeuser, err := env.dao.CreateTempleuser(dao.CreateTempleuserInput{
+		ID:                 uuid,
+		AuthID:             auth.ID,
+		Username:           *req.Username,
+		Email:              *req.Email,
+		FirstName:          *req.FirstName,
+		LastName:           *req.LastName,
+		CreatedAt:          *req.CreatedAt,
+		NumberOfDogs:       *req.NumberOfDogs,
+		CurrentBankBalance: *req.CurrentBankBalance,
+		BirthDate:          *req.BirthDate,
+		BreakfastTime:      *req.BreakfastTime,
+	})
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusInternalServerError)
+		return
+	}
+
+	json.NewEncoder(w).Encode(createTempleuserResponse{
+		ID:                 templeuser.ID,
+		Username:           templeuser.Username,
+		Email:              templeuser.Email,
+		FirstName:          templeuser.FirstName,
+		LastName:           templeuser.LastName,
+		CreatedAt:          templeuser.CreatedAt.Format(time.RFC3339),
+		NumberOfDogs:       templeuser.NumberOfDogs,
+		CurrentBankBalance: templeuser.CurrentBankBalance,
+		BirthDate:          templeuser.BirthDate,
+		BreakfastTime:      templeuser.BreakfastTime,
+	})
 }
 
 func (env *env) readTempleuserHandler(w http.ResponseWriter, r *http.Request) {

--- a/src/main/scala/temple/generate/server/ServiceRoot.scala
+++ b/src/main/scala/temple/generate/server/ServiceRoot.scala
@@ -16,7 +16,7 @@ import scala.collection.immutable.ListMap
   * @param port the port number this service will be served on
   * @param idAttribute the name of the ID field
   * @param createdByAttribute the input name, name and type of the createdBy field in this service, and whether it is
-  * used to enumerate the service in the List endpoint
+  * used to enumerate the service in the List endpoint. Also indicates whether this service has an auth block.
   * @param attributes the user-defined fields of the resource handled by this service
   * @param datastore the datastore being used
   */

--- a/src/main/scala/temple/generate/server/go/GoHTTPStatus.scala
+++ b/src/main/scala/temple/generate/server/go/GoHTTPStatus.scala
@@ -1,0 +1,6 @@
+package temple.generate.server.go
+
+object GoHTTPStatus extends Enumeration {
+  type GoHTTPStatus = Value
+  val StatusBadRequest, StatusUnauthorized, StatusInternalServerError = Value
+}

--- a/src/main/scala/temple/generate/server/go/service/GoServiceGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/GoServiceGenerator.scala
@@ -51,7 +51,7 @@ object GoServiceGenerator extends ServiceGenerator {
         GoServiceMainGenerator.generateRouter(root, operations),
         GoCommonMainGenerator.generateMain(root.name, root.port, usesComms, isAuth = false),
         GoCommonMainGenerator.generateJsonMiddleware(),
-        GoServiceMainHandlersGenerator.generateHandlers(root, operations),
+        GoServiceMainHandlersGenerator.generateHandlers(root, operations, clientAttributes, usesComms),
       ),
       File(root.name, "hook.go") -> mkCode.doubleLines(
         GoCommonGenerator.generatePackage("main"),

--- a/src/main/scala/temple/generate/server/go/service/main/GoServiceMainCreateHandlerGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/main/GoServiceMainCreateHandlerGenerator.scala
@@ -1,16 +1,41 @@
 package temple.generate.server.go.service.main
 
+import temple.ast.Attribute
 import temple.generate.CRUD.Create
 import temple.generate.server.ServiceRoot
+import temple.generate.server.go.common.GoCommonGenerator._
 import temple.generate.server.go.service.main.GoServiceMainHandlersGenerator.generateHandlerDecl
 import temple.generate.utils.CodeTerm.{CodeWrap, mkCode}
+import temple.generate.server.go.service.main.GoServiceMainHandlersGenerator._
+
+import scala.collection.immutable.ListMap
+import scala.Option.when
 
 object GoServiceMainCreateHandlerGenerator {
 
+  /** Generate the checking that incoming request parameters are not nil */
+  private def generateRequestNilCheck(root: ServiceRoot, clientAttributes: ListMap[String, Attribute]): String =
+    genIf(
+      clientAttributes.map { case name -> _ => s"req.${name.capitalize} == nil" }.mkString(" || "),
+      mkCode.lines(generateHTTPError("StatusBadRequest", "Missing request parameter(s)"), genReturn()),
+    )
+
   /** Generate the create handler function */
-  private[main] def generateCreateHandler(root: ServiceRoot): String =
+  private[main] def generateCreateHandler(
+    root: ServiceRoot,
+    clientAttributes: ListMap[String, Attribute],
+    usesComms: Boolean,
+  ): String =
     mkCode(
       generateHandlerDecl(root, Create),
-      CodeWrap.curly.tabbed(),
+      CodeWrap.curly.tabbed(
+        mkCode.doubleLines(
+          generateExtractAuthBlock(),
+          generateDecodeRequestBlock(s"create${root.name.capitalize}"),
+          generateRequestNilCheck(root, clientAttributes),
+          generateValidateStructBlock(),
+          when(usesComms) { generateForeignKeyCheckBlocks(root, clientAttributes) },
+        ),
+      ),
     )
 }

--- a/src/main/scala/temple/generate/server/go/service/main/GoServiceMainCreateHandlerGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/main/GoServiceMainCreateHandlerGenerator.scala
@@ -7,6 +7,7 @@ import temple.generate.server.go.common.GoCommonGenerator._
 import temple.generate.server.go.service.main.GoServiceMainHandlersGenerator.generateHandlerDecl
 import temple.generate.utils.CodeTerm.{CodeWrap, mkCode}
 import temple.generate.server.go.service.main.GoServiceMainHandlersGenerator._
+import temple.generate.server.go.GoHTTPStatus.{StatusBadRequest, StatusInternalServerError}
 
 import scala.collection.immutable.ListMap
 import scala.Option.when
@@ -17,14 +18,58 @@ object GoServiceMainCreateHandlerGenerator {
   private def generateRequestNilCheck(root: ServiceRoot, clientAttributes: ListMap[String, Attribute]): String =
     genIf(
       clientAttributes.map { case name -> _ => s"req.${name.capitalize} == nil" }.mkString(" || "),
-      mkCode.lines(generateHTTPError("StatusBadRequest", "Missing request parameter(s)"), genReturn()),
+      generateHTTPErrorReturn(StatusBadRequest, "Missing request parameter(s)"),
     )
+
+  /** Generate new UUID block */
+  private def generateNewUUIDBlock(): String =
+    mkCode.lines(
+      genDeclareAndAssign(genMethodCall("uuid", "NewUUID"), "uuid", "err"),
+      genIfErr(
+        generateHTTPErrorReturn(StatusInternalServerError, "Could not create UUID: %s", genMethodCall("err", "Error")),
+      ),
+    )
+
+  private def generateDAOCallBlock(
+    root: ServiceRoot,
+    hasAuthBlock: Boolean,
+    clientAttributes: ListMap[String, Attribute],
+  ): String = {
+    val idCapitalized = root.idAttribute.name.toUpperCase
+    // If service has auth block then an AuthID is passed in as ID, otherwise a created uuid is passed in
+    val createInput = ListMap(idCapitalized -> (if (hasAuthBlock) s"auth.$idCapitalized" else "uuid")) ++
+      // If service does not have auth block AuthID is passed for created_by field
+      when(!hasAuthBlock) { s"Auth$idCapitalized" -> s"auth.$idCapitalized" } ++
+      // TODO: ServerSet values need to be passed in, not just client-provided attributes
+      clientAttributes.map { case str -> _ => str.capitalize -> s"*req.${str.capitalize}" }
+
+    mkCode.lines(
+      genDeclareAndAssign(
+        genMethodCall(
+          "env.dao",
+          s"Create${root.name.capitalize}",
+          genPopulateStruct(s"dao.Create${root.name.capitalize}Input", createInput),
+        ),
+        root.name,
+        "err",
+      ),
+      genIfErr(
+        generateHTTPErrorReturn(
+          StatusInternalServerError,
+          "Something went wrong: %s",
+          genMethodCall("err", "Error"),
+        ),
+      ),
+    )
+  }
 
   /** Generate the create handler function */
   private[main] def generateCreateHandler(
     root: ServiceRoot,
     clientAttributes: ListMap[String, Attribute],
     usesComms: Boolean,
+    hasAuthBlock: Boolean,
+    responseMap: ListMap[String, String],
   ): String =
     mkCode(
       generateHandlerDecl(root, Create),
@@ -35,6 +80,9 @@ object GoServiceMainCreateHandlerGenerator {
           generateRequestNilCheck(root, clientAttributes),
           generateValidateStructBlock(),
           when(usesComms) { generateForeignKeyCheckBlocks(root, clientAttributes) },
+          when(!hasAuthBlock) { generateNewUUIDBlock() },
+          generateDAOCallBlock(root, hasAuthBlock, clientAttributes),
+          generateJSONResponse(s"create${root.name.capitalize}", responseMap),
         ),
       ),
     )

--- a/src/main/scala/temple/generate/server/go/service/main/GoServiceMainGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/main/GoServiceMainGenerator.scala
@@ -23,11 +23,9 @@ object GoServiceMainGenerator {
     mkCode(
       "import",
       CodeWrap.parens.tabbed(
-        // TODO: This check is temporary to make the integrations tests pass
-        when(operations.contains(List)) { doubleQuote("encoding/json") },
+        doubleQuote("encoding/json"),
         doubleQuote("flag"),
-        // TODO: This check is temporary to make the integrations tests pass
-        when(operations.contains(List)) { doubleQuote("fmt") },
+        doubleQuote("fmt"),
         doubleQuote("log"),
         doubleQuote("net/http"),
         when(usesTime) { doubleQuote("time") },

--- a/src/main/scala/temple/generate/server/go/service/main/GoServiceMainHandlersGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/main/GoServiceMainHandlersGenerator.scala
@@ -4,6 +4,7 @@ import temple.ast.AttributeType.DateTimeType
 import temple.ast.{Annotation, Attribute, AttributeType}
 import temple.generate.CRUD._
 import temple.generate.server.ServiceRoot
+import temple.generate.server.go.GoHTTPStatus._
 import temple.generate.server.go.common.GoCommonGenerator._
 import temple.generate.server.go.service.main.GoServiceMainCreateHandlerGenerator.generateCreateHandler
 import temple.generate.server.go.service.main.GoServiceMainDeleteHandlerGenerator.generateDeleteHandler
@@ -11,7 +12,7 @@ import temple.generate.server.go.service.main.GoServiceMainListHandlerGenerator.
 import temple.generate.server.go.service.main.GoServiceMainReadHandlerGenerator.generateReadHandler
 import temple.generate.server.go.service.main.GoServiceMainUpdateHandlerGenerator.generateUpdateHandler
 import temple.generate.utils.CodeTerm.mkCode
-import temple.utils.StringUtils.doubleQuote
+import temple.utils.StringUtils.{decapitalize, doubleQuote}
 
 import scala.collection.immutable.ListMap
 
@@ -38,7 +39,7 @@ object GoServiceMainHandlersGenerator {
     s"func (env *env) ${operation.toString.toLowerCase}${root.name.capitalize}Handler(w http.ResponseWriter, r *http.Request)"
 
   /** Generate a errMsg declaration and http.Error call */
-  private[main] def generateHTTPError(statusCodeEnum: String, errMsg: String, errMsgArgs: String*): String = {
+  private[main] def generateHTTPError(statusCodeEnum: GoHTTPStatus, errMsg: String, errMsgArgs: String*): String = {
     val createErrorJSONargs =
       if (errMsgArgs.nonEmpty) genMethodCall("fmt", "Sprintf", (doubleQuote(errMsg) +: errMsgArgs): _*)
       else doubleQuote(errMsg)
@@ -56,14 +57,22 @@ object GoServiceMainHandlersGenerator {
     )
   }
 
+  /** Generate HTTP error and return */
+  private[main] def generateHTTPErrorReturn(statusCodeEnum: GoHTTPStatus, errMsg: String, errMsgArgs: String*): String =
+    mkCode.lines(
+      generateHTTPError(statusCodeEnum, errMsg, errMsgArgs: _*),
+      genReturn(),
+    )
+
   /** Generate the block for extracting an AuthID from the request header */
   private[main] def generateExtractAuthBlock(): String =
     mkCode.lines(
       genDeclareAndAssign(genMethodCall("util", "ExtractAuthIDFromRequest", "r.Header"), "auth", "err"),
       genIfErr(
-        mkCode.lines(
-          generateHTTPError("StatusUnauthorized", "Could not authorize request: %s", genMethodCall("err", "Error")),
-          genReturn(),
+        generateHTTPErrorReturn(
+          StatusUnauthorized,
+          "Could not authorize request: %s",
+          genMethodCall("err", "Error"),
         ),
       ),
     )
@@ -74,10 +83,7 @@ object GoServiceMainHandlersGenerator {
       genVar("req", s"${typePrefix}Request"),
       genAssign(genMethodCall(genMethodCall("json", "NewDecoder", "r.Body"), "Decode", "&req"), "err"),
       genIfErr(
-        mkCode.lines(
-          generateHTTPError("StatusBadRequest", "Invalid request parameters: %s", genMethodCall("err", "Error")),
-          genReturn(),
-        ),
+        generateHTTPErrorReturn(StatusBadRequest, "Invalid request parameters: %s", genMethodCall("err", "Error")),
       ),
     )
 
@@ -86,17 +92,37 @@ object GoServiceMainHandlersGenerator {
     mkCode.lines(
       genAssign(genMethodCall("valid", "ValidateStruct", "req"), "_", "err"),
       genIfErr(
-        mkCode.lines(
-          generateHTTPError("StatusBadRequest", "Invalid request parameters: %s", genMethodCall("err", "Error")),
-          genReturn(),
-        ),
+        generateHTTPErrorReturn(StatusBadRequest, "Invalid request parameters: %s", genMethodCall("err", "Error")),
       ),
     )
 
-  private def generateForeignKeyCheckBlock(root: ServiceRoot, name: String): String =
+  private def generateForeignKeyCheckBlock(root: ServiceRoot, name: String, reference: String): String =
     mkCode.lines(
-      // TODO: Return here
-      genDeclareAndAssign(genMethodCall(genMethodCall("env.Comm", s"Check${root.name.capitalize}"))),
+      genDeclareAndAssign(
+        genMethodCall(
+          "env.comm",
+          s"Check$reference",
+          s"*req.${name.capitalize}",
+          genMethodCall("r.Header", "Get", doubleQuote("Authorization")),
+        ),
+        s"${name}Valid",
+        "err",
+      ),
+      genIfErr(
+        generateHTTPErrorReturn(
+          StatusInternalServerError,
+          s"Unable to reach ${decapitalize(reference)} service: %s",
+          genMethodCall("err", "Error"),
+        ),
+      ),
+      genIf(
+        s"!${name}Valid",
+        generateHTTPErrorReturn(
+          StatusBadRequest,
+          s"Unknown $reference: %s",
+          genMethodCall(s"req.${name.capitalize}", "String"),
+        ),
+      ),
     )
 
   /** Generate the block for checking foreign keys against other services */
@@ -108,10 +134,18 @@ object GoServiceMainHandlersGenerator {
       clientAttributes.map {
         case name -> attribute =>
           attribute.attributeType match {
-            case _: AttributeType.ForeignKey | AttributeType.UUIDType => generateForeignKeyCheckBlock(root, name)
-            case _                                                    => ""
+            case AttributeType.ForeignKey(reference) => generateForeignKeyCheckBlock(root, name, reference)
+            case _                                   => ""
           }
       },
+    )
+
+  /** Generate JSON response from DAO response */
+  private[main] def generateJSONResponse(typePrefix: String, responseMap: ListMap[String, String]): String =
+    genMethodCall(
+      genMethodCall("json", "NewEncoder", "w"),
+      "Encode",
+      genPopulateStruct(s"${typePrefix}Response", responseMap),
     )
 
   /** Generate the env handler functions */
@@ -120,12 +154,13 @@ object GoServiceMainHandlersGenerator {
     operations: Set[CRUD],
     clientAttributes: ListMap[String, Attribute],
     usesComms: Boolean,
+    hasAuthBlock: Boolean,
   ): String = {
     val responseMap = generateResponseMap(root)
     mkCode.doubleLines(
       operations.toSeq.sorted.map {
         case List   => generateListHandler(root, responseMap)
-        case Create => generateCreateHandler(root, clientAttributes, usesComms)
+        case Create => generateCreateHandler(root, clientAttributes, usesComms, hasAuthBlock, responseMap)
         case Read   => generateReadHandler(root)
         case Update => generateUpdateHandler(root)
         case Delete => generateDeleteHandler(root)

--- a/src/main/scala/temple/generate/server/go/service/main/GoServiceMainListHandlerGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/main/GoServiceMainListHandlerGenerator.scala
@@ -5,6 +5,7 @@ import temple.generate.server.go.common.GoCommonGenerator._
 import temple.generate.server.go.service.main.GoServiceMainHandlersGenerator.{generateHandlerDecl, generateExtractAuthBlock, generateHTTPError}
 import temple.generate.server.{CreatedByAttribute, ServiceRoot}
 import temple.generate.utils.CodeTerm.{CodeWrap, mkCode}
+import temple.generate.server.go.GoHTTPStatus.StatusInternalServerError
 
 import scala.Option.when
 import scala.collection.immutable.ListMap
@@ -41,7 +42,7 @@ object GoServiceMainListHandlerGenerator {
     val queryDAOErrorBlock = genIfErr(
       mkCode.lines(
         generateHTTPError(
-          "StatusInternalServerError",
+          StatusInternalServerError,
           "Something went wrong: %s",
           genMethodCall("err", "Error"),
         ),

--- a/src/test/resources/go/complex-user/complexuser.go.snippet
+++ b/src/test/resources/go/complex-user/complexuser.go.snippet
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
+	"fmt"
 	"log"
 	"net/http"
 	"time"
@@ -144,7 +146,70 @@ func jsonMiddleware(next http.Handler) http.Handler {
 }
 
 func (env *env) createComplexuserHandler(w http.ResponseWriter, r *http.Request) {
+	auth, err := util.ExtractAuthIDFromRequest(r.Header)
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Could not authorize request: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusUnauthorized)
+		return
+	}
 
+	var req createComplexuserRequest
+	err = json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Invalid request parameters: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusBadRequest)
+		return
+	}
+
+	if req.SmallIntField == nil || req.IntField == nil || req.BigIntField == nil || req.FloatField == nil || req.DoubleField == nil || req.StringField == nil || req.BoundedStringField == nil || req.BoolField == nil || req.DateField == nil || req.TimeField == nil || req.DateTimeField == nil || req.BlobField == nil {
+		errMsg := util.CreateErrorJSON("Missing request parameter(s)")
+		http.Error(w, errMsg, http.StatusBadRequest)
+		return
+	}
+
+	_, err = valid.ValidateStruct(req)
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Invalid request parameters: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusBadRequest)
+		return
+	}
+
+	complexuser, err := env.dao.CreateComplexuser(dao.CreateComplexuserInput{
+		ID:                 auth.ID,
+		SmallIntField:      *req.SmallIntField,
+		IntField:           *req.IntField,
+		BigIntField:        *req.BigIntField,
+		FloatField:         *req.FloatField,
+		DoubleField:        *req.DoubleField,
+		StringField:        *req.StringField,
+		BoundedStringField: *req.BoundedStringField,
+		BoolField:          *req.BoolField,
+		DateField:          *req.DateField,
+		TimeField:          *req.TimeField,
+		DateTimeField:      *req.DateTimeField,
+		BlobField:          *req.BlobField,
+	})
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusInternalServerError)
+		return
+	}
+
+	json.NewEncoder(w).Encode(createComplexuserResponse{
+		ID:                 complexuser.ID,
+		SmallIntField:      complexuser.SmallIntField,
+		IntField:           complexuser.IntField,
+		BigIntField:        complexuser.BigIntField,
+		FloatField:         complexuser.FloatField,
+		DoubleField:        complexuser.DoubleField,
+		StringField:        complexuser.StringField,
+		BoundedStringField: complexuser.BoundedStringField,
+		BoolField:          complexuser.BoolField,
+		DateField:          complexuser.DateField,
+		TimeField:          complexuser.TimeField,
+		DateTimeField:      complexuser.DateTimeField.Format(time.RFC3339),
+		BlobField:          complexuser.BlobField,
+	})
 }
 
 func (env *env) readComplexuserHandler(w http.ResponseWriter, r *http.Request) {

--- a/src/test/resources/go/simple-user/user.go.snippet
+++ b/src/test/resources/go/simple-user/user.go.snippet
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
+	"fmt"
 	"log"
 	"net/http"
 	"time"
@@ -124,7 +126,62 @@ func jsonMiddleware(next http.Handler) http.Handler {
 }
 
 func (env *env) createTempleuserHandler(w http.ResponseWriter, r *http.Request) {
+	auth, err := util.ExtractAuthIDFromRequest(r.Header)
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Could not authorize request: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusUnauthorized)
+		return
+	}
 
+	var req createTempleuserRequest
+	err = json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Invalid request parameters: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusBadRequest)
+		return
+	}
+
+	if req.IntField == nil || req.DoubleField == nil || req.StringField == nil || req.BoolField == nil || req.DateField == nil || req.TimeField == nil || req.DateTimeField == nil || req.BlobField == nil {
+		errMsg := util.CreateErrorJSON("Missing request parameter(s)")
+		http.Error(w, errMsg, http.StatusBadRequest)
+		return
+	}
+
+	_, err = valid.ValidateStruct(req)
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Invalid request parameters: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusBadRequest)
+		return
+	}
+
+	templeuser, err := env.dao.CreateTempleuser(dao.CreateTempleuserInput{
+		ID:            auth.ID,
+		IntField:      *req.IntField,
+		DoubleField:   *req.DoubleField,
+		StringField:   *req.StringField,
+		BoolField:     *req.BoolField,
+		DateField:     *req.DateField,
+		TimeField:     *req.TimeField,
+		DateTimeField: *req.DateTimeField,
+		BlobField:     *req.BlobField,
+	})
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusInternalServerError)
+		return
+	}
+
+	json.NewEncoder(w).Encode(createTempleuserResponse{
+		ID:            templeuser.ID,
+		IntField:      templeuser.IntField,
+		DoubleField:   templeuser.DoubleField,
+		StringField:   templeuser.StringField,
+		BoolField:     templeuser.BoolField,
+		DateField:     templeuser.DateField,
+		TimeField:     templeuser.TimeField,
+		DateTimeField: templeuser.DateTimeField.Format(time.RFC3339),
+		BlobField:     templeuser.BlobField,
+	})
 }
 
 func (env *env) readTempleuserHandler(w http.ResponseWriter, r *http.Request) {

--- a/src/test/scala/temple/generate/server/go/testfiles/match/match.go.snippet
+++ b/src/test/scala/temple/generate/server/go/testfiles/match/match.go.snippet
@@ -150,7 +150,33 @@ func (env *env) listMatchHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (env *env) createMatchHandler(w http.ResponseWriter, r *http.Request) {
+	auth, err := util.ExtractAuthIDFromRequest(r.Header)
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Could not authorize request: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusUnauthorized)
+		return
+	}
 
+	var req createMatchRequest
+	err = json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Invalid request parameters: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusBadRequest)
+		return
+	}
+
+	if req.UserOne == nil || req.UserTwo == nil {
+		errMsg := util.CreateErrorJSON("Missing request parameter(s)")
+		http.Error(w, errMsg, http.StatusBadRequest)
+		return
+	}
+
+	_, err = valid.ValidateStruct(req)
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Invalid request parameters: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusBadRequest)
+		return
+	}
 }
 
 func (env *env) readMatchHandler(w http.ResponseWriter, r *http.Request) {

--- a/src/test/scala/temple/generate/server/go/testfiles/match/match.go.snippet
+++ b/src/test/scala/temple/generate/server/go/testfiles/match/match.go.snippet
@@ -177,6 +177,56 @@ func (env *env) createMatchHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, errMsg, http.StatusBadRequest)
 		return
 	}
+
+	userOneValid, err := env.comm.CheckUser(*req.UserOne, r.Header.Get("Authorization"))
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Unable to reach user service: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusInternalServerError)
+		return
+	}
+	if !userOneValid {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Unknown User: %s", req.UserOne.String()))
+		http.Error(w, errMsg, http.StatusBadRequest)
+		return
+	}
+
+	userTwoValid, err := env.comm.CheckUser(*req.UserTwo, r.Header.Get("Authorization"))
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Unable to reach user service: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusInternalServerError)
+		return
+	}
+	if !userTwoValid {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Unknown User: %s", req.UserTwo.String()))
+		http.Error(w, errMsg, http.StatusBadRequest)
+		return
+	}
+
+	uuid, err := uuid.NewUUID()
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Could not create UUID: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusInternalServerError)
+		return
+	}
+
+	match, err := env.dao.CreateMatch(dao.CreateMatchInput{
+		ID:      uuid,
+		AuthID:  auth.ID,
+		UserOne: *req.UserOne,
+		UserTwo: *req.UserTwo,
+	})
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusInternalServerError)
+		return
+	}
+
+	json.NewEncoder(w).Encode(createMatchResponse{
+		ID:        match.ID,
+		UserOne:   match.UserOne,
+		UserTwo:   match.UserTwo,
+		MatchedOn: match.MatchedOn.Format(time.RFC3339),
+	})
 }
 
 func (env *env) readMatchHandler(w http.ResponseWriter, r *http.Request) {

--- a/src/test/scala/temple/generate/server/go/testfiles/user/user.go.snippet
+++ b/src/test/scala/temple/generate/server/go/testfiles/user/user.go.snippet
@@ -88,7 +88,33 @@ func jsonMiddleware(next http.Handler) http.Handler {
 }
 
 func (env *env) createUserHandler(w http.ResponseWriter, r *http.Request) {
+	auth, err := util.ExtractAuthIDFromRequest(r.Header)
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Could not authorize request: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusUnauthorized)
+		return
+	}
 
+	var req createUserRequest
+	err = json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Invalid request parameters: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusBadRequest)
+		return
+	}
+
+	if req.Name == nil {
+		errMsg := util.CreateErrorJSON("Missing request parameter(s)")
+		http.Error(w, errMsg, http.StatusBadRequest)
+		return
+	}
+
+	_, err = valid.ValidateStruct(req)
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Invalid request parameters: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusBadRequest)
+		return
+	}
 }
 
 func (env *env) readUserHandler(w http.ResponseWriter, r *http.Request) {

--- a/src/test/scala/temple/generate/server/go/testfiles/user/user.go.snippet
+++ b/src/test/scala/temple/generate/server/go/testfiles/user/user.go.snippet
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
+	"fmt"
 	"log"
 	"net/http"
 
@@ -115,6 +117,21 @@ func (env *env) createUserHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, errMsg, http.StatusBadRequest)
 		return
 	}
+
+	user, err := env.dao.CreateUser(dao.CreateUserInput{
+		ID:   auth.ID,
+		Name: *req.Name,
+	})
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusInternalServerError)
+		return
+	}
+
+	json.NewEncoder(w).Encode(createUserResponse{
+		ID:   user.ID,
+		Name: user.Name,
+	})
 }
 
 func (env *env) readUserHandler(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
* Adds generation of create handlers
  * Splits up generating functions ready for reuse with update handler
* Adds GoHTTPStatus enum
* Updates tests

Should be pretty readable, will make it reasonably quick to write the update handler. About 300 lines of snippets.

A few issues that will need to be handled:
  * What if there are no client facing attributes
  * ServerSet values cannot be created in the SQL query

I have made cards for these issues.