### PR TITLE
[go-gen] Fix declare case and blob type encoding

### DIFF
--- a/src/main/scala/temple/generate/server/go/service/main/GoServiceMainCreateHandlerGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/main/GoServiceMainCreateHandlerGenerator.scala
@@ -69,7 +69,7 @@ object GoServiceMainCreateHandlerGenerator {
           // Only need to handle request JSONs when there are client attributes
           when(clientAttributes.nonEmpty) {
             mkCode.doubleLines(
-              generateDecodeRequestBlock(s"create${root.name}"),
+              generateDecodeRequestBlock(root, Create, s"create${root.name}"),
               generateRequestNilCheck(root, clientAttributes),
               generateValidateStructBlock(),
               when(usesComms) { generateForeignKeyCheckBlocks(root, clientAttributes) },

--- a/src/main/scala/temple/generate/server/go/service/main/GoServiceMainGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/main/GoServiceMainGenerator.scala
@@ -14,6 +14,7 @@ object GoServiceMainGenerator {
 
   private[service] def generateImports(
     root: ServiceRoot,
+    usesBase64: Boolean,
     usesTime: Boolean,
     usesComms: Boolean,
     clientAttributes: ListMap[String, Attribute],
@@ -22,6 +23,7 @@ object GoServiceMainGenerator {
     mkCode(
       "import",
       CodeWrap.parens.tabbed(
+        when(usesBase64) { doubleQuote("encoding/base64") },
         doubleQuote("encoding/json"),
         doubleQuote("flag"),
         doubleQuote("fmt"),

--- a/src/main/scala/temple/generate/server/go/service/main/GoServiceMainHandlersGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/main/GoServiceMainHandlersGenerator.scala
@@ -1,6 +1,6 @@
 package temple.generate.server.go.service.main
 
-import temple.ast.AttributeType.{DateTimeType, DateType, TimeType}
+import temple.ast.AttributeType.{BlobType, DateTimeType, DateType, TimeType}
 import temple.ast.{Annotation, Attribute, AttributeType}
 import temple.generate.CRUD._
 import temple.generate.server.ServiceRoot
@@ -19,15 +19,19 @@ import scala.Option.when
 
 object GoServiceMainHandlersGenerator {
 
-  private def generateResponseMapFormat(attributeType: AttributeType): String = {
-    // Must add formatting to attributes with date, time or datetime type
-    val layout = attributeType match {
-      case DateType     => doubleQuote("2006-01-02")
-      case TimeType     => doubleQuote("15:04:05.999999999")
-      case DateTimeType => "time.RFC3339"
-      case _            => ""
+  private def generateResponseMapFormat(root: ServiceRoot, name: String, attributeType: AttributeType): String = {
+    val responseFieldName = s"${root.decapitalizedName}.${name.capitalize}"
+    attributeType match {
+      case DateType =>
+        s"$responseFieldName.${genFunctionCall("Format", doubleQuote("2006-01-02"))}"
+      case TimeType =>
+        s"$responseFieldName.${genFunctionCall("Format", doubleQuote("15:04:05.999999999"))}"
+      case DateTimeType =>
+        s"$responseFieldName.${genFunctionCall("Format", "time.RFC3339")}"
+      case _: BlobType =>
+        genMethodCall("base64.StdEncoding", "EncodeToString", responseFieldName)
+      case _ => responseFieldName
     }
-    if (layout.nonEmpty) s".${genFunctionCall("Format", layout)}" else ""
   }
 
   /** Generate a map for converting the fields of the DAO response to the JSON response */
@@ -36,7 +40,7 @@ object GoServiceMainHandlersGenerator {
     ListMap(root.idAttribute.name.toUpperCase -> s"${root.decapitalizedName}.${root.idAttribute.name.toUpperCase}") ++
     root.attributes.collect {
       case name -> attribute if !attribute.accessAnnotation.contains(Annotation.Server) =>
-        name.capitalize -> s"${root.decapitalizedName}.${name.capitalize}${generateResponseMapFormat(attribute.attributeType)}"
+        name.capitalize -> generateResponseMapFormat(root, name, attribute.attributeType)
     }
 
   /** Generate a handler method declaration */
@@ -145,14 +149,19 @@ object GoServiceMainHandlersGenerator {
     }
 
   /** Generate the block for decoding an incoming request JSON into a request object */
-  private[main] def generateDecodeRequestBlock(typePrefix: String): String =
+  private[main] def generateDecodeRequestBlock(root: ServiceRoot, op: CRUD, typePrefix: String): String = {
+    val jsonDecodeCall = genMethodCall(genMethodCall("json", "NewDecoder", "r.Body"), "Decode", "&req")
     mkCode.lines(
       genVar("req", s"${typePrefix}Request"),
-      genAssign(genMethodCall(genMethodCall("json", "NewDecoder", "r.Body"), "Decode", "&req"), "err"),
+      if (!root.projectUsesAuth && op == Create) genDeclareAndAssign(jsonDecodeCall, "err")
+      else {
+        genAssign(jsonDecodeCall, "err")
+      },
       genIfErr(
         generateHTTPErrorReturn(StatusBadRequest, "Invalid request parameters: %s", genMethodCall("err", "Error")),
       ),
     )
+  }
 
   /** Generate the checking that incoming request parameters are not nil */
   private[main] def generateRequestNilCheck(root: ServiceRoot, clientAttributes: ListMap[String, Attribute]): String =

--- a/src/main/scala/temple/generate/server/go/service/main/GoServiceMainUpdateHandlerGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/main/GoServiceMainUpdateHandlerGenerator.scala
@@ -43,7 +43,7 @@ object GoServiceMainUpdateHandlerGenerator {
           // Only need to handle request JSONs when there are client attributes
           when(clientAttributes.nonEmpty) {
             mkCode.doubleLines(
-              generateDecodeRequestBlock(s"update${root.name}"),
+              generateDecodeRequestBlock(root, Update, s"update${root.name}"),
               generateRequestNilCheck(root, clientAttributes),
               generateValidateStructBlock(),
               when(usesComms) { generateForeignKeyCheckBlocks(root, clientAttributes) },

--- a/src/test/resources/project-builder-complex/complex-user/complex-user.go
+++ b/src/test/resources/project-builder-complex/complex-user/complex-user.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -208,7 +209,7 @@ func (env *env) createComplexUserHandler(w http.ResponseWriter, r *http.Request)
 		DateField:          complexUser.DateField.Format("2006-01-02"),
 		TimeField:          complexUser.TimeField.Format("15:04:05.999999999"),
 		DateTimeField:      complexUser.DateTimeField.Format(time.RFC3339),
-		BlobField:          complexUser.BlobField,
+		BlobField:          base64.StdEncoding.EncodeToString(complexUser.BlobField),
 	})
 }
 
@@ -259,7 +260,7 @@ func (env *env) readComplexUserHandler(w http.ResponseWriter, r *http.Request) {
 		DateField:          complexUser.DateField.Format("2006-01-02"),
 		TimeField:          complexUser.TimeField.Format("15:04:05.999999999"),
 		DateTimeField:      complexUser.DateTimeField.Format(time.RFC3339),
-		BlobField:          complexUser.BlobField,
+		BlobField:          base64.StdEncoding.EncodeToString(complexUser.BlobField),
 	})
 }
 
@@ -343,7 +344,7 @@ func (env *env) updateComplexUserHandler(w http.ResponseWriter, r *http.Request)
 		DateField:          complexUser.DateField.Format("2006-01-02"),
 		TimeField:          complexUser.TimeField.Format("15:04:05.999999999"),
 		DateTimeField:      complexUser.DateTimeField.Format(time.RFC3339),
-		BlobField:          complexUser.BlobField,
+		BlobField:          base64.StdEncoding.EncodeToString(complexUser.BlobField),
 	})
 }
 

--- a/src/test/resources/project-builder-simple/temple-user/temple-user.go
+++ b/src/test/resources/project-builder-simple/temple-user/temple-user.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -127,7 +128,7 @@ func jsonMiddleware(next http.Handler) http.Handler {
 
 func (env *env) createTempleUserHandler(w http.ResponseWriter, r *http.Request) {
 	var req createTempleUserRequest
-	err = json.NewDecoder(r.Body).Decode(&req)
+	err := json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
 		errMsg := util.CreateErrorJSON(fmt.Sprintf("Invalid request parameters: %s", err.Error()))
 		http.Error(w, errMsg, http.StatusBadRequest)
@@ -180,7 +181,7 @@ func (env *env) createTempleUserHandler(w http.ResponseWriter, r *http.Request) 
 		DateField:     templeUser.DateField.Format("2006-01-02"),
 		TimeField:     templeUser.TimeField.Format("15:04:05.999999999"),
 		DateTimeField: templeUser.DateTimeField.Format(time.RFC3339),
-		BlobField:     templeUser.BlobField,
+		BlobField:     base64.StdEncoding.EncodeToString(templeUser.BlobField),
 	})
 }
 
@@ -214,7 +215,7 @@ func (env *env) readTempleUserHandler(w http.ResponseWriter, r *http.Request) {
 		DateField:     templeUser.DateField.Format("2006-01-02"),
 		TimeField:     templeUser.TimeField.Format("15:04:05.999999999"),
 		DateTimeField: templeUser.DateTimeField.Format(time.RFC3339),
-		BlobField:     templeUser.BlobField,
+		BlobField:     base64.StdEncoding.EncodeToString(templeUser.BlobField),
 	})
 }
 
@@ -277,7 +278,7 @@ func (env *env) updateTempleUserHandler(w http.ResponseWriter, r *http.Request) 
 		DateField:     templeUser.DateField.Format("2006-01-02"),
 		TimeField:     templeUser.TimeField.Format("15:04:05.999999999"),
 		DateTimeField: templeUser.DateTimeField.Format(time.RFC3339),
-		BlobField:     templeUser.BlobField,
+		BlobField:     base64.StdEncoding.EncodeToString(templeUser.BlobField),
 	})
 }
 


### PR DESCRIPTION
* Fixes a case where a service is in a project without auth and has client attributes, variable wasn getting assigned before being declared
* Fixes encoding of blob types to base64
  * Includes import generation

I thought I would try compile the temple-user service from the project builder tests, since it's our only set of testfiles that doesn't have auth in the project. Compiles now :) 