### PR TITLE
[docker-compose gen] Allow docker-compose and kube in DSL

### DIFF
--- a/src/main/scala/temple/ast/Metadata.scala
+++ b/src/main/scala/temple/ast/Metadata.scala
@@ -34,12 +34,14 @@ object Metadata {
     case object Go extends ServiceLanguage("Go", "golang")
   }
 
-  sealed abstract class Provider private (name: String) extends EnumEntry(name) with ProjectMetadata
+  sealed abstract class Provider private (name: String, aliases: String*)
+      extends EnumEntry(name, aliases)
+      with ProjectMetadata
 
   object Provider extends Enum[Provider] {
     val values: IndexedSeq[Provider] = findValues
-    case object Kubernetes    extends Provider("kubernetes")
-    case object DockerCompose extends Provider("docker-compose")
+    case object Kubernetes    extends Provider("kubernetes", "kube", "k8s", "kubernooties")
+    case object DockerCompose extends Provider("dockerCompose", "dc")
   }
 
   sealed abstract class Database private (name: String, aliases: String*)

--- a/src/main/scala/temple/ast/Metadata.scala
+++ b/src/main/scala/temple/ast/Metadata.scala
@@ -38,7 +38,8 @@ object Metadata {
 
   object Provider extends Enum[Provider] {
     val values: IndexedSeq[Provider] = findValues
-    case object AWS extends Provider("aws")
+    case object Kubernetes    extends Provider("kubernetes")
+    case object DockerCompose extends Provider("docker-compose")
   }
 
   sealed abstract class Database private (name: String, aliases: String*)

--- a/src/test/scala/temple/DSL/semantics/ValidatorTest.scala
+++ b/src/test/scala/temple/DSL/semantics/ValidatorTest.scala
@@ -19,7 +19,7 @@ class ValidatorTest extends FlatSpec with Matchers {
     validationErrors(
       Templefile(
         "MyProject",
-        projectBlock = ProjectBlock(Seq(Database.Postgres, Provider.AWS)),
+        projectBlock = ProjectBlock(Seq(Database.Postgres, Provider.Kubernetes)),
         services = Map(
           "User" -> ServiceBlock(
             attributes = Map(
@@ -232,7 +232,7 @@ class ValidatorTest extends FlatSpec with Matchers {
       validate(
         Templefile(
           "MyProject",
-          projectBlock = ProjectBlock(Seq(Database.Postgres, Provider.AWS)),
+          projectBlock = ProjectBlock(Seq(Database.Postgres, Provider.Kubernetes)),
           services = Map(
             "User" -> ServiceBlock(
               attributes = Map("a" -> Attribute(IntType())),


### PR DESCRIPTION
Allows `#provider(kubernetes)` and `#provider(docker-compose)` in Templefile