### PR TITLE
[deploy] Deploy registry service

### DIFF
--- a/src/e2e/resources/simple-temple-expected/deploy.sh
+++ b/src/e2e/resources/simple-temple-expected/deploy.sh
@@ -38,6 +38,26 @@ do
   kubectl create configmap "grafana-$file-config" --from-file "$BASEDIR/grafana/provisioning/dashboards/$filename" -o=yaml
 done
 
+# Create private registry
+kubectl create -f kube/deploy
+sleep 5
+
+# Forward ports from minikube to localhost
+REGISTRY_NAME=$(kubectl get pod -n kube-system | grep kube-registry-v0 | awk '{ print $1 ;}')
+echo $REGISTRY_NAME
+
+# Until all of the pods have status of either "Running" or "Completed"
+until ! kubectl get pod -n kube-system | awk '{ if (NR != 1) printf $3 "\n" }' | grep -s -q -E "Running|Completed" --invert
+do
+  sleep 1
+done
+
+kubectl port-forward --namespace kube-system $REGISTRY_NAME 5000:5000 2>&1 1>/dev/null &
+sleep 5
+
+# Push images to private repo
+sh push-image.sh
+
 for dir in "$BASEDIR/kube/"*
 do
   kubectl create -f $dir
@@ -72,7 +92,7 @@ echo Configuring Kong...
 
 sleep 1
 
-sh "$BASEDIR/kong/configure-kong-k8s.sh"
+sh "$BASEDIR/kong/configure-kong.sh"
 
 echo $PURPLE
 

--- a/src/e2e/resources/simple-temple-expected/kube/auth/deployment.yaml
+++ b/src/e2e/resources/simple-temple-expected/kube/auth/deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       hostname: auth
       containers:
-      - image: simple-temple-test-auth
+      - image: localhost:5000/simple-temple-test-auth
         name: auth
         ports:
         - containerPort: 1024

--- a/src/e2e/resources/simple-temple-expected/kube/booking/deployment.yaml
+++ b/src/e2e/resources/simple-temple-expected/kube/booking/deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       hostname: booking
       containers:
-      - image: simple-temple-test-booking
+      - image: localhost:5000/simple-temple-test-booking
         name: booking
         ports:
         - containerPort: 1028

--- a/src/e2e/resources/simple-temple-expected/kube/simple-temple-test-group/deployment.yaml
+++ b/src/e2e/resources/simple-temple-expected/kube/simple-temple-test-group/deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       hostname: simple-temple-test-group
       containers:
-      - image: simple-temple-test-simple-temple-test-group
+      - image: localhost:5000/simple-temple-test-simple-temple-test-group
         name: simple-temple-test-group
         ports:
         - containerPort: 1030

--- a/src/e2e/resources/simple-temple-expected/kube/simple-temple-test-user/deployment.yaml
+++ b/src/e2e/resources/simple-temple-expected/kube/simple-temple-test-user/deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       hostname: simple-temple-test-user
       containers:
-      - image: simple-temple-test-simple-temple-test-user
+      - image: localhost:5000/simple-temple-test-simple-temple-test-user
         name: simple-temple-test-user
         ports:
         - containerPort: 1026

--- a/src/main/resources/shell/deploy.sh.body.snippet
+++ b/src/main/resources/shell/deploy.sh.body.snippet
@@ -32,7 +32,7 @@ echo Configuring Kong...
 
 sleep 1
 
-sh "$BASEDIR/kong/configure-kong-k8s.sh"
+sh "$BASEDIR/kong/configure-kong.sh"
 
 echo $PURPLE
 

--- a/src/main/resources/shell/deploy.sh.deployment.snippet
+++ b/src/main/resources/shell/deploy.sh.deployment.snippet
@@ -1,0 +1,19 @@
+# Create private registry
+kubectl create -f kube/deploy
+sleep 5
+
+# Forward ports from minikube to localhost
+REGISTRY_NAME=$(kubectl get pod -n kube-system | grep kube-registry-v0 | awk '{ print $1 ;}')
+echo $REGISTRY_NAME
+
+# Until all of the pods have status of either "Running" or "Completed"
+until ! kubectl get pod -n kube-system | awk '{ if (NR != 1) printf $3 "\n" }' | grep -s -q -E "Running|Completed" --invert
+do
+  sleep 1
+done
+
+kubectl port-forward --namespace kube-system $REGISTRY_NAME 5000:5000 2>&1 1>/dev/null &
+sleep 5
+
+# Push images to private repo
+sh push-image.sh

