### PR TITLE
[Auth-Map] Add GeneratedBlock trait for more abstraction

### DIFF
--- a/src/main/scala/temple/DSL/semantics/Validator.scala
+++ b/src/main/scala/temple/DSL/semantics/Validator.scala
@@ -111,7 +111,7 @@ private class Validator private (templefile: Templefile) {
   def validate(): Seq[String] = {
     val context = SemanticContext.empty
 
-    templefile.services.foreachEntry(context(validateService))
+    templefile.providedServices.foreachEntry(context(validateService))
     templefile.targets.foreachEntry(context(validateBlockOfMetadata))
     validateBlockOfMetadata(templefile.projectBlock)(context :+ s"${templefile.projectName} project")
 

--- a/src/main/scala/temple/ast/AuthServiceBlock.scala
+++ b/src/main/scala/temple/ast/AuthServiceBlock.scala
@@ -1,0 +1,15 @@
+package temple.ast
+
+import temple.ast.Metadata.{Endpoint, Omit, ServiceMetadata}
+
+case object AuthServiceBlock extends GeneratedBlock {
+
+  override def attributes: Map[String, Attribute] = Map(
+    "id"       -> Attribute(AttributeType.UUIDType, valueAnnotations = Set(Annotation.Unique)),
+    "email"    -> Attribute(AttributeType.StringType(), valueAnnotations = Set(Annotation.Unique)),
+    "password" -> Attribute(AttributeType.StringType()),
+  )
+
+  override def metadata                          = Seq(Omit(Set(Endpoint.Update, Endpoint.Delete)))
+  override def structs: Map[String, StructBlock] = Map()
+}

--- a/src/main/scala/temple/ast/GeneratedBlock.scala
+++ b/src/main/scala/temple/ast/GeneratedBlock.scala
@@ -1,0 +1,25 @@
+package temple.ast
+
+import temple.ast.Metadata.ServiceMetadata
+
+trait GeneratedBlock extends TempleBlock[ServiceMetadata] {
+  def attributes: Map[String, Attribute]
+  def metadata: Seq[ServiceMetadata]
+  def structs: Map[String, StructBlock]
+
+  /**
+    * Flatten a service block into a sequence of structs, including the service's root struct.
+    *
+    * @param rootName The name of the root struct, typically the name of the service.
+    * @return An iterator of pairs of names and struct blocks,
+    *         represented as an iterator of pairs of names and attributes
+    */
+  def structIterator(rootName: String): Iterator[(String, Map[String, Attribute])] =
+    Iterator((rootName, attributes)) ++ structs.iterator.map { case (str, block) => (str, block.attributes) }
+
+  /** Set the parent that this Templefile is within */
+  override private[temple] def setParent(parent: TempleNode): Unit = {
+    super.setParent(parent)
+    structs.valuesIterator.foreach(_.setParent(this))
+  }
+}

--- a/src/main/scala/temple/ast/ServiceBlock.scala
+++ b/src/main/scala/temple/ast/ServiceBlock.scala
@@ -7,21 +7,4 @@ case class ServiceBlock(
   attributes: Map[String, Attribute],
   metadata: Seq[ServiceMetadata] = Nil,
   structs: Map[String, StructBlock] = Map.empty,
-) extends TempleBlock[ServiceMetadata] {
-
-  /**
-    * Flatten a service block into a sequence of structs, including the service’s root struct.
-    *
-    * @param rootName The name of the root struct, typically the name of the service.
-    * @return An iterator of pairs of names and struct blocks,
-    *         represented as an iterator of pairs of names and attributes
-    */
-  def structIterator(rootName: String): Iterator[(String, Map[String, Attribute])] =
-    Iterator((rootName, attributes)) ++ structs.iterator.map { case (str, block) => (str, block.attributes) }
-
-  /** Set the parent that this Templefile is within */
-  override private[temple] def setParent(parent: TempleNode): Unit = {
-    super.setParent(parent)
-    structs.valuesIterator.foreach(_.setParent(this))
-  }
-}
+) extends GeneratedBlock

--- a/src/main/scala/temple/ast/Templefile.scala
+++ b/src/main/scala/temple/ast/Templefile.scala
@@ -10,31 +10,35 @@ case class Templefile(
   projectName: String,
   projectBlock: ProjectBlock = ProjectBlock(),
   targets: Map[String, TargetBlock] = Map(),
-  var services: Map[String, ServiceBlock] = Map(),
+  var services: Map[String, GeneratedBlock] = Map(),
 ) extends TempleNode {
   // Inform every child node of their parent, so that they can access the project information
   for (block <- Iterator(projectBlock) ++ targets.valuesIterator ++ services.valuesIterator) {
     block.setParent(this)
   }
 
-  def servicesWithPorts: Iterable[(String, ServiceBlock, Ports)] =
+  def providedServices: Map[String, ServiceBlock] = services.collect {
+    case (name: String, service: ServiceBlock) => name -> service
+  }
+
+  def servicesWithPorts: Iterable[(String, GeneratedBlock, Ports)] =
     services
       .zip(Iterator.from(1025, step = 2)) // 1024 is reserved for auth service
       .map {
         case ((name, service), port) =>
-          if (name == "Auth") (name, service, Ports(ProjectConfig.authPort, ProjectConfig.authPort + 1))
+          if (service == AuthServiceBlock) (name, service, Ports(ProjectConfig.authPort, ProjectConfig.authPort + 1))
           else (name, service, Ports(port, port + 1))
       }
 
-  def servicesWithPortsWithoutAuth: Iterable[(String, ServiceBlock, Ports)] =
-    servicesWithPorts.filterNot { case (name, _, _) => name == "Auth" }
+  def servicesWithPortsWithoutAuth: Iterable[(String, GeneratedBlock, Ports)] =
+    servicesWithPorts.filterNot { case (_, service, _) => service == AuthServiceBlock }
 
   /**
     * Add an extra service to an exisiting Templefile - useful for adding auth when needed.
     * @param name - the name of the new service
     * @param block - the [[ServiceBlock]] to add
     */
-  def addService(name: String, block: ServiceBlock): Unit = {
+  def addService(name: String, block: GeneratedBlock): Unit = {
     block.setParent(this)
     services += name -> block
   }

--- a/src/main/scala/temple/ast/Templefile.scala
+++ b/src/main/scala/temple/ast/Templefile.scala
@@ -17,11 +17,15 @@ case class Templefile(
     block.setParent(this)
   }
 
+  /**
+    * The services provided in the templefile, i.e the ServiceBlocks, not the AuthServiceBlocks
+    * @return
+    */
   def providedServices: Map[String, ServiceBlock] = services.collect {
     case (name: String, service: ServiceBlock) => name -> service
   }
 
-  def servicesWithPorts: Iterable[(String, GeneratedBlock, Ports)] =
+  def allServicesWithPorts: Iterable[(String, GeneratedBlock, Ports)] =
     services
       .zip(Iterator.from(1025, step = 2)) // 1024 is reserved for auth service
       .map {
@@ -30,8 +34,8 @@ case class Templefile(
           else (name, service, Ports(port, port + 1))
       }
 
-  def servicesWithPortsWithoutAuth: Iterable[(String, GeneratedBlock, Ports)] =
-    servicesWithPorts.filterNot { case (_, service, _) => service == AuthServiceBlock }
+  def providedServicesWithPorts: Iterable[(String, ServiceBlock, Ports)] =
+    allServicesWithPorts.collect { case (name, service: ServiceBlock, ports) => (name, service, ports) }
 
   /**
     * Add an extra service to an exisiting Templefile - useful for adding auth when needed.

--- a/src/main/scala/temple/builder/DatabaseBuilder.scala
+++ b/src/main/scala/temple/builder/DatabaseBuilder.scala
@@ -1,7 +1,7 @@
 package temple.builder
 
 import temple.ast.Annotation.Nullable
-import temple.ast.{Annotation, Attribute, AttributeType, ServiceBlock}
+import temple.ast.{Annotation, Attribute, AttributeType, GeneratedBlock, ServiceBlock}
 import temple.generate.CRUD.{CRUD, Create, Delete, List, Read, Update}
 import temple.generate.database.ast.ColumnConstraint.Check
 import temple.generate.database.ast.Condition.PreparedComparison
@@ -109,7 +109,7 @@ object DatabaseBuilder {
     * @param service     The ServiceBlock to generate
     * @return the associated create statement
     */
-  def createServiceTables(serviceName: String, service: ServiceBlock): Seq[Statement.Create] = {
+  def createServiceTables(serviceName: String, service: GeneratedBlock): Seq[Statement.Create] = {
     service.structIterator(serviceName).map {
       case (tableName, attributes) =>
         val columns = attributes.map { case (name, attributes) => toColDef(name, attributes) }

--- a/src/main/scala/temple/builder/DockerfileBuilder.scala
+++ b/src/main/scala/temple/builder/DockerfileBuilder.scala
@@ -1,6 +1,6 @@
 package temple.builder
 
-import temple.ast.{Metadata, ServiceBlock}
+import temple.ast.{GeneratedBlock, Metadata, ServiceBlock}
 import temple.builder.project.ProjectConfig
 import temple.generate.docker.ast.Statement._
 import temple.generate.docker.ast.{DockerfileRoot, Statement}
@@ -8,7 +8,7 @@ import temple.generate.docker.ast.{DockerfileRoot, Statement}
 /** Construct a Dockerfile from a Templefile service */
 object DockerfileBuilder {
 
-  def createServiceDockerfile(serviceName: String, service: ServiceBlock, port: Int): DockerfileRoot = {
+  def createServiceDockerfile(serviceName: String, service: GeneratedBlock, port: Int): DockerfileRoot = {
     val language    = service.lookupMetadata[Metadata.ServiceLanguage].getOrElse(ProjectConfig.defaultLanguage)
     val dockerImage = ProjectConfig.dockerImage(language)
 

--- a/src/main/scala/temple/builder/OrchestrationBuilder.scala
+++ b/src/main/scala/temple/builder/OrchestrationBuilder.scala
@@ -1,7 +1,7 @@
 package temple.builder
 
 import temple.ast.Metadata.Database
-import temple.ast.{Metadata, ServiceBlock}
+import temple.ast.{GeneratedBlock, Metadata, ServiceBlock}
 import temple.builder.project.ProjectConfig
 import temple.generate.kube.ast.OrchestrationType.{OrchestrationRoot, Service}
 import temple.generate.kube.ast.gen.LifecycleCommand
@@ -11,7 +11,7 @@ object OrchestrationBuilder {
 
   def createServiceOrchestrationRoot(
     projectName: String,
-    services: Seq[(String, ServiceBlock, Int)],
+    services: Seq[(String, GeneratedBlock, Int)],
   ): OrchestrationRoot =
     OrchestrationRoot(
       services map {

--- a/src/main/scala/temple/builder/ServerBuilder.scala
+++ b/src/main/scala/temple/builder/ServerBuilder.scala
@@ -17,7 +17,7 @@ object ServerBuilder {
 
   def buildServiceRoot(
     serviceName: String,
-    serviceBlock: ServiceBlock,
+    serviceBlock: GeneratedBlock,
     port: Int,
     endpoints: Set[CRUD],
     detail: LanguageDetail,

--- a/src/main/scala/temple/builder/project/ProjectBuilder.scala
+++ b/src/main/scala/temple/builder/project/ProjectBuilder.scala
@@ -49,23 +49,13 @@ object ProjectBuilder {
     */
   def build(templefile: Templefile, detail: LanguageDetail): Project = {
 
-    // Whether or not to generate an auth service - based on whether any service have #auth
+    // Whether or not to generate an auth service - based on whether any service has #auth
     val usesAuth = templefile.services.exists {
       case (_, service) => service.lookupMetadata[ServiceAuth].nonEmpty
     }
 
     if (usesAuth) {
-      templefile.addService(
-        "Auth",
-        ServiceBlock(
-          attributes = Map(
-            "id"       -> Attribute(AttributeType.UUIDType, valueAnnotations = Set(Annotation.Unique)),
-            "email"    -> Attribute(AttributeType.StringType(), valueAnnotations = Set(Annotation.Unique)),
-            "password" -> Attribute(AttributeType.StringType()),
-          ),
-          metadata = Seq(Omit(Set(Endpoint.Update, Endpoint.Delete))),
-        ),
-      )
+      templefile.addService("Auth", AuthServiceBlock)
     }
 
     implicit val dbContext: PostgresContext = PostgresContext(DollarNumbers)

--- a/src/main/scala/temple/test/ProjectTester.scala
+++ b/src/main/scala/temple/test/ProjectTester.scala
@@ -46,9 +46,9 @@ object ProjectTester {
     if (serviceAuths.nonEmpty) {
       AuthServiceTest.test(serviceAuths, url)
     }
-    templefile.services.foreach {
+    templefile.providedServices.foreach {
       case (name, block) =>
-        CRUDServiceTest.test(name, block, templefile.services, url)
+        CRUDServiceTest.test(name, block, templefile.providedServices, url)
     }
   }
 

--- a/src/test/scala/temple/builder/ServerBuilderTest.scala
+++ b/src/test/scala/temple/builder/ServerBuilderTest.scala
@@ -15,7 +15,7 @@ class ServerBuilderTest extends FlatSpec with Matchers {
   behavior of "ServerBuilderTest"
 
   it should "build a correct simple ServiceRoot with all endpoints" in {
-    val serviceRoot: ServiceRoot = BuilderTestData.simpleTemplefile.servicesWithPorts.head match {
+    val serviceRoot: ServiceRoot = BuilderTestData.simpleTemplefile.allServicesWithPorts.head match {
       case (name, service, port) =>
         ServerBuilder
           .buildServiceRoot(
@@ -55,7 +55,7 @@ class ServerBuilderTest extends FlatSpec with Matchers {
   }
 
   it should "build a correct simple ServiceRoot with no endpoints" in {
-    val serviceRoot: ServiceRoot = BuilderTestData.simpleTemplefile.servicesWithPorts.head match {
+    val serviceRoot: ServiceRoot = BuilderTestData.simpleTemplefile.allServicesWithPorts.head match {
       case (name, service, port) =>
         ServerBuilder
           .buildServiceRoot(
@@ -89,7 +89,7 @@ class ServerBuilderTest extends FlatSpec with Matchers {
   }
 
   it should "build a correct complex ServiceRoot with all endpoints" in {
-    val serviceRoot: ServiceRoot = BuilderTestData.complexTemplefile.servicesWithPorts.head match {
+    val serviceRoot: ServiceRoot = BuilderTestData.complexTemplefile.allServicesWithPorts.head match {
       case (name, service, port) =>
         ServerBuilder
           .buildServiceRoot(


### PR DESCRIPTION
Adds the GeneratedBlock trait, which abstracts above a ServiceBlock, to allow pattern matching between ServiceBlock and AuthServiceBlock