### PR TITLE
[docker-gen] Remove go.sum from Dockerfile

### DIFF
--- a/src/e2e/resources/simple-temple-expected/auth/Dockerfile
+++ b/src/e2e/resources/simple-temple-expected/auth/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.13.7-alpine
 
 WORKDIR /auth
 
-COPY go.mod go.sum ./
+COPY go.mod ./
 
 RUN ["go", "mod", "download"]
 

--- a/src/e2e/resources/simple-temple-expected/booking/Dockerfile
+++ b/src/e2e/resources/simple-temple-expected/booking/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.13.7-alpine
 
 WORKDIR /booking
 
-COPY go.mod go.sum ./
+COPY go.mod ./
 
 RUN ["go", "mod", "download"]
 

--- a/src/e2e/resources/simple-temple-expected/simple-temple-test-group/Dockerfile
+++ b/src/e2e/resources/simple-temple-expected/simple-temple-test-group/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.13.7-alpine
 
 WORKDIR /simple-temple-test-group
 
-COPY go.mod go.sum ./
+COPY go.mod ./
 
 RUN ["go", "mod", "download"]
 

--- a/src/e2e/resources/simple-temple-expected/simple-temple-test-user/Dockerfile
+++ b/src/e2e/resources/simple-temple-expected/simple-temple-test-user/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.13.7-alpine
 
 WORKDIR /simple-temple-test-user
 
-COPY go.mod go.sum ./
+COPY go.mod ./
 
 RUN ["go", "mod", "download"]
 

--- a/src/main/scala/temple/builder/DockerfileBuilder.scala
+++ b/src/main/scala/temple/builder/DockerfileBuilder.scala
@@ -16,7 +16,7 @@ object DockerfileBuilder {
       case Metadata.ServiceLanguage.Go =>
         Seq(
           WorkDir(s"/$serviceName"),
-          Copy("go.mod go.sum", "./"),
+          Copy("go.mod", "./"),
           Run("go", Seq("mod", "download")),
           Copy(".", "."),
           Copy("config.json", s"/etc/$serviceName-service/"),

--- a/src/test/resources/project-builder-complex/auth/Dockerfile
+++ b/src/test/resources/project-builder-complex/auth/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.13.7-alpine
 
 WORKDIR /auth
 
-COPY go.mod go.sum ./
+COPY go.mod ./
 
 RUN ["go", "mod", "download"]
 

--- a/src/test/resources/project-builder-complex/complex-user/Dockerfile
+++ b/src/test/resources/project-builder-complex/complex-user/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.13.7-alpine
 
 WORKDIR /complex-user
 
-COPY go.mod go.sum ./
+COPY go.mod ./
 
 RUN ["go", "mod", "download"]
 

--- a/src/test/resources/project-builder-simple/temple-user/Dockerfile
+++ b/src/test/resources/project-builder-simple/temple-user/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.13.7-alpine
 
 WORKDIR /temple-user
 
-COPY go.mod go.sum ./
+COPY go.mod ./
 
 RUN ["go", "mod", "download"]
 

--- a/src/test/scala/temple/builder/DockerfileBuilderTestData.scala
+++ b/src/test/scala/temple/builder/DockerfileBuilderTestData.scala
@@ -9,7 +9,7 @@ object DockerfileBuilderTestData {
     From("golang", Some("1.13.7-alpine")),
     Seq(
       WorkDir("/sampleservice"),
-      Copy("go.mod go.sum", "./"),
+      Copy("go.mod", "./"),
       Run("go", Seq("mod", "download")),
       Copy(".", "."),
       Copy("config.json", "/etc/sampleservice-service/"),
@@ -23,7 +23,7 @@ object DockerfileBuilderTestData {
     From("golang", Some("1.13.7-alpine")),
     Seq(
       WorkDir("/complexservice"),
-      Copy("go.mod go.sum", "./"),
+      Copy("go.mod", "./"),
       Run("go", Seq("mod", "download")),
       Copy(".", "."),
       Copy("config.json", "/etc/complexservice-service/"),


### PR DESCRIPTION
Turns out we don't generate `go.sum`, so we can't copy it into the Docker container....

It gets automatically generated in the container, so safe to remove here