--- a/src/main/scala/temple/builder/OrchestrationBuilder.scala
+++ b/src/main/scala/temple/builder/OrchestrationBuilder.scala
@@ -16,7 +16,7 @@ object OrchestrationBuilder {
         case (name: String, service: AbstractServiceBlock, port: Ports) =>
           val kebabName   = StringUtils.kebabCase(name)
           val projectName = StringUtils.kebabCase(templefile.projectName)
-          val dockerImage = s"$projectName-$kebabName"
+          val dockerImage = s"${ProjectConfig.registryURL}/$projectName-$kebabName"
           val dbLanguage  = service.lookupMetadata[Metadata.Database].getOrElse(ProjectConfig.defaultDatabase)
           val dbImage     = ProjectConfig.dockerImage(dbLanguage)
           Service(

--- a/src/main/scala/temple/builder/project/ProjectConfig.scala
+++ b/src/main/scala/temple/builder/project/ProjectConfig.scala
@@ -10,6 +10,7 @@ object ProjectConfig {
     override def toString: String = image + ":" + version
   }
 
+  val registryURL                      = "localhost:5000"
   val defaultLanguage: ServiceLanguage = ServiceLanguage.Go
   val defaultDatabase: Database        = Database.Postgres
   val defaultAuth: ServiceAuth         = ServiceAuth.Email

--- a/src/main/scala/temple/generate/kube/DeployScriptGenerator.scala
+++ b/src/main/scala/temple/generate/kube/DeployScriptGenerator.scala
@@ -13,6 +13,8 @@ object DeployScriptGenerator {
 
   private val scriptMetricsBlock: String = FileUtils.readResources("shell/deploy.sh.metrics.snippet")
 
+  private val scriptTemplateDeployment: String = FileUtils.readResources("shell/deploy.sh.deployment.snippet")
+
   def generate(orchestrationRoot: OrchestrationRoot): (File, FileContent) = File("", "deploy.sh") -> mkCode.lines(
     scriptTemplateHeader,
     "# DB init scripts",
@@ -21,6 +23,7 @@ object DeployScriptGenerator {
     },
     "",
     Option.when(orchestrationRoot.usesMetrics) { scriptMetricsBlock },
+    scriptTemplateDeployment,
     scriptTemplateBody,
   )
 }

--- a/src/test/resources/kube/user-deployment.yaml
+++ b/src/test/resources/kube/user-deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       hostname: user
       containers:
-      - image: temple-user-service
+      - image: localhost:5000/temple-user-service
         name: user
         ports:
         - containerPort: 80

--- a/src/test/resources/project-builder-complex/deploy.sh
+++ b/src/test/resources/project-builder-complex/deploy.sh
@@ -36,6 +36,26 @@ do
   kubectl create configmap "grafana-$file-config" --from-file "$BASEDIR/grafana/provisioning/dashboards/$filename" -o=yaml
 done
 
+# Create private registry
+kubectl create -f kube/deploy
+sleep 5
+
+# Forward ports from minikube to localhost
+REGISTRY_NAME=$(kubectl get pod -n kube-system | grep kube-registry-v0 | awk '{ print $1 ;}')
+echo $REGISTRY_NAME
+
+# Until all of the pods have status of either "Running" or "Completed"
+until ! kubectl get pod -n kube-system | awk '{ if (NR != 1) printf $3 "\n" }' | grep -s -q -E "Running|Completed" --invert
+do
+  sleep 1
+done
+
+kubectl port-forward --namespace kube-system $REGISTRY_NAME 5000:5000 2>&1 1>/dev/null &
+sleep 5
+
+# Push images to private repo
+sh push-image.sh
+
 for dir in "$BASEDIR/kube/"*
 do
   kubectl create -f $dir
@@ -70,7 +90,7 @@ echo Configuring Kong...
 
 sleep 1
 
-sh "$BASEDIR/kong/configure-kong-k8s.sh"
+sh "$BASEDIR/kong/configure-kong.sh"
 
 echo $PURPLE
 

--- a/src/test/resources/project-builder-complex/kube/auth/deployment.yaml
+++ b/src/test/resources/project-builder-complex/kube/auth/deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       hostname: auth
       containers:
-      - image: sample-complex-project-auth
+      - image: localhost:5000/sample-complex-project-auth
         name: auth
         ports:
         - containerPort: 1024

--- a/src/test/resources/project-builder-complex/kube/complex-user/deployment.yaml
+++ b/src/test/resources/project-builder-complex/kube/complex-user/deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       hostname: complex-user
       containers:
-      - image: sample-complex-project-complex-user
+      - image: localhost:5000/sample-complex-project-complex-user
         name: complex-user
         ports:
         - containerPort: 1026

--- a/src/test/resources/project-builder-simple/deploy.sh
+++ b/src/test/resources/project-builder-simple/deploy.sh
@@ -22,6 +22,26 @@ echo
 # DB init scripts
 kubectl create configmap temple-user-db-config --from-file "$BASEDIR/temple-user-db/init.sql" -o=yaml
 
+# Create private registry
+kubectl create -f kube/deploy
+sleep 5
+
+# Forward ports from minikube to localhost
+REGISTRY_NAME=$(kubectl get pod -n kube-system | grep kube-registry-v0 | awk '{ print $1 ;}')
+echo $REGISTRY_NAME
+
+# Until all of the pods have status of either "Running" or "Completed"
+until ! kubectl get pod -n kube-system | awk '{ if (NR != 1) printf $3 "\n" }' | grep -s -q -E "Running|Completed" --invert
+do
+  sleep 1
+done
+
+kubectl port-forward --namespace kube-system $REGISTRY_NAME 5000:5000 2>&1 1>/dev/null &
+sleep 5
+
+# Push images to private repo
+sh push-image.sh
+
 for dir in "$BASEDIR/kube/"*
 do
   kubectl create -f $dir
@@ -56,7 +76,7 @@ echo Configuring Kong...
 
 sleep 1
 
-sh "$BASEDIR/kong/configure-kong-k8s.sh"
+sh "$BASEDIR/kong/configure-kong.sh"
 
 echo $PURPLE
 

--- a/src/test/resources/project-builder-simple/kube/temple-user/deployment.yaml
+++ b/src/test/resources/project-builder-simple/kube/temple-user/deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       hostname: temple-user
       containers:
-      - image: sample-project-temple-user
+      - image: localhost:5000/sample-project-temple-user
         name: temple-user
         ports:
         - containerPort: 1026

--- a/src/test/resources/shell/deploy-without-metrics.sh
+++ b/src/test/resources/shell/deploy-without-metrics.sh
@@ -22,6 +22,26 @@ echo
 # DB init scripts
 kubectl create configmap user-db-config --from-file "$BASEDIR/user-db/init.sql" -o=yaml
 
+# Create private registry
+kubectl create -f kube/deploy
+sleep 5
+
+# Forward ports from minikube to localhost
+REGISTRY_NAME=$(kubectl get pod -n kube-system | grep kube-registry-v0 | awk '{ print $1 ;}')
+echo $REGISTRY_NAME
+
+# Until all of the pods have status of either "Running" or "Completed"
+until ! kubectl get pod -n kube-system | awk '{ if (NR != 1) printf $3 "\n" }' | grep -s -q -E "Running|Completed" --invert
+do
+  sleep 1
+done
+
+kubectl port-forward --namespace kube-system $REGISTRY_NAME 5000:5000 2>&1 1>/dev/null &
+sleep 5
+
+# Push images to private repo
+sh push-image.sh
+
 for dir in "$BASEDIR/kube/"*
 do
   kubectl create -f $dir
@@ -56,7 +76,7 @@ echo Configuring Kong...
 
 sleep 1
 
-sh "$BASEDIR/kong/configure-kong-k8s.sh"
+sh "$BASEDIR/kong/configure-kong.sh"
 
 echo $PURPLE
 

--- a/src/test/resources/shell/deploy.sh
+++ b/src/test/resources/shell/deploy.sh
@@ -35,6 +35,26 @@ do
   kubectl create configmap "grafana-$file-config" --from-file "$BASEDIR/grafana/provisioning/dashboards/$filename" -o=yaml
 done
 
+# Create private registry
+kubectl create -f kube/deploy
+sleep 5
+
+# Forward ports from minikube to localhost
+REGISTRY_NAME=$(kubectl get pod -n kube-system | grep kube-registry-v0 | awk '{ print $1 ;}')
+echo $REGISTRY_NAME
+
+# Until all of the pods have status of either "Running" or "Completed"
+until ! kubectl get pod -n kube-system | awk '{ if (NR != 1) printf $3 "\n" }' | grep -s -q -E "Running|Completed" --invert
+do
+  sleep 1
+done
+
+kubectl port-forward --namespace kube-system $REGISTRY_NAME 5000:5000 2>&1 1>/dev/null &
+sleep 5
+
+# Push images to private repo
+sh push-image.sh
+
 for dir in "$BASEDIR/kube/"*
 do
   kubectl create -f $dir
@@ -69,7 +89,7 @@ echo Configuring Kong...
 
 sleep 1
 
-sh "$BASEDIR/kong/configure-kong-k8s.sh"
+sh "$BASEDIR/kong/configure-kong.sh"
 
 echo $PURPLE
 

--- a/src/test/scala/temple/generate/kube/UnitTestData.scala
+++ b/src/test/scala/temple/generate/kube/UnitTestData.scala
@@ -8,7 +8,7 @@ object UnitTestData {
 
   val basicOrchestrationService: Service = Service(
     name = "user",
-    image = "temple-user-service",
+    image = "localhost:5000/temple-user-service",
     dbImage = "postgres:12.1",
     ports = Seq("api" -> 80),
     replicas = 1,


### PR DESCRIPTION
Spins up the registry before all other containers, then invokes the push-image script once ready.

Also fixes a bug where the kong configuration was renamed and includes the url `localhost:5000` in the image name.


Test by running `temple generate` on `simple.temple` - then

- To your `/etc/hosts/` add a mapping to `registry.me` from localhost:
```
127.0.0.1|localhost registry.me
```
- update `push-image.sh` to use `registry.me:5000` instead of `localhost:5000`
- run `source deploy.sh`