### PR TITLE
[config] Map into config.json

### DIFF
--- a/src/e2e/resources/simple-temple-expected/booking/config.json
+++ b/src/e2e/resources/simple-temple-expected/booking/config.json
@@ -1,0 +1,13 @@
+{
+  "user" : "postgres",
+  "dbName" : "postgres",
+  "host" : "booking-db",
+  "sslMode" : "disable",
+  "services" : {
+    
+  },
+  "ports" : {
+    "service" : 1028,
+    "prometheus" : 1029
+  }
+}

--- a/src/e2e/resources/simple-temple-expected/simple-temple-test-group/config.json
+++ b/src/e2e/resources/simple-temple-expected/simple-temple-test-group/config.json
@@ -1,0 +1,13 @@
+{
+  "user" : "postgres",
+  "dbName" : "postgres",
+  "host" : "simple-temple-test-group-db",
+  "sslMode" : "disable",
+  "services" : {
+    
+  },
+  "ports" : {
+    "service" : 1030,
+    "prometheus" : 1031
+  }
+}

--- a/src/e2e/resources/simple-temple-expected/simple-temple-test-user/config.json
+++ b/src/e2e/resources/simple-temple-expected/simple-temple-test-user/config.json
@@ -1,0 +1,13 @@
+{
+  "user" : "postgres",
+  "dbName" : "postgres",
+  "host" : "simple-temple-test-user-db",
+  "sslMode" : "disable",
+  "services" : {
+    
+  },
+  "ports" : {
+    "service" : 1026,
+    "prometheus" : 1027
+  }
+}

--- a/src/main/scala/temple/builder/project/ProjectBuilder.scala
+++ b/src/main/scala/temple/builder/project/ProjectBuilder.scala
@@ -126,6 +126,7 @@ object ProjectBuilder {
 
         val configFileContents =
           ServerConfigGenerator.generate(serviceRoot.kebabName, serviceRoot.datastore, serviceComms, port)
+          
         serverFiles + (File(serviceRoot.kebabName, "config.json") -> configFileContents)
     }
 

--- a/src/main/scala/temple/builder/project/ProjectBuilder.scala
+++ b/src/main/scala/temple/builder/project/ProjectBuilder.scala
@@ -126,7 +126,7 @@ object ProjectBuilder {
 
         val configFileContents =
           ServerConfigGenerator.generate(serviceRoot.kebabName, serviceRoot.datastore, serviceComms, port)
-          
+
         serverFiles + (File(serviceRoot.kebabName, "config.json") -> configFileContents)
     }
 

--- a/src/main/scala/temple/generate/server/config/ServerConfigGenerator.scala
+++ b/src/main/scala/temple/generate/server/config/ServerConfigGenerator.scala
@@ -11,6 +11,6 @@ object ServerConfigGenerator {
     val databaseConfig = database match {
       case Database.Postgres => PostgresConfig(serviceName + "-db")
     }
-    ServerConfig(databaseConfig, services, ports).asJson.toString
+    ServerConfig(databaseConfig, services, ports).asJson.toString + "\n"
   }
 }

--- a/src/test/resources/project-builder-complex/complex-user/config.json
+++ b/src/test/resources/project-builder-complex/complex-user/config.json
@@ -1,0 +1,13 @@
+{
+  "user" : "postgres",
+  "dbName" : "postgres",
+  "host" : "complex-user-db",
+  "sslMode" : "disable",
+  "services" : {
+    
+  },
+  "ports" : {
+    "service" : 1026,
+    "prometheus" : 1027
+  }
+}

--- a/src/test/resources/project-builder-simple/temple-user/config.json
+++ b/src/test/resources/project-builder-simple/temple-user/config.json
@@ -1,0 +1,13 @@
+{
+  "user" : "postgres",
+  "dbName" : "postgres",
+  "host" : "temple-user-db",
+  "sslMode" : "disable",
+  "services" : {
+    
+  },
+  "ports" : {
+    "service" : 1026,
+    "prometheus" : 1027
+  }
+}

--- a/src/test/scala/temple/builder/project/ProjectBuilderTest.scala
+++ b/src/test/scala/temple/builder/project/ProjectBuilderTest.scala
@@ -6,6 +6,7 @@ import org.scalatest.FlatSpec
 import temple.TestUtils
 import temple.detail.LanguageDetail.GoLanguageDetail
 import temple.generate.FileMatchers
+import temple.generate.FileSystem.File
 
 class ProjectBuilderTest extends FlatSpec with FileMatchers {
 
@@ -33,6 +34,14 @@ class ProjectBuilderTest extends FlatSpec with FileMatchers {
     val actual = ProjectBuilder
       .build(ProjectBuilderTestData.simpleTemplefilePostgresService, GoLanguageDetail("github.com/squat/and/dab"))
     projectFilesShouldMatch(actual, expected)
+  }
+
+  it should "correctly generate config.json for cross service communication" in {
+    val project = ProjectBuilder
+      .build(ProjectBuilderTestData.simpleTemplefileForeignKeyService, GoLanguageDetail("github.com/squat/and/dab"))
+    val actualConfig   = project.files(File("a", "config.json"))
+    val expectedConfig = ProjectBuilderTestData.foreignKeyConfigJson
+    actualConfig shouldBe expectedConfig
   }
 
   it should "correctly create a complex service with nested struct" in {

--- a/src/test/scala/temple/builder/project/ProjectBuilderTestData.scala
+++ b/src/test/scala/temple/builder/project/ProjectBuilderTestData.scala
@@ -59,6 +59,26 @@ object ProjectBuilderTestData {
     ),
   )
 
+  val simpleTemplefileForeignKeyService: Templefile = Templefile(
+    "SampleProject",
+    services = Map(
+      "A" -> ServiceBlock(
+        attributes = Map("myB" -> Attribute(ForeignKey("B"))),
+        structs = Map(
+          "InnerStruct" -> StructBlock(
+            attributes = Map("myC" -> Attribute(ForeignKey("C"))),
+          ),
+        ),
+      ),
+      "B" -> ServiceBlock(
+        attributes = Map("example" -> Attribute(IntType())),
+      ),
+      "C" -> ServiceBlock(
+        attributes = Map("anotherExample" -> Attribute(IntType())),
+      ),
+    ),
+  )
+
   val complexTemplefile: Templefile = Templefile(
     "SampleComplexProject",
     services = Map(
@@ -69,4 +89,21 @@ object ProjectBuilderTestData {
       ),
     ),
   )
+
+  val foreignKeyConfigJson: String =
+    """|{
+       |  "user" : "postgres",
+       |  "dbName" : "postgres",
+       |  "host" : "a-db",
+       |  "sslMode" : "disable",
+       |  "services" : {
+       |    "B" : "http://b:1028",
+       |    "C" : "http://c:1030"
+       |  },
+       |  "ports" : {
+       |    "service" : 1026,
+       |    "prometheus" : 1027
+       |  }
+       |}
+       |""".stripMargin
 }

--- a/src/test/scala/temple/generate/server/config/ServerConfigGeneratorTestData.scala
+++ b/src/test/scala/temple/generate/server/config/ServerConfigGeneratorTestData.scala
@@ -15,5 +15,6 @@ object ServerConfigGeneratorTestData {
       |    "service" : 81,
       |    "prometheus" : 2113
       |  }
-      |}""".stripMargin
+      |}
+      |""".stripMargin
 }


### PR DESCRIPTION
This generates `config.json` for each service. 

Couple of things were found whilst doing this:
- Computing which services can be accessed also needs to take into account any structs within that service
- Go looks service keys up using `CamelCase` names, but then the URL needs `kebab-case` - are we okay with these being different?
- I don't like the user of `.get`, but we're pretty certain it's going to be in there - what should I do instead? Throw?
- None of our examples in ProjectBuilder or E2E test actually include a foreign key.
  - Rather than add one and have to deal with Go changes I just created a new test
