### PR TITLE
[Validator] Perform renaming of structs/services and attributes (without test update)

### DIFF
--- a/src/main/scala/temple/DSL/semantics/NameClashes.scala
+++ b/src/main/scala/temple/DSL/semantics/NameClashes.scala
@@ -1,0 +1,148 @@
+package temple.DSL.semantics
+
+import temple.utils.StringUtils
+
+import scala.collection.Iterator.iterate
+
+object NameClashes {
+
+  // https://www.postgresql.org/docs/10/sql-keywords-appendix.html
+  // only those marked as "reserved"/"reserved (can be function or type)" in Postgres
+  private val postgresNames = Set(
+    "all",
+    "analyse",
+    "analyze",
+    "and",
+    "any",
+    "array",
+    "as",
+    "asc",
+    "asymmetric",
+    "authorization",
+    "binary",
+    "both",
+    "case",
+    "cast",
+    "check",
+    "collate",
+    "collation",
+    "column",
+    "concurrently",
+    "constraint",
+    "create",
+    "cross",
+    "current_catalog",
+    "current_date",
+    "current_role",
+    "current_schema",
+    "current_time",
+    "current_timestamp",
+    "current_user",
+    "default",
+    "deferrable",
+    "desc",
+    "distinct",
+    "do",
+    "else",
+    "end",
+    "except",
+    "false",
+    "fetch",
+    "for",
+    "foreign",
+    "freeze",
+    "from",
+    "full",
+    "grant",
+    "group",
+    "having",
+    "ilike", // sql, it’s my favourite language
+    "in",
+    "initially",
+    "inner",
+    "intersect",
+    "into",
+    "is",
+    "isnull",
+    "join",
+    "lateral",
+    "leading",
+    "left",
+    "like",
+    "limit",
+    "localtime",
+    "localtimestamp",
+    "natural",
+    "not",
+    "notnull",
+    "null",
+    "offset",
+    "on",
+    "only",
+    "or",
+    "order",
+    "outer",
+    "overlaps",
+    "placing",
+    "primary",
+    "references",
+    "returning",
+    "right",
+    "select",
+    "session_user",
+    "similar",
+    "some",
+    "symmetric",
+    "table",
+    "tablesample",
+    "then",
+    "to",
+    "trailing",
+    "true",
+    "union",
+    "unique",
+    "user",
+    "using",
+    "variadic",
+    "verbose",
+    "when",
+    "where",
+    "window",
+    "with",
+  )
+
+  case class NameValidator private (private[NameClashes] val isValid: (String, Set[String]) => Boolean) {
+
+    def &(other: NameValidator): NameValidator = NameValidator { (str, taken) =>
+      this.isValid(str, taken) && other.isValid(str, taken)
+    }
+
+    def join(others: IterableOnce[NameValidator]): NameValidator = others.iterator.fold(this) { _ & _ }
+  }
+
+  private def iterableValidator(strings: Set[String]): NameValidator = NameValidator { (name, taken) =>
+    !strings.iterator.contains(name) && !taken.contains(name)
+  }
+
+  private def caseInsensitiveIterableValidator(strings: Set[String]): NameValidator = NameValidator { (name, taken) =>
+    val lowerName = name.toLowerCase
+    !strings.iterator.contains(lowerName) && !taken.contains(lowerName)
+  }
+
+  val postgresValidator: NameValidator = caseInsensitiveIterableValidator(postgresNames)
+
+  def nameSuggestions(name: String, project: String, decapitalize: Boolean = false): Iterator[String] =
+    iterate(name.capitalize) { project + _ }.map {
+      if (decapitalize) StringUtils.decapitalize
+      else identity
+    }
+
+  def dodgeNames(name: String, project: String, takenNames: Set[String], decapitalize: Boolean = false)(
+    nameValidator1: NameValidator,
+    nameValidators: NameValidator*,
+  ): String = {
+    val nameValidator = nameValidator1.join(nameValidators)
+    nameSuggestions(name, project, decapitalize).filter { nameValidator.isValid(_, takenNames) }.next
+  }
+
+}

