### PR TITLE
[go-gen] Add readable/writable to ServiceRoot

### DIFF
--- a/src/it/scala/temple/generate/server/GoGeneratorIntegrationTestData.scala
+++ b/src/it/scala/temple/generate/server/GoGeneratorIntegrationTestData.scala
@@ -1,6 +1,7 @@
 package temple.generate.server
 
 import temple.ast.Metadata.Database.Postgres
+import temple.ast.Metadata.{Readable, Writable}
 import temple.ast.{Annotation, Attribute, AttributeType}
 import temple.generate.CRUD
 
@@ -23,6 +24,8 @@ object GoGeneratorIntegrationTestData {
     CreatedByAttribute.None,
     ListMap("name" -> Attribute(AttributeType.StringType())),
     Postgres,
+    Readable.All,
+    Writable.This,
   )
 
   val simpleServiceRootWithComms: ServiceRoot = ServiceRoot(
@@ -45,5 +48,7 @@ object GoGeneratorIntegrationTestData {
       "matchedOn" -> Attribute(AttributeType.DateTimeType, Some(Annotation.ServerSet)),
     ),
     Postgres,
+    Readable.This,
+    Writable.This,
   )
 }

--- a/src/main/scala/temple/builder/ServerBuilder.scala
+++ b/src/main/scala/temple/builder/ServerBuilder.scala
@@ -21,6 +21,7 @@ object ServerBuilder {
     port: Int,
     endpoints: Set[CRUD],
     detail: LanguageDetail,
+    projectUsesAuth: Boolean,
   ): ServiceRoot = {
     val language = serviceBlock.lookupMetadata[ServiceLanguage].getOrElse(ProjectConfig.defaultLanguage)
     val database = serviceBlock.lookupMetadata[Database].getOrElse(ProjectConfig.defaultDatabase)
@@ -66,7 +67,10 @@ object ServerBuilder {
       case (_, Attribute(x: ForeignKey, _, _)) => x.references
     }.toSeq
 
-    // TODO: Auth
+    val readable =
+      serviceBlock.lookupLocalMetadata[Metadata.Readable].getOrElse(ProjectConfig.getDefaultReadable(projectUsesAuth))
+    val writable =
+      serviceBlock.lookupLocalMetadata[Metadata.Writable].getOrElse(ProjectConfig.getDefaultWritable(projectUsesAuth))
 
     ServiceRoot(
       serviceName,
@@ -78,6 +82,8 @@ object ServerBuilder {
       createdByAttribute = createdBy,
       attributes = ListMap.from(serviceBlock.attributes),
       datastore = serviceBlock.lookupMetadata[Metadata.Database].getOrElse(ProjectConfig.defaultDatabase),
+      readable = readable,
+      writable = writable,
     )
   }
 

--- a/src/main/scala/temple/builder/project/ProjectBuilder.scala
+++ b/src/main/scala/temple/builder/project/ProjectBuilder.scala
@@ -105,7 +105,7 @@ object ProjectBuilder {
     var serverFiles = templefile.servicesWithPorts.flatMap {
       case (name, service, port) =>
         val serviceRoot =
-          ServerBuilder.buildServiceRoot(name.toLowerCase, service, port.service, endpoints(service), detail)
+          ServerBuilder.buildServiceRoot(name.toLowerCase, service, port.service, endpoints(service), detail, usesAuth)
         service.lookupMetadata[ServiceLanguage].getOrElse(ProjectConfig.defaultLanguage) match {
           case ServiceLanguage.Go =>
             GoServiceGenerator.generate(serviceRoot)

--- a/src/main/scala/temple/builder/project/ProjectConfig.scala
+++ b/src/main/scala/temple/builder/project/ProjectConfig.scala
@@ -31,4 +31,10 @@ object ProjectConfig {
         hostPath = s"/data/$serviceName-db",
       )
   }
+
+  def getDefaultReadable(projectHasAuthBlock: Boolean): Readable =
+    if (projectHasAuthBlock) Readable.This else Readable.All
+
+  def getDefaultWritable(projectHasAuthBlock: Boolean): Writable =
+    if (projectHasAuthBlock) Writable.This else Writable.All
 }

--- a/src/main/scala/temple/generate/server/ServiceRoot.scala
+++ b/src/main/scala/temple/generate/server/ServiceRoot.scala
@@ -1,7 +1,7 @@
 package temple.generate.server
 
 import temple.ast.Attribute
-import temple.ast.Metadata.Database
+import temple.ast.Metadata.{Database, Readable, Writable}
 import temple.generate.CRUD.CRUD
 
 import scala.collection.immutable.ListMap
@@ -30,4 +30,6 @@ case class ServiceRoot(
   createdByAttribute: CreatedByAttribute,
   attributes: ListMap[String, Attribute],
   datastore: Database,
+  readable: Readable,
+  writable: Writable,
 )

--- a/src/test/scala/temple/builder/ServerBuilderTest.scala
+++ b/src/test/scala/temple/builder/ServerBuilderTest.scala
@@ -2,7 +2,7 @@ package temple.builder
 
 import org.scalatest.{FlatSpec, Matchers}
 import temple.ast.AttributeType._
-import temple.ast.Metadata.{Database, ServiceAuth}
+import temple.ast.Metadata.{Database, Readable, ServiceAuth, Writable}
 import temple.ast.{Attribute, AttributeType}
 import temple.detail.LanguageDetail.GoLanguageDetail
 import temple.generate.CRUD._
@@ -24,6 +24,7 @@ class ServerBuilderTest extends FlatSpec with Matchers {
             endpoints = Set(Create, Read, Update, Delete, List),
             port = port.service,
             detail = GoLanguageDetail("github.com/squat/and/dab"),
+            projectUsesAuth = false,
           )
     }
     serviceRoot shouldBe ServiceRoot(
@@ -51,6 +52,8 @@ class ServerBuilderTest extends FlatSpec with Matchers {
         "image"       -> Attribute(BlobType()),
       ),
       datastore = Database.Postgres,
+      readable = Readable.All,
+      writable = Writable.All,
     )
   }
 
