### PR TITLE
[go-gen] Replace createdByAttribute with optional

### DIFF
--- a/src/it/scala/temple/generate/server/GoGeneratorIntegrationTestData.scala
+++ b/src/it/scala/temple/generate/server/GoGeneratorIntegrationTestData.scala
@@ -10,45 +10,45 @@ import scala.collection.immutable.ListMap
 object GoGeneratorIntegrationTestData {
 
   val simpleServiceRoot: ServiceRoot = ServiceRoot(
-    "User",
-    "github.com/TempleEight/spec-golang/user",
-    Seq.empty,
-    ListMap(
+    name = "User",
+    module = "github.com/TempleEight/spec-golang/user",
+    comms = Seq.empty,
+    opQueries = ListMap(
       CRUD.Create -> "INSERT INTO user_temple (id, name) VALUES ($1, $2) RETURNING id, name",
       CRUD.Read   -> "SELECT id, name FROM user_temple WHERE id = $1",
       CRUD.Update -> "UPDATE user_temple SET name = $1 WHERE id = $2 RETURNING id, name",
       CRUD.Delete -> "DELETE FROM user_temple WHERE id = $1",
     ),
-    80,
-    IDAttribute("id"),
-    CreatedByAttribute.None,
-    ListMap("name" -> Attribute(AttributeType.StringType())),
-    Postgres,
-    Readable.All,
-    Writable.This,
+    port = 80,
+    idAttribute = IDAttribute("id"),
+    createdByAttribute = None,
+    attributes = ListMap("name" -> Attribute(AttributeType.StringType(Option(255L), Option(2)))),
+    datastore = Postgres,
+    readable = Readable.All,
+    writable = Writable.This,
   )
 
   val simpleServiceRootWithComms: ServiceRoot = ServiceRoot(
-    "Match",
-    "github.com/TempleEight/spec-golang/match",
-    Seq("user"),
-    ListMap(
+    name = "Match",
+    module = "github.com/TempleEight/spec-golang/match",
+    comms = Seq("user"),
+    opQueries = ListMap(
       CRUD.List   -> "SELECT id, created_by, userOne, userTwo, matchedOn FROM match WHERE created_by = $1",
       CRUD.Create -> "INSERT INTO match (id, created_by, userOne, userTwo, matchedOn) VALUES ($1, $2, $3, $4, NOW()) RETURNING id, created_by, userOne, userTwo, matchedOn",
       CRUD.Read   -> "SELECT id, created_by, userOne, userTwo, matchedOn FROM match WHERE id = $1",
       CRUD.Update -> "UPDATE match SET userOne = $1, userTwo = $2, matchedOn = NOW() WHERE id = $3 RETURNING id, created_by, userOne, userTwo, matchedOn",
       CRUD.Delete -> "DELETE FROM match WHERE id = $1",
     ),
-    81,
-    IDAttribute("id"),
-    CreatedByAttribute.EnumerateByCreator("authID", "createdBy"),
-    ListMap(
+    port = 81,
+    idAttribute = IDAttribute("id"),
+    createdByAttribute = Some(CreatedByAttribute("authID", "createdBy", filterEnumeration = true)),
+    attributes = ListMap(
       "userOne"   -> Attribute(AttributeType.ForeignKey("User")),
       "userTwo"   -> Attribute(AttributeType.ForeignKey("User")),
       "matchedOn" -> Attribute(AttributeType.DateTimeType, Some(Annotation.ServerSet)),
     ),
-    Postgres,
-    Readable.This,
-    Writable.This,
+    datastore = Postgres,
+    readable = Readable.This,
+    writable = Writable.This,
   )
 }

--- a/src/main/scala/temple/builder/DatabaseBuilder.scala
+++ b/src/main/scala/temple/builder/DatabaseBuilder.scala
@@ -53,7 +53,7 @@ object DatabaseBuilder {
     serviceName: String,
     attributes: Map[String, Attribute],
     endpoints: Set[CRUD],
-    createdByAttribute: CreatedByAttribute,
+    createdByAttribute: Option[CreatedByAttribute],
     selectionAttribute: String = "id",
   ): ListMap[CRUD, Statement] = {
     val tableName = StringUtils.snakeCase(serviceName)
@@ -86,7 +86,7 @@ object DatabaseBuilder {
           )
         case List =>
           createdByAttribute match {
-            case CreatedByAttribute.EnumerateByCreator(_, _) =>
+            case Some(CreatedByAttribute(_, _, true)) =>
               List -> Statement.Read(
                 tableName,
                 columns = columns,

--- a/src/main/scala/temple/builder/ServerBuilder.scala
+++ b/src/main/scala/temple/builder/ServerBuilder.scala
@@ -30,25 +30,13 @@ object ServerBuilder {
       case ServiceLanguage.Go => GoLanguageConfig
     }
 
-    // TODO: This could be nicer
-    val createdBy: Option[CreatedByAttribute] = serviceBlock.lookupMetadata[ServiceEnumerable] match {
-      case Some(ServiceEnumerable(true)) =>
-        Some(
-          CreatedByAttribute(
-            languageConfig.createdByInputName,
-            languageConfig.createdByName,
-            filterEnumeration = true,
-          ),
+    val createdBy: Option[CreatedByAttribute] = serviceBlock.lookupMetadata[ServiceEnumerable].map {
+      case ServiceEnumerable(byThis) =>
+        CreatedByAttribute(
+          languageConfig.createdByInputName,
+          languageConfig.createdByName,
+          filterEnumeration = byThis,
         )
-      case Some(ServiceEnumerable(false)) =>
-        Some(
-          CreatedByAttribute(
-            languageConfig.createdByInputName,
-            languageConfig.createdByName,
-            filterEnumeration = false,
-          ),
-        )
-      case None => None
     }
 
     val idAttribute = IDAttribute("id")

--- a/src/main/scala/temple/builder/ServerBuilder.scala
+++ b/src/main/scala/temple/builder/ServerBuilder.scala
@@ -30,18 +30,25 @@ object ServerBuilder {
       case ServiceLanguage.Go => GoLanguageConfig
     }
 
-    val createdBy: CreatedByAttribute = serviceBlock.lookupMetadata[ServiceEnumerable] match {
+    // TODO: This could be nicer
+    val createdBy: Option[CreatedByAttribute] = serviceBlock.lookupMetadata[ServiceEnumerable] match {
       case Some(ServiceEnumerable(true)) =>
-        CreatedByAttribute.EnumerateByCreator(
-          languageConfig.createdByInputName,
-          languageConfig.createdByName,
+        Some(
+          CreatedByAttribute(
+            languageConfig.createdByInputName,
+            languageConfig.createdByName,
+            filterEnumeration = true,
+          ),
         )
       case Some(ServiceEnumerable(false)) =>
-        CreatedByAttribute.EnumerateByAll(
-          languageConfig.createdByInputName,
-          languageConfig.createdByName,
+        Some(
+          CreatedByAttribute(
+            languageConfig.createdByInputName,
+            languageConfig.createdByName,
+            filterEnumeration = false,
+          ),
         )
-      case None => CreatedByAttribute.None
+      case None => None
     }
 
     val idAttribute = IDAttribute("id")
@@ -113,7 +120,7 @@ object ServerBuilder {
               "auth",
               attributes,
               Set(Create, Read),
-              CreatedByAttribute.None,
+              None,
               selectionAttribute = "email",
             )
           val createQuery = PostgresGenerator.generate(queries(Create))

--- a/src/main/scala/temple/generate/server/CreatedByAttribute.scala
+++ b/src/main/scala/temple/generate/server/CreatedByAttribute.scala
@@ -1,36 +1,11 @@
 package temple.generate.server
 
-import temple.ast.AttributeType
-
-sealed trait CreatedByAttribute
-
-object CreatedByAttribute {
-
-  /**
-    * None encapsulates the case where no Temple defined createdBy field exists, e.g. in the case of an Auth block
-    */
-  case object None extends CreatedByAttribute
-
-  sealed trait Enumerating extends CreatedByAttribute {
-    def inputName: String
-    def name: String
-  }
-
-  /**
-    * EnumerateByThis encapsulates the case where a Temple defined createdBy field exists and is used to enumerate the
-    * List operation
-    *
-    * @param inputName the name of the variable used as input, e.g. "authID", present for improving semantics of code
-    * @param name the name of attribute, e.g. "createdBy"
-    */
-  case class EnumerateByCreator(inputName: String, name: String) extends Enumerating
-
-  /**
-    * EnumerateByAll encapsulates the case where a Temple defined createdBy field exists, but is not used to enumerate
-    * the List operation
-    *
-    * @param inputName the name of the variable used as input, e.g. "authID", present for improving semantics of code
-    * @param name the name of attribute, e.g. "createdBy"
-    */
-  case class EnumerateByAll(inputName: String, name: String) extends Enumerating
-}
+/**
+  * CreatedByAttribute encapsulates the temple defined attribute used to track which authenticated ID created a resource
+  *
+  * @param inputName the name of the variable used as input, e.g. "authID", present for improving semantics of generated
+  *                  code
+  * @param name the name of the attribute, e.g. "createdBy"
+  * @param filterEnumeration whether or not this attribute is used to filter the list operation
+  */
+case class CreatedByAttribute(inputName: String, name: String, filterEnumeration: Boolean)

--- a/src/main/scala/temple/generate/server/ServiceRoot.scala
+++ b/src/main/scala/temple/generate/server/ServiceRoot.scala
@@ -17,10 +17,11 @@ import scala.collection.immutable.ListMap
   * @param opQueries a map of CRUD operations to their corresponding datastore query
   * @param port the port number this service will be served on
   * @param idAttribute the name of the ID field
-  * @param createdByAttribute the input name, name and type of the createdBy field in this service, and whether it is
-  * used to enumerate the service in the List endpoint. Also indicates whether this service has an auth block.
+  * @param createdByAttribute whether or not this service has a createdBy attribute. Also indicates whether this service has an auth block.
   * @param attributes the user-defined fields of the resource handled by this service
   * @param datastore the datastore being used
+  * @param readable whether this service is readable by this or by all
+  * @param writable whether this service is writable by this or by all
   */
 case class ServiceRoot(
   override val name: String,
@@ -29,7 +30,7 @@ case class ServiceRoot(
   opQueries: ListMap[CRUD, String],
   port: Int,
   idAttribute: IDAttribute,
-  createdByAttribute: CreatedByAttribute,
+  createdByAttribute: Option[CreatedByAttribute],
   attributes: ListMap[String, Attribute],
   datastore: Database,
   readable: Readable,

--- a/src/main/scala/temple/generate/server/go/service/GoServiceGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/GoServiceGenerator.scala
@@ -40,8 +40,14 @@ object GoServiceGenerator extends ServiceGenerator {
 
     // Whether or not this service has an auth block
     val hasAuthBlock = root.createdByAttribute match {
-      case CreatedByAttribute.None                                                         => true
-      case _: CreatedByAttribute.EnumerateByCreator | _: CreatedByAttribute.EnumerateByAll => false
+      case None                        => true
+      case Some(_: CreatedByAttribute) => false
+    }
+
+    // Whether or not this service is enumerating by creator
+    val enumeratingByCreator = root.createdByAttribute match {
+      case Some(CreatedByAttribute(_, _, true)) => true
+      case _                                    => false
     }
 
     (Map(
@@ -57,7 +63,8 @@ object GoServiceGenerator extends ServiceGenerator {
         GoServiceMainGenerator.generateRouter(root, operations),
         GoCommonMainGenerator.generateMain(root, root.port, usesComms, isAuth = false),
         GoCommonMainGenerator.generateJsonMiddleware(),
-        GoServiceMainHandlersGenerator.generateHandlers(root, operations, clientAttributes, usesComms, hasAuthBlock),
+        GoServiceMainHandlersGenerator
+          .generateHandlers(root, operations, clientAttributes, usesComms, hasAuthBlock, enumeratingByCreator),
       ),
       File(root.kebabName, "hook.go") -> mkCode.doubleLines(
         GoCommonGenerator.generatePackage("main"),
@@ -71,13 +78,13 @@ object GoServiceGenerator extends ServiceGenerator {
       File(s"${root.kebabName}/dao", "dao.go") -> mkCode.doubleLines(
         GoCommonGenerator.generatePackage("dao"),
         GoServiceDAOGenerator.generateImports(root, usesTime),
-        GoServiceDAOInterfaceGenerator.generateInterface(root, operations),
+        GoServiceDAOInterfaceGenerator.generateInterface(root, operations, enumeratingByCreator),
         GoCommonDAOGenerator.generateDAOStruct(),
         GoServiceDAOGenerator.generateDatastoreObjectStruct(root),
-        GoServiceDAOInputStructsGenerator.generateStructs(root, operations),
+        GoServiceDAOInputStructsGenerator.generateStructs(root, operations, enumeratingByCreator),
         GoCommonDAOGenerator.generateInit(),
         GoServiceDAOGenerator.generateQueryFunctions(operations),
-        GoServiceDAOFunctionsGenerator.generateDAOFunctions(root),
+        GoServiceDAOFunctionsGenerator.generateDAOFunctions(root, enumeratingByCreator),
       ),
       File(s"${root.kebabName}/util", "util.go") -> mkCode.doubleLines(
         GoCommonGenerator.generatePackage("util"),

--- a/src/main/scala/temple/generate/server/go/service/GoServiceGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/GoServiceGenerator.scala
@@ -39,10 +39,7 @@ object GoServiceGenerator extends ServiceGenerator {
     }
 
     // Whether or not this service has an auth block
-    val hasAuthBlock = root.createdByAttribute match {
-      case None                        => true
-      case Some(_: CreatedByAttribute) => false
-    }
+    val hasAuthBlock = root.createdByAttribute.isEmpty
 
     // Whether or not this service is enumerating by creator
     val enumeratingByCreator = root.createdByAttribute match {

--- a/src/main/scala/temple/generate/server/go/service/dao/GoServiceDAOGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/dao/GoServiceDAOGenerator.scala
@@ -35,11 +35,8 @@ object GoServiceDAOGenerator {
 
   private[service] def generateDatastoreObjectStruct(root: ServiceRoot): String = {
     val idMap = ListMap(root.idAttribute.name.toUpperCase -> generateGoType(AttributeType.UUIDType))
-    val createdByMap = root.createdByAttribute match {
-      case None =>
-        ListMap.empty
-      case Some(enumerating: CreatedByAttribute) =>
-        ListMap(enumerating.name.capitalize -> generateGoType(AttributeType.UUIDType))
+    val createdByMap = root.createdByAttribute.fold(ListMap[String, String]()) { enumerating =>
+      ListMap(enumerating.name.capitalize -> generateGoType(AttributeType.UUIDType))
     }
     val attributesMap = root.attributes.map {
       case (name, attribute) => name.capitalize -> generateGoType(attribute.attributeType)

--- a/src/main/scala/temple/generate/server/go/service/dao/GoServiceDAOGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/dao/GoServiceDAOGenerator.scala
@@ -36,9 +36,9 @@ object GoServiceDAOGenerator {
   private[service] def generateDatastoreObjectStruct(root: ServiceRoot): String = {
     val idMap = ListMap(root.idAttribute.name.toUpperCase -> generateGoType(AttributeType.UUIDType))
     val createdByMap = root.createdByAttribute match {
-      case CreatedByAttribute.None =>
+      case None =>
         ListMap.empty
-      case enumerating: CreatedByAttribute.Enumerating =>
+      case Some(enumerating: CreatedByAttribute) =>
         ListMap(enumerating.name.capitalize -> generateGoType(AttributeType.UUIDType))
     }
     val attributesMap = root.attributes.map {

--- a/src/main/scala/temple/generate/server/go/service/dao/GoServiceDAOInputStructsGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/dao/GoServiceDAOInputStructsGenerator.scala
@@ -28,9 +28,9 @@ object GoServiceDAOInputStructsGenerator {
 
     // Note we use the createdBy input name, rather than name
     lazy val createdByMap = root.createdByAttribute match {
-      case CreatedByAttribute.None =>
+      case None =>
         ListMap.empty
-      case enumerating: CreatedByAttribute.Enumerating =>
+      case Some(enumerating: CreatedByAttribute) =>
         ListMap(enumerating.inputName.capitalize -> generateGoType(AttributeType.UUIDType))
     }
 
@@ -60,15 +60,14 @@ object GoServiceDAOInputStructsGenerator {
     )
   }
 
-  private[service] def generateStructs(root: ServiceRoot, operations: Set[CRUD]): String = {
-    val enumeratingByCreator = root.createdByAttribute match {
-      case _: CreatedByAttribute.EnumerateByCreator => true
-      case _                                        => false
-    }
+  private[service] def generateStructs(
+    root: ServiceRoot,
+    operations: Set[CRUD],
+    enumeratingByCreator: Boolean,
+  ): String =
     mkCode.doubleLines(
       // Generate input struct for each operation, except for List when not enumerating by creator
       for (operation <- operations.toSeq.sorted if operation != CRUD.List || enumeratingByCreator)
         yield generateStruct(root, operation),
     )
-  }
 }

--- a/src/main/scala/temple/generate/server/go/service/dao/GoServiceDAOInputStructsGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/dao/GoServiceDAOInputStructsGenerator.scala
@@ -27,11 +27,8 @@ object GoServiceDAOInputStructsGenerator {
     lazy val idMap = ListMap(root.idAttribute.name.toUpperCase -> generateGoType(AttributeType.UUIDType))
 
     // Note we use the createdBy input name, rather than name
-    lazy val createdByMap = root.createdByAttribute match {
-      case None =>
-        ListMap.empty
-      case Some(enumerating: CreatedByAttribute) =>
-        ListMap(enumerating.inputName.capitalize -> generateGoType(AttributeType.UUIDType))
+    lazy val createdByMap = root.createdByAttribute.fold(ListMap[String, String]()) { enumerating =>
+      ListMap(enumerating.inputName.capitalize -> generateGoType(AttributeType.UUIDType))
     }
 
     // Omit attribute from input struct fields if server set

--- a/src/main/scala/temple/generate/server/go/service/dao/GoServiceDAOInterfaceGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/dao/GoServiceDAOInterfaceGenerator.scala
@@ -15,12 +15,12 @@ object GoServiceDAOInterfaceGenerator {
       case Delete                 => "error"
     }
 
-  private[dao] def generateInterfaceFunction(root: ServiceRoot, operation: CRUD): String = {
+  private[dao] def generateInterfaceFunction(
+    root: ServiceRoot,
+    operation: CRUD,
+    enumeratingByCreator: Boolean,
+  ): String = {
     val functionName = generateDAOFunctionName(root, operation)
-    val enumeratingByCreator = root.createdByAttribute match {
-      case _: CreatedByAttribute.EnumerateByCreator => true
-      case _                                        => false
-    }
     val functionArgs = if (enumeratingByCreator || operation != CRUD.List) s"input ${functionName}Input" else ""
     mkCode(
       s"$functionName($functionArgs)",
@@ -28,14 +28,18 @@ object GoServiceDAOInterfaceGenerator {
     )
   }
 
-  private[service] def generateInterface(root: ServiceRoot, operations: Set[CRUD]): String =
+  private[service] def generateInterface(
+    root: ServiceRoot,
+    operations: Set[CRUD],
+    enumeratingByCreator: Boolean,
+  ): String =
     mkCode.lines(
       "// Datastore provides the interface adopted by the DAO, allowing for mocking",
       mkCode(
         "type Datastore interface",
         CodeWrap.curly.tabbed(
           for (operation <- operations.toSeq.sorted)
-            yield generateInterfaceFunction(root, operation),
+            yield generateInterfaceFunction(root, operation, enumeratingByCreator),
         ),
       ),
     )

--- a/src/main/scala/temple/generate/server/go/service/main/GoServiceMainHandlersGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/main/GoServiceMainHandlersGenerator.scala
@@ -155,11 +155,12 @@ object GoServiceMainHandlersGenerator {
     clientAttributes: ListMap[String, Attribute],
     usesComms: Boolean,
     hasAuthBlock: Boolean,
+    enumeratingByCreator: Boolean,
   ): String = {
     val responseMap = generateResponseMap(root)
     mkCode.doubleLines(
       operations.toSeq.sorted.map {
-        case List   => generateListHandler(root, responseMap)
+        case List   => generateListHandler(root, responseMap, enumeratingByCreator)
         case Create => generateCreateHandler(root, clientAttributes, usesComms, hasAuthBlock, responseMap)
         case Read   => generateReadHandler(root)
         case Update => generateUpdateHandler(root)

--- a/src/main/scala/temple/generate/server/go/service/main/GoServiceMainListHandlerGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/main/GoServiceMainListHandlerGenerator.scala
@@ -13,21 +13,18 @@ import scala.collection.immutable.ListMap
 object GoServiceMainListHandlerGenerator {
 
   /** Generate the list handler function */
-  private[main] def generateListHandler(root: ServiceRoot, responseMap: ListMap[String, String]): String = {
-    // Whether enumerating by created_by field or not
-    val byCreator = root.createdByAttribute match {
-      case CreatedByAttribute.None                  => false
-      case _: CreatedByAttribute.EnumerateByCreator => true
-      case _: CreatedByAttribute.EnumerateByAll     => false
-    }
-
+  private[main] def generateListHandler(
+    root: ServiceRoot,
+    responseMap: ListMap[String, String],
+    enumeratingByCreator: Boolean,
+  ): String = {
     // Fetch list from DAO
     val queryDAOBlock =
       genDeclareAndAssign(
         genMethodCall(
           "env.dao",
           s"List${root.name}",
-          when(byCreator) {
+          when(enumeratingByCreator) {
             genPopulateStruct(
               s"dao.List${root.name}Input",
               ListMap(s"AuthID" -> "auth.ID"),
@@ -78,7 +75,7 @@ object GoServiceMainListHandlerGenerator {
       generateHandlerDecl(root, List),
       CodeWrap.curly.tabbed(
         mkCode.doubleLines(
-          when(byCreator) { generateExtractAuthBlock() },
+          when(enumeratingByCreator) { generateExtractAuthBlock() },
           mkCode.lines(
             queryDAOBlock,
             queryDAOErrorBlock,

--- a/src/test/scala/temple/builder/DatabaseBuilderTest.scala
+++ b/src/test/scala/temple/builder/DatabaseBuilderTest.scala
@@ -23,7 +23,7 @@ class DatabaseBuilderTest extends FlatSpec with Matchers {
       "test_service",
       BuilderTestData.sampleService.attributes,
       Set(CRUD.Create),
-      CreatedByAttribute.None,
+      createdByAttribute = None,
     )
     queries.keys should contain(CRUD.Create)
     queries(CRUD.Create) shouldBe DatabaseBuilderTestData.sampleInsertStatement
@@ -34,7 +34,7 @@ class DatabaseBuilderTest extends FlatSpec with Matchers {
       "test_service",
       BuilderTestData.sampleService.attributes,
       Set(CRUD.Read),
-      CreatedByAttribute.None,
+      createdByAttribute = None,
     )
     queries.keys should contain(CRUD.Read)
     queries(CRUD.Read) shouldBe DatabaseBuilderTestData.sampleReadStatement
@@ -45,7 +45,7 @@ class DatabaseBuilderTest extends FlatSpec with Matchers {
       "test_service",
       BuilderTestData.sampleService.attributes,
       Set(CRUD.Update),
-      CreatedByAttribute.None,
+      createdByAttribute = None,
     )
     queries.keys should contain(CRUD.Update)
     queries(CRUD.Update) shouldBe DatabaseBuilderTestData.sampleUpdateStatement
@@ -56,7 +56,7 @@ class DatabaseBuilderTest extends FlatSpec with Matchers {
       "test_service",
       BuilderTestData.sampleService.attributes,
       Set(CRUD.Delete),
-      CreatedByAttribute.None,
+      createdByAttribute = None,
     )
     queries.keys should contain(CRUD.Delete)
     queries(CRUD.Delete) shouldBe DatabaseBuilderTestData.sampleDeleteStatement
@@ -67,7 +67,7 @@ class DatabaseBuilderTest extends FlatSpec with Matchers {
       "test_service",
       BuilderTestData.sampleService.attributes,
       Set(CRUD.List),
-      CreatedByAttribute.None,
+      createdByAttribute = None,
     )
     queries.keys should contain(CRUD.List)
     queries(CRUD.List) shouldBe DatabaseBuilderTestData.sampleListStatementEnumerateByAll
@@ -78,7 +78,7 @@ class DatabaseBuilderTest extends FlatSpec with Matchers {
       "test_service",
       BuilderTestData.sampleService.attributes,
       Set(CRUD.List),
-      CreatedByAttribute.EnumerateByAll("created_by", "created_by"),
+      Some(CreatedByAttribute("created_by", "created_by", filterEnumeration = false)),
     )
     queries.keys should contain(CRUD.List)
     queries(CRUD.List) shouldBe DatabaseBuilderTestData.sampleListStatementEnumerateByAll
@@ -89,7 +89,7 @@ class DatabaseBuilderTest extends FlatSpec with Matchers {
       "test_service",
       BuilderTestData.sampleService.attributes,
       Set(CRUD.List),
-      CreatedByAttribute.EnumerateByCreator("created_by", "created_by"),
+      Some(CreatedByAttribute("created_by", "created_by", filterEnumeration = true)),
     )
     queries.keys should contain(CRUD.List)
     queries(CRUD.List) shouldBe DatabaseBuilderTestData.sampleListStatementEnumerateByCreator

--- a/src/test/scala/temple/builder/ServerBuilderTest.scala
+++ b/src/test/scala/temple/builder/ServerBuilderTest.scala
@@ -40,7 +40,7 @@ class ServerBuilderTest extends FlatSpec with Matchers {
         List   -> "SELECT id, bankBalance, name, isStudent, dateOfBirth, timeOfDay, expiry, image FROM test_service;",
       ),
       idAttribute = IDAttribute("id"),
-      createdByAttribute = CreatedByAttribute.None,
+      createdByAttribute = None,
       attributes = ListMap(
         "id"          -> Attribute(IntType()),
         "bankBalance" -> Attribute(FloatType()),
@@ -77,7 +77,7 @@ class ServerBuilderTest extends FlatSpec with Matchers {
       port = 1025,
       opQueries = ListMap(),
       idAttribute = IDAttribute("id"),
-      createdByAttribute = CreatedByAttribute.None,
+      createdByAttribute = None,
       attributes = ListMap(
         "id"          -> Attribute(IntType()),
         "bankBalance" -> Attribute(FloatType()),
@@ -120,7 +120,7 @@ class ServerBuilderTest extends FlatSpec with Matchers {
         List   -> "SELECT id, anotherId, yetAnotherId, bankBalance, bigBankBalance, name, initials, isStudent, dateOfBirth, timeOfDay, expiry, image FROM test_complex_service;",
       ),
       idAttribute = IDAttribute("id"),
-      createdByAttribute = CreatedByAttribute.None,
+      createdByAttribute = None,
       attributes = ListMap(
         "id"             -> Attribute(IntType(max = Some(100), min = Some(10), precision = 2)),
         "anotherId"      -> Attribute(IntType(max = Some(100), min = Some(10))),

--- a/src/test/scala/temple/generate/server/go/GoServiceGeneratorTestData.scala
+++ b/src/test/scala/temple/generate/server/go/GoServiceGeneratorTestData.scala
@@ -13,22 +13,22 @@ import scala.collection.immutable.ListMap
 object GoServiceGeneratorTestData {
 
   val simpleServiceRoot: ServiceRoot = ServiceRoot(
-    "User",
-    "github.com/TempleEight/spec-golang/user",
-    Seq.empty,
-    ListMap(
+    name = "User",
+    module = "github.com/TempleEight/spec-golang/user",
+    comms = Seq.empty,
+    opQueries = ListMap(
       CRUD.Create -> "INSERT INTO user_temple (id, name) VALUES ($1, $2) RETURNING id, name",
       CRUD.Read   -> "SELECT id, name FROM user_temple WHERE id = $1",
       CRUD.Update -> "UPDATE user_temple SET name = $1 WHERE id = $2 RETURNING id, name",
       CRUD.Delete -> "DELETE FROM user_temple WHERE id = $1",
     ),
-    80,
-    IDAttribute("id"),
-    CreatedByAttribute.None,
-    ListMap("name" -> Attribute(AttributeType.StringType(Option(255L), Option(2)))),
-    Postgres,
-    Readable.All,
-    Writable.This,
+    port = 80,
+    idAttribute = IDAttribute("id"),
+    createdByAttribute = None,
+    attributes = ListMap("name" -> Attribute(AttributeType.StringType(Option(255L), Option(2)))),
+    datastore = Postgres,
+    readable = Readable.All,
+    writable = Writable.This,
   )
 
   val simpleServiceFiles: Files = Map(
@@ -53,27 +53,27 @@ object GoServiceGeneratorTestData {
 
   val simpleServiceRootWithComms: ServiceRoot =
     ServiceRoot(
-      "Match",
-      "github.com/TempleEight/spec-golang/match",
-      Seq("user"),
-      ListMap(
+      name = "Match",
+      module = "github.com/TempleEight/spec-golang/match",
+      comms = Seq("user"),
+      opQueries = ListMap(
         CRUD.List   -> "SELECT id, created_by, userOne, userTwo, matchedOn FROM match WHERE created_by = $1",
         CRUD.Create -> "INSERT INTO match (id, created_by, userOne, userTwo, matchedOn) VALUES ($1, $2, $3, $4, NOW()) RETURNING id, created_by, userOne, userTwo, matchedOn",
         CRUD.Read   -> "SELECT id, created_by, userOne, userTwo, matchedOn FROM match WHERE id = $1",
         CRUD.Update -> "UPDATE match SET userOne = $1, userTwo = $2, matchedOn = NOW() WHERE id = $3 RETURNING id, created_by, userOne, userTwo, matchedOn",
         CRUD.Delete -> "DELETE FROM match WHERE id = $1",
       ),
-      81,
-      IDAttribute("id"),
-      CreatedByAttribute.EnumerateByCreator("authID", "createdBy"),
-      ListMap(
+      port = 81,
+      idAttribute = IDAttribute("id"),
+      createdByAttribute = Some(CreatedByAttribute("authID", "createdBy", filterEnumeration = true)),
+      attributes = ListMap(
         "userOne"   -> Attribute(AttributeType.ForeignKey("User")),
         "userTwo"   -> Attribute(AttributeType.ForeignKey("User")),
         "matchedOn" -> Attribute(AttributeType.DateTimeType, Some(Annotation.ServerSet)),
       ),
-      Postgres,
-      Readable.This,
-      Writable.This,
+      datastore = Postgres,
+      readable = Readable.This,
+      writable = Writable.This,
     )
 
   val simpleServiceFilesWithComms: Files = Map(


### PR DESCRIPTION
* Replaces `CreatedByAttribute` with `Option[CreatedByAttribute]` in `ServiceRoot` and makes  it a simple case class with a boolean to indicate if used to filter enumeration
* Adds names to `ServiceRoot` arguments in tests

I realised that to implement readable and writable on the handlers, this will be switched on rather a lot, so I thought I'd tidy it up.