--- a/src/main/scala/temple/DSL/semantics/SemanticContext.scala
+++ b/src/main/scala/temple/DSL/semantics/SemanticContext.scala
@@ -5,8 +5,6 @@ import temple.errors.ErrorHandlingContext
 final case class SemanticContext private (private val chain: List[String]) extends ErrorHandlingContext {
   def :+(string: String): SemanticContext = SemanticContext(string :: chain)
 
-  def apply[T](f: T => SemanticContext => Unit)(name: String, t: T): Unit = f(t)(this :+ name)
-
   override def toString: String = chain.mkString(", in ")
 
   private def location: String = if (chain.nonEmpty) s" in $this" else ""

--- a/src/main/scala/temple/DSL/semantics/ServiceRenamer.scala
+++ b/src/main/scala/temple/DSL/semantics/ServiceRenamer.scala
@@ -1,0 +1,88 @@
+package temple.DSL.semantics
+
+import temple.ast._
+
+case class ServiceRenamer(renaming: Map[String, String]) {
+
+  private def renameTargetBlock(block: TargetBlock): TargetBlock =
+    // currently `identity`, as language is the only metadata
+    TargetBlock(block.metadata.map {
+      case language: Metadata.TargetLanguage => language
+    })
+
+  private def renameProjectBlock(block: ProjectBlock): ProjectBlock =
+    // currently `identity`, as no metadata contains a service name
+    ProjectBlock(
+      block.metadata.map {
+        case language: Metadata.ServiceLanguage => language
+        case provider: Metadata.Provider        => provider
+        case database: Metadata.Database        => database
+        case readable: Metadata.Readable        => readable
+        case writable: Metadata.Writable        => writable
+      },
+    )
+
+  private def renameTargetBlocks(targets: Map[String, TargetBlock]): Map[String, TargetBlock] =
+    targets.view.mapValues(renameTargetBlock).toMap
+
+  private def renameServiceMetadata(metadata: Metadata.ServiceMetadata): Metadata.ServiceMetadata = metadata match {
+    // rename any services referenced in #uses
+    case Metadata.Uses(services) => Metadata.Uses(services.map(renaming))
+    // otherwise just return the other metadata, as it contains no service names
+    case language: Metadata.ServiceLanguage     => language
+    case database: Metadata.Database            => database
+    case readable: Metadata.Readable            => readable
+    case writable: Metadata.Writable            => writable
+    case omit: Metadata.Omit                    => omit
+    case auth: Metadata.ServiceAuth             => auth
+    case enumerable: Metadata.ServiceEnumerable => enumerable
+  }
+
+  def renameStructMetadata(metadata: Metadata.StructMetadata): Metadata.StructMetadata = metadata match {
+    // currently `identity`, as no metadata contains a service name
+    case readable: Metadata.Readable            => readable
+    case writable: Metadata.Writable            => writable
+    case omit: Metadata.Omit                    => omit
+    case enumerable: Metadata.ServiceEnumerable => enumerable
+  }
+
+  private def renameStructBlock(block: StructBlock): StructBlock =
+    StructBlock(renameAttributes(block.attributes), block.metadata.map(renameStructMetadata))
+
+  private def renameStructBlocks(structs: Map[String, StructBlock]): Map[String, StructBlock] = structs.map {
+    case (name, block) => renaming(name) -> renameStructBlock(block)
+  }
+
+  private def renameAttributeType(attributeType: AttributeType): AttributeType = attributeType match {
+    case AttributeType.ForeignKey(references)                => AttributeType.ForeignKey(renaming(references))
+    case attributeType: AttributeType.PrimitiveAttributeType => attributeType
+  }
+
+  private def renameAttribute(attribute: Attribute): Attribute = Attribute(
+    renameAttributeType(attribute.attributeType),
+    attribute.accessAnnotation,
+    attribute.valueAnnotations,
+  )
+
+  private def renameAttributes(attributes: Map[String, Attribute]): Map[String, Attribute] =
+    attributes.view.mapValues(renameAttribute).to(attributes.mapFactory)
+
+  private def renameServiceBlock(block: ServiceBlock): ServiceBlock =
+    ServiceBlock(
+      renameAttributes(block.attributes),
+      block.metadata.map(renameServiceMetadata),
+      renameStructBlocks(block.structs),
+    )
+
+  private def renameServiceBlocks(services: Map[String, ServiceBlock]): Map[String, ServiceBlock] = services.map {
+    case (name, block) => renaming(name) -> renameServiceBlock(block)
+  }
+
+  def apply(templefile: Templefile): Templefile =
+    Templefile(
+      templefile.projectName,
+      renameProjectBlock(templefile.projectBlock),
+      renameTargetBlocks(templefile.targets),
+      renameServiceBlocks(templefile.services),
+    )
+}

--- a/src/main/scala/temple/DSL/semantics/Validator.scala
+++ b/src/main/scala/temple/DSL/semantics/Validator.scala
@@ -16,8 +16,6 @@ private class Validator(templefile: Templefile) {
     case _ -> service => service.structs.keys
   }
 
-  private var newServices = templefile.services
-
   private val allServices: Set[String] = templefile.services.keys.toSet
 
   private val allStructsAndServices: Set[String] = allServices ++ allStructs

--- a/src/main/scala/temple/DSL/semantics/Validator.scala
+++ b/src/main/scala/temple/DSL/semantics/Validator.scala
@@ -16,6 +16,8 @@ private class Validator(templefile: Templefile) {
 
   private val allServices: Set[String] = templefile.services.keys.toSet
 
+  private var newServices: Map[String, ServiceBlock] = templefile.services
+
   private val allStructsAndServices: Set[String] = allServices ++ allStructs
 
   private val globalRenaming      = mutable.Map[String, String]()

--- a/src/main/scala/temple/DSL/semantics/Validator.scala
+++ b/src/main/scala/temple/DSL/semantics/Validator.scala
@@ -4,12 +4,13 @@ import temple.DSL.semantics.NameClashes._
 import temple.ast.AttributeType._
 import temple.ast.{Metadata, _}
 import temple.builder.project.ProjectConfig
+import temple.utils.MonadUtils.FromEither
 
 import scala.collection.mutable
 import scala.reflect.{ClassTag, classTag}
 
 private class Validator private (templefile: Templefile) {
-  var errors: mutable.Buffer[String] = mutable.Buffer()
+  var errors: mutable.Set[String] = mutable.Set()
 
   private val allStructs: Iterable[String] = templefile.services.flatMap {
     case _ -> service => service.structs.keys
@@ -18,8 +19,10 @@ private class Validator private (templefile: Templefile) {
   private val allServices: Set[String]           = templefile.services.keys.toSet
   private val allStructsAndServices: Set[String] = allServices ++ allStructs
 
+  // The services, updated with renamed attributes
   private var newServices: Map[String, ServiceBlock] = templefile.services
 
+  // A mapping from every service/struct name in the input Templefile to its new name
   private val globalRenaming      = mutable.Map[String, String]()
   def allGlobalNames: Set[String] = globalRenaming.valuesIterator.toSet ++ allStructsAndServices
 
@@ -29,9 +32,11 @@ private class Validator private (templefile: Templefile) {
   ): Map[String, Attribute] = {
     attributes.foreach { case (name, t) => validateAttribute(t, context :+ name) }
 
-    // This looks like a map, but it isn’t because the accumulator `newAttributes`’ names are accessed during iteration
-    attributes.foldLeft(attributes.mapFactory[String, Attribute]()) {
-      case (newAttributes, (attributeName, value)) =>
+    // Keep a set of names that have been used already
+    val takenNames: mutable.Set[String] = mutable.Set(attributes.keys)
+
+    attributes.map {
+      case (attributeName, value) =>
         if (attributeName.headOption.exists(!_.isLower))
           errors += context.errorMessage(
             s"Invalid attribute name $attributeName, it must start with a lowercase letter,",
@@ -39,13 +44,21 @@ private class Validator private (templefile: Templefile) {
         val newName = constructUniqueName(
           attributeName,
           templefile.projectName,
-          (newAttributes.keys ++ attributes.keys).toSet - attributeName,
+          // takenNames includes this attribute’s names, so remove it
+          takenNames.toSet - attributeName,
           decapitalize = true,
         )(postgresValidator)
-        newAttributes + (newName -> value)
+
+        // Prevent this new name from being used by other attributes
+        takenNames += newName
+
+        newName -> value
     }
   }
 
+  /** Given a service block or a struct block, find a valid name for it (taking into account the clashes from all the
+    * languages that are generated from the block), and entering it into the map of renamings. Note that an entry is
+    * always inserted into this block, even if the same name is kept. */
   private def renameBlock(name: String, block: TempleBlock[_]): Unit = {
     val database = block.lookupMetadata[Metadata.Database].getOrElse(ProjectConfig.defaultDatabase)
     if (database == Metadata.Database.Postgres) {
@@ -182,26 +195,37 @@ private class Validator private (templefile: Templefile) {
     errors.toSeq
   }
 
+  /** Perform the renaming at the struct level, using the renamed services */
   def transformed: Templefile = ServiceRenamer(globalRenaming.toMap)(templefile.copy(services = newServices))
 }
 
 object Validator {
 
+  /** Take a Templefile and get a set of errors with it */
   def validationErrors(templefile: Templefile): Set[String] = {
     val validator = new Validator(templefile)
     validator.validate()
     validator.errors.toSet
   }
 
-  def validate(templefile: Templefile): Templefile = {
+  /** Take a Templefile and find any errors with it, or return a version valid for use in all the languages it will be
+    * deployed to */
+  def validateEither(templefile: Templefile): Either[Set[String], Templefile] = {
     val validator   = new Validator(templefile)
     val parseErrors = validator.validate()
-    if (parseErrors.nonEmpty) {
+    if (parseErrors.nonEmpty) Left(parseErrors.toSet)
+    else Right(validator.transformed)
+  }
+
+  /** Take a Templefile and convert it to a version valid for use in all the languages it will be deployed to
+    *
+    * @throws SemanticParsingException a non-empty set of strings representing parse errors
+    */
+  def validate(templefile: Templefile): Templefile =
+    validateEither(templefile) fromEither { parseErrors =>
       val errorsWere = if (parseErrors.sizeIs == 1) "An error was" else s"${parseErrors.size} errors were"
       throw new SemanticParsingException(
         s"$errorsWere encountered while validating the Templefile\n${parseErrors.mkString("\n")}",
       )
     }
-    validator.transformed
-  }
 }

--- a/src/main/scala/temple/DSL/semantics/Validator.scala
+++ b/src/main/scala/temple/DSL/semantics/Validator.scala
@@ -38,7 +38,7 @@ private class Validator(templefile: Templefile) {
           errors += context.errorMessage(
             s"Invalid attribute name $attributeName, it must start with a lowercase letter,",
           )
-        val newName = dodgeNames(
+        val newName = constructUniqueName(
           attributeName,
           templefile.projectName,
           (newAttributes.keys ++ attributes.keys).toSet - attributeName,
@@ -51,7 +51,7 @@ private class Validator(templefile: Templefile) {
   private def renameBlock(name: String, block: TempleBlock[_]): Unit = {
     val database = block.lookupMetadata[Metadata.Database].getOrElse(ProjectConfig.defaultDatabase)
     if (database == Metadata.Database.Postgres) {
-      val newServiceName = dodgeNames(name, templefile.projectName, allGlobalNames - name)(postgresValidator)
+      val newServiceName = constructUniqueName(name, templefile.projectName, allGlobalNames - name)(postgresValidator)
       globalRenaming += name -> newServiceName
     }
   }

--- a/src/main/scala/temple/DSL/semantics/Validator.scala
+++ b/src/main/scala/temple/DSL/semantics/Validator.scala
@@ -16,9 +16,9 @@ private class Validator(templefile: Templefile) {
 
   private val allServices: Set[String] = templefile.services.keys.toSet
 
-  private var newServices: Map[String, ServiceBlock] = templefile.services
-
   private val allStructsAndServices: Set[String] = allServices ++ allStructs
+
+  private var newServices: Map[String, ServiceBlock] = templefile.services
 
   private val globalRenaming      = mutable.Map[String, String]()
   def allGlobalNames: Set[String] = globalRenaming.valuesIterator.toSet ++ allStructsAndServices


### PR DESCRIPTION
Splitting up #235 by removing all the updates to tests. Everything still passes, it just doesn’t demonstrate any of the pwer of this PR. Check out #235 to see the full gory detail of what happens when you apply it to tests, but basically if any naming conflict is found, it is then resolved by prefixing the name with the project name (repeatedly until no more conflicts).

- `NameClashes`, a new object to handle names reserved by Postgres. This is composable so any lists of names can be used to determine conflicts. **100** lines of this are just a list of Postgres reserved keywords
- `SemanticContext`, removing that this was a function (see `Validator`).
- `ServiceRenamer`, a new class for performing renaming (of services/structs) on a Templefile. It is constructed with a map from old names to new, and then serves as a function from Templefile to Templefile. A lot of this file is exhaustive matches, even when they are just the identity function. This is so that any newly added metadata types etc. will throw MatchErrors here instead of silently allowing unrenamed items through, which would become a real pain to debug.
- `Validator`: The validator now also performs renaming on the Templefile’s fields and attributes (Suggestions of what to rename this class (and its methods) to are welcome!).
  It seemed a bit strange to me that `context` was a function, so now an explicit `foreachValueWithContext` etc is used, serving basically the same purpose but a little more explicitly.

Re codecov, every new untested line is tested in the e2e tests

Spurious branch naming as I cherry-picked my way to two non-XXL PRs.