@@ -64,6 +67,7 @@ class ServerBuilderTest extends FlatSpec with Matchers {
             endpoints = Set(),
             port = port.service,
             detail = GoLanguageDetail("github.com/squat/and/dab"),
+            projectUsesAuth = false,
           )
     }
     serviceRoot shouldBe ServiceRoot(
@@ -85,6 +89,8 @@ class ServerBuilderTest extends FlatSpec with Matchers {
         "image"       -> Attribute(BlobType()),
       ),
       datastore = Database.Postgres,
+      readable = Readable.All,
+      writable = Writable.All,
     )
   }
 
@@ -98,6 +104,7 @@ class ServerBuilderTest extends FlatSpec with Matchers {
             endpoints = Set(Create, Read, Update, Delete, List),
             port = port.service,
             detail = GoLanguageDetail("github.com/squat/and/dab"),
+            projectUsesAuth = false,
           )
     }
     serviceRoot shouldBe ServiceRoot(
@@ -129,6 +136,8 @@ class ServerBuilderTest extends FlatSpec with Matchers {
         "image"          -> Attribute(BlobType()),
       ),
       datastore = Database.Postgres,
+      readable = Readable.All,
+      writable = Writable.All,
     )
   }
 

--- a/src/test/scala/temple/generate/server/go/GoServiceGeneratorTestData.scala
+++ b/src/test/scala/temple/generate/server/go/GoServiceGeneratorTestData.scala
@@ -6,6 +6,7 @@ import temple.generate.CRUD
 import temple.generate.FileSystem._
 import temple.generate.server.{CreatedByAttribute, IDAttribute, ServiceRoot}
 import temple.utils.FileUtils._
+import temple.ast.Metadata.{Readable, Writable}
 
 import scala.collection.immutable.ListMap
 
@@ -26,6 +27,8 @@ object GoServiceGeneratorTestData {
     CreatedByAttribute.None,
     ListMap("name" -> Attribute(AttributeType.StringType(Option(255L), Option(2)))),
     Postgres,
+    Readable.All,
+    Writable.This,
   )
 
   val simpleServiceFiles: Files = Map(
@@ -67,6 +70,8 @@ object GoServiceGeneratorTestData {
         "matchedOn" -> Attribute(AttributeType.DateTimeType, Some(Annotation.ServerSet)),
       ),
       Postgres,
+      Readable.This,
+      Writable.This,
     )
 
   val simpleServiceFilesWithComms: Files = Map(


### PR DESCRIPTION
* Adds readable and writable fields to `ServiceRoot`

We decided the defaults are as follows:
  * If any service in the project has an auth block, readable and writable default to `(by: this)`
  * If no service in the project has an auth block, readable and writable default to `(by: all)`

This does bring up that if no service has an auth block, we cannot read or write `(by: this)`, and so therefore need to be blocked at the DSL level. I have made cards, for Charlie, for this.