### PR TITLE
[go-gen] Fix handling of @serverSet attributes in DAO generation

### DIFF
--- a/src/it/scala/temple/generate/server/GoGeneratorIntegrationTestData.scala
+++ b/src/it/scala/temple/generate/server/GoGeneratorIntegrationTestData.scala
@@ -36,9 +36,9 @@ object GoGeneratorIntegrationTestData {
     comms = Seq("user"),
     opQueries = ListMap(
       CRUD.List   -> "SELECT id, created_by, userOne, userTwo, matchedOn FROM match WHERE created_by = $1",
-      CRUD.Create -> "INSERT INTO match (id, created_by, userOne, userTwo, matchedOn) VALUES ($1, $2, $3, $4, NOW()) RETURNING id, created_by, userOne, userTwo, matchedOn",
+      CRUD.Create -> "INSERT INTO match (id, created_by, userOne, userTwo, matchedOn) VALUES ($1, $2, $3, $4, $5) RETURNING id, created_by, userOne, userTwo, matchedOn",
       CRUD.Read   -> "SELECT id, created_by, userOne, userTwo, matchedOn FROM match WHERE id = $1",
-      CRUD.Update -> "UPDATE match SET userOne = $1, userTwo = $2, matchedOn = NOW() WHERE id = $3 RETURNING id, created_by, userOne, userTwo, matchedOn",
+      CRUD.Update -> "UPDATE match SET userOne = $1, userTwo = $2, matchedOn = $3 WHERE id = $4 RETURNING id, created_by, userOne, userTwo, matchedOn",
       CRUD.Delete -> "DELETE FROM match WHERE id = $1",
     ),
     port = 81,

--- a/src/main/scala/temple/generate/server/go/service/GoServiceGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/GoServiceGenerator.scala
@@ -7,7 +7,7 @@ import temple.generate.FileSystem._
 import temple.generate.server.go.common._
 import temple.generate.server.go.service.dao._
 import temple.generate.server.go.service.main.{GoServiceMainGenerator, GoServiceMainHandlersGenerator, GoServiceMainStructGenerator}
-import temple.generate.server.{CreatedByAttribute, ServiceGenerator, ServiceRoot}
+import temple.generate.server.{ServiceGenerator, ServiceRoot}
 import temple.generate.utils.CodeTerm.mkCode
 
 import scala.Option.when

--- a/src/main/scala/temple/generate/server/go/service/dao/GoServiceDAOFunctionsGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/dao/GoServiceDAOFunctionsGenerator.scala
@@ -43,16 +43,13 @@ object GoServiceDAOFunctionsGenerator {
       case Some(CreatedByAttribute(inputName, _)) => Seq(s"$prefix.${inputName.capitalize}")
       case _                                      => Seq.empty
     }
-    lazy val filteredAttributes = root.attributes.collect {
-      case (name, attribute) if !attribute.accessAnnotation.contains(Annotation.ServerSet) =>
-        s"$prefix.${name.capitalize}"
-    }.toSeq
+    lazy val attributes = root.attributes.map { case name -> _ => s"$prefix.${name.capitalize}" }.toSeq
 
     operation match {
       case List          => createdBy
-      case Create        => id ++ createdBy ++ filteredAttributes
+      case Create        => id ++ createdBy ++ attributes
       case Read | Delete => id
-      case Update        => filteredAttributes ++ id
+      case Update        => attributes ++ id
     }
   }
 

--- a/src/main/scala/temple/generate/server/go/service/dao/GoServiceDAOInputStructsGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/dao/GoServiceDAOInputStructsGenerator.scala
@@ -31,10 +31,8 @@ object GoServiceDAOInputStructsGenerator {
       ListMap(enumerating.inputName.capitalize -> generateGoType(AttributeType.UUIDType))
     }
 
-    // Omit attribute from input struct fields if server set
-    lazy val attributesMap = root.attributes.collect {
-      case (name, attribute) if !attribute.accessAnnotation.contains(Annotation.ServerSet) =>
-        (name.capitalize, generateGoType(attribute.attributeType))
+    lazy val attributesMap = root.attributes.map {
+      case (name, attribute) => (name.capitalize, generateGoType(attribute.attributeType))
     }
 
     mkCode.lines(

--- a/src/main/scala/temple/generate/server/go/service/main/GoServiceMainCreateHandlerGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/main/GoServiceMainCreateHandlerGenerator.scala
@@ -3,7 +3,7 @@ package temple.generate.server.go.service.main
 import temple.ast.Attribute
 import temple.generate.CRUD.Create
 import temple.generate.server.ServiceRoot
-import temple.generate.server.go.GoHTTPStatus.{StatusBadRequest, StatusInternalServerError}
+import temple.generate.server.go.GoHTTPStatus.{StatusInternalServerError}
 import temple.generate.server.go.common.GoCommonGenerator._
 import temple.generate.server.go.service.main.GoServiceMainHandlersGenerator.{generateHandlerDecl, _}
 import temple.generate.utils.CodeTerm.{CodeWrap, mkCode}
@@ -31,7 +31,7 @@ object GoServiceMainCreateHandlerGenerator {
     val createInput = ListMap(idCapitalized -> (if (root.hasAuthBlock) s"auth.$idCapitalized" else "uuid")) ++
       // If the project uses auth, but this service does not have an auth block, AuthID is passed for created_by field
       when(!root.hasAuthBlock && root.projectUsesAuth) { s"Auth$idCapitalized" -> s"auth.$idCapitalized" } ++
-      // TODO: ServerSet values need to be passed in, not just client-provided attributes
+      // ServerSet values must not be passed, as this will cause a nil pointer dereference error
       clientAttributes.map { case str -> _ => str.capitalize -> s"*req.${str.capitalize}" }
 
     mkCode.lines(

--- a/src/main/scala/temple/generate/server/go/service/main/GoServiceMainUpdateHandlerGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/main/GoServiceMainUpdateHandlerGenerator.scala
@@ -15,7 +15,6 @@ object GoServiceMainUpdateHandlerGenerator {
 
   private def generateDAOCallBlock(root: ServiceRoot, clientAttributes: ListMap[String, Attribute]): String = {
     val createInput = ListMap("ID" -> s"${root.decapitalizedName}ID") ++
-      // TODO: Consider if server set attributes need to be updated and add them in
       clientAttributes.map { case str -> _ => str.capitalize -> s"*req.${str.capitalize}" }
     mkCode.lines(
       genDeclareAndAssign(

--- a/src/test/scala/temple/generate/server/go/GoServiceGeneratorTestData.scala
+++ b/src/test/scala/temple/generate/server/go/GoServiceGeneratorTestData.scala
@@ -60,9 +60,9 @@ object GoServiceGeneratorTestData {
       comms = Seq("user"),
       opQueries = ListMap(
         CRUD.List   -> "SELECT id, created_by, userOne, userTwo, matchedOn FROM match WHERE created_by = $1",
-        CRUD.Create -> "INSERT INTO match (id, created_by, userOne, userTwo, matchedOn) VALUES ($1, $2, $3, $4, NOW()) RETURNING id, created_by, userOne, userTwo, matchedOn",
+        CRUD.Create -> "INSERT INTO match (id, created_by, userOne, userTwo, matchedOn) VALUES ($1, $2, $3, $4, $5) RETURNING id, created_by, userOne, userTwo, matchedOn",
         CRUD.Read   -> "SELECT id, created_by, userOne, userTwo, matchedOn FROM match WHERE id = $1",
-        CRUD.Update -> "UPDATE match SET userOne = $1, userTwo = $2, matchedOn = NOW() WHERE id = $3 RETURNING id, created_by, userOne, userTwo, matchedOn",
+        CRUD.Update -> "UPDATE match SET userOne = $1, userTwo = $2, matchedOn = $3 WHERE id = $4 RETURNING id, created_by, userOne, userTwo, matchedOn",
         CRUD.Delete -> "DELETE FROM match WHERE id = $1",
       ),
       port = 81,

--- a/src/test/scala/temple/generate/server/go/testfiles/match/dao/dao.go.snippet
+++ b/src/test/scala/temple/generate/server/go/testfiles/match/dao/dao.go.snippet
@@ -42,10 +42,11 @@ type ListMatchInput struct {
 
 // CreateMatchInput encapsulates the information required to create a single match in the datastore
 type CreateMatchInput struct {
-	ID      uuid.UUID
-	AuthID  uuid.UUID
-	UserOne uuid.UUID
-	UserTwo uuid.UUID
+	ID        uuid.UUID
+	AuthID    uuid.UUID
+	UserOne   uuid.UUID
+	UserTwo   uuid.UUID
+	MatchedOn time.Time
 }
 
 // ReadMatchInput encapsulates the information required to read a single match in the datastore
@@ -55,9 +56,10 @@ type ReadMatchInput struct {
 
 // UpdateMatchInput encapsulates the information required to update a single match in the datastore
 type UpdateMatchInput struct {
-	ID      uuid.UUID
-	UserOne uuid.UUID
-	UserTwo uuid.UUID
+	ID        uuid.UUID
+	UserOne   uuid.UUID
+	UserTwo   uuid.UUID
+	MatchedOn time.Time
 }
 
 // DeleteMatchInput encapsulates the information required to delete a single match in the datastore
@@ -120,7 +122,7 @@ func (dao *DAO) ListMatch(input ListMatchInput) (*[]Match, error) {
 
 // CreateMatch creates a new match in the datastore, returning the newly created match
 func (dao *DAO) CreateMatch(input CreateMatchInput) (*Match, error) {
-	row := executeQueryWithRowResponse(dao.DB, "INSERT INTO match (id, created_by, userOne, userTwo, matchedOn) VALUES ($1, $2, $3, $4, NOW()) RETURNING id, created_by, userOne, userTwo, matchedOn", input.ID, input.AuthID, input.UserOne, input.UserTwo)
+	row := executeQueryWithRowResponse(dao.DB, "INSERT INTO match (id, created_by, userOne, userTwo, matchedOn) VALUES ($1, $2, $3, $4, $5) RETURNING id, created_by, userOne, userTwo, matchedOn", input.ID, input.AuthID, input.UserOne, input.UserTwo, input.MatchedOn)
 
 	var match Match
 	err := row.Scan(&match.ID, &match.CreatedBy, &match.UserOne, &match.UserTwo, &match.MatchedOn)
@@ -151,7 +153,7 @@ func (dao *DAO) ReadMatch(input ReadMatchInput) (*Match, error) {
 
 // UpdateMatch updates the match in the datastore for a given ID, returning the newly updated match
 func (dao *DAO) UpdateMatch(input UpdateMatchInput) (*Match, error) {
-	row := executeQueryWithRowResponse(dao.DB, "UPDATE match SET userOne = $1, userTwo = $2, matchedOn = NOW() WHERE id = $3 RETURNING id, created_by, userOne, userTwo, matchedOn", input.UserOne, input.UserTwo, input.ID)
+	row := executeQueryWithRowResponse(dao.DB, "UPDATE match SET userOne = $1, userTwo = $2, matchedOn = $3 WHERE id = $4 RETURNING id, created_by, userOne, userTwo, matchedOn", input.UserOne, input.UserTwo, input.MatchedOn, input.ID)
 
 	var match Match
 	err := row.Scan(&match.ID, &match.CreatedBy, &match.UserOne, &match.UserTwo, &match.MatchedOn)


### PR DESCRIPTION
* Fixes handling of `@serverSet` attributes in the DAO
  * Previously `matchedOn` for example was provided in the SQL query as `NOW()`, but we don't know what this value will always be
  * The client attributes, which omit `@serverSet` attributes are passed to the DAO Create and Update input structs. Since the `@serverSet` attributes are omitted, they take their zero value, but can be overruled in the hooks!

This should make the go generation ready for use! Aside from some (large) edge cases (see cards).

![](https://media.giphy.com/media/PiQejEf31116URju4V/giphy.gif)

