### PR TITLE
[orchestration] Refactor into common parent package

### DIFF
--- a/src/it/scala/temple/generate/orchestration/kube/KubernetesGeneratorIntegrationTest.scala
+++ b/src/it/scala/temple/generate/orchestration/kube/KubernetesGeneratorIntegrationTest.scala
@@ -1,4 +1,4 @@
-package temple.generate.kube
+package temple.generate.orchestration.kube
 
 import org.scalatest.{BeforeAndAfter, Matchers}
 import temple.containers.KubeSpec

--- a/src/it/scala/temple/generate/orchestration/kube/KubernetesGeneratorIntegrationTestData.scala
+++ b/src/it/scala/temple/generate/orchestration/kube/KubernetesGeneratorIntegrationTestData.scala
@@ -1,7 +1,7 @@
-package temple.generate.kube
+package temple.generate.orchestration.kube
 
-import temple.generate.kube.ast.OrchestrationType.{DbStorage, OrchestrationRoot, Service}
-import temple.generate.kube.ast.gen.LifecycleCommand
+import temple.generate.orchestration.ast.OrchestrationType.{DbStorage, OrchestrationRoot, Service}
+import temple.generate.orchestration.kube.ast.LifecycleCommand
 
 object KubernetesGeneratorIntegrationTestData {
 

--- a/src/main/scala/temple/builder/OrchestrationBuilder.scala
+++ b/src/main/scala/temple/builder/OrchestrationBuilder.scala
@@ -5,8 +5,8 @@ import temple.ast.Metadata.Database
 import temple.ast.Templefile.Ports
 import temple.ast.{AbstractServiceBlock, Metadata, Templefile}
 import temple.builder.project.ProjectConfig
-import temple.generate.kube.ast.OrchestrationType.{OrchestrationRoot, Service}
-import temple.generate.kube.ast.gen.LifecycleCommand
+import temple.generate.orchestration.ast.OrchestrationType.{OrchestrationRoot, Service}
+import temple.generate.orchestration.kube.ast.LifecycleCommand
 import temple.utils.StringUtils
 
 object OrchestrationBuilder {

--- a/src/main/scala/temple/builder/project/ProjectBuilder.scala
+++ b/src/main/scala/temple/builder/project/ProjectBuilder.scala
@@ -11,7 +11,7 @@ import temple.generate.FileSystem._
 import temple.generate.database.ast.Statement
 import temple.generate.database.{PostgresContext, PostgresGenerator}
 import temple.generate.docker.DockerfileGenerator
-import temple.generate.kube.KubernetesGenerator
+import temple.generate.orchestration.kube.KubernetesGenerator
 import temple.generate.metrics.grafana.ast.Datasource
 import temple.generate.metrics.grafana.{GrafanaDashboardConfigGenerator, GrafanaDashboardGenerator, GrafanaDatasourceConfigGenerator}
 import temple.generate.metrics.prometheus.PrometheusConfigGenerator

--- a/src/main/scala/temple/builder/project/ProjectConfig.scala
+++ b/src/main/scala/temple/builder/project/ProjectConfig.scala
@@ -2,7 +2,7 @@ package temple.builder.project
 
 import temple.ast.Metadata._
 import temple.generate.database.PreparedType
-import temple.generate.kube.ast.OrchestrationType.DbStorage
+import temple.generate.orchestration.ast.OrchestrationType.DbStorage
 
 object ProjectConfig {
 

--- a/src/main/scala/temple/generate/orchestration/ast/OrchestrationType.scala
+++ b/src/main/scala/temple/generate/orchestration/ast/OrchestrationType.scala
@@ -1,4 +1,4 @@
-package temple.generate.kube.ast
+package temple.generate.orchestration.ast
 
 object OrchestrationType {
 

--- a/src/main/scala/temple/generate/orchestration/dockercompose/DockerComposeGenerator.scala
+++ b/src/main/scala/temple/generate/orchestration/dockercompose/DockerComposeGenerator.scala
@@ -1,0 +1,10 @@
+package temple.generate.orchestration.dockercompose
+
+import temple.generate.FileSystem.{File, Files}
+import temple.generate.orchestration.ast.OrchestrationType.OrchestrationRoot
+
+object DockerComposeGenerator {
+
+  def generate(projectName: String, orchestrationRoot: OrchestrationRoot): Files =
+    Map(File("", "docker-compose.yml") -> "")
+}

--- a/src/main/scala/temple/generate/orchestration/kube/DeployScriptGenerator.scala
+++ b/src/main/scala/temple/generate/orchestration/kube/DeployScriptGenerator.scala
@@ -1,7 +1,7 @@
-package temple.generate.kube
+package temple.generate.orchestration.kube
 
 import temple.generate.FileSystem.{File, FileContent}
-import temple.generate.kube.ast.OrchestrationType.OrchestrationRoot
+import temple.generate.orchestration.ast.OrchestrationType.OrchestrationRoot
 import temple.generate.utils.CodeTerm.mkCode
 import temple.utils.FileUtils
 

--- a/src/main/scala/temple/generate/orchestration/kube/GenType.scala
+++ b/src/main/scala/temple/generate/orchestration/kube/GenType.scala
@@ -1,4 +1,4 @@
-package temple.generate.kube
+package temple.generate.orchestration.kube
 
 /** Case class to encapsulate which Kubernetes object kind being generated */
 sealed trait GenType

--- a/src/main/scala/temple/generate/orchestration/kube/KongConfigGenerator.scala
+++ b/src/main/scala/temple/generate/orchestration/kube/KongConfigGenerator.scala
@@ -1,7 +1,7 @@
-package temple.generate.kube
+package temple.generate.orchestration.kube
 
 import temple.generate.FileSystem.{File, FileContent}
-import temple.generate.kube.ast.OrchestrationType.{OrchestrationRoot, Service}
+import temple.generate.orchestration.ast.OrchestrationType.{OrchestrationRoot, Service}
 import temple.generate.utils.CodeTerm.mkCode
 
 /**

--- a/src/main/scala/temple/generate/orchestration/kube/KubernetesGenerator.scala
+++ b/src/main/scala/temple/generate/orchestration/kube/KubernetesGenerator.scala
@@ -1,14 +1,14 @@
-package temple.generate.kube
+package temple.generate.orchestration.kube
 
 import io.circe.generic.auto._
 import io.circe.syntax._
 import io.circe.yaml.Printer
 import temple.generate.FileSystem._
-import temple.generate.kube.ast.OrchestrationType._
-import temple.generate.kube.ast.gen.KubeType._
-import temple.generate.kube.ast.gen.Spec._
-import temple.generate.kube.ast.gen.volume.{AccessMode, ReclaimPolicy, StorageClass}
-import temple.generate.kube.ast.gen.{PlacementStrategy, RestartPolicy}
+import temple.generate.orchestration.ast.OrchestrationType._
+import temple.generate.orchestration.kube.ast.KubeType._
+import temple.generate.orchestration.kube.ast.Spec._
+import temple.generate.orchestration.kube.ast.{PlacementStrategy, RestartPolicy}
+import temple.generate.orchestration.kube.ast.volume.{AccessMode, ReclaimPolicy, StorageClass}
 import temple.generate.utils.CodeTerm.mkCode
 import temple.utils.FileUtils
 

--- a/src/main/scala/temple/generate/orchestration/kube/PushImageScriptGenerator.scala
+++ b/src/main/scala/temple/generate/orchestration/kube/PushImageScriptGenerator.scala
@@ -1,7 +1,7 @@
-package temple.generate.kube
+package temple.generate.orchestration.kube
 
 import temple.generate.FileSystem.{File, FileContent}
-import temple.generate.kube.ast.OrchestrationType.OrchestrationRoot
+import temple.generate.orchestration.ast.OrchestrationType.OrchestrationRoot
 import temple.utils.StringUtils
 
 object PushImageScriptGenerator {

--- a/src/main/scala/temple/generate/orchestration/kube/ast/KubeType.scala
+++ b/src/main/scala/temple/generate/orchestration/kube/ast/KubeType.scala
@@ -1,8 +1,8 @@
-package temple.generate.kube.ast.gen
+package temple.generate.orchestration.kube.ast
 
 import io.circe.Json
 import temple.generate.JsonEncodable
-import temple.generate.kube.GenType
+import temple.generate.orchestration.kube.GenType
 
 import scala.Option.when
 

--- a/src/main/scala/temple/generate/orchestration/kube/ast/LifecycleCommand.scala
+++ b/src/main/scala/temple/generate/orchestration/kube/ast/LifecycleCommand.scala
@@ -1,4 +1,4 @@
-package temple.generate.kube.ast.gen
+package temple.generate.orchestration.kube.ast
 
 object LifecycleCommand extends Enumeration {
   type LifecycleCommand = Value

--- a/src/main/scala/temple/generate/orchestration/kube/ast/PlacementStrategy.scala
+++ b/src/main/scala/temple/generate/orchestration/kube/ast/PlacementStrategy.scala
@@ -1,4 +1,4 @@
-package temple.generate.kube.ast.gen
+package temple.generate.orchestration.kube.ast
 
 object PlacementStrategy extends Enumeration {
   type Strategy = Value

--- a/src/main/scala/temple/generate/orchestration/kube/ast/RestartPolicy.scala
+++ b/src/main/scala/temple/generate/orchestration/kube/ast/RestartPolicy.scala
@@ -1,4 +1,4 @@
-package temple.generate.kube.ast.gen
+package temple.generate.orchestration.kube.ast
 
 object RestartPolicy extends Enumeration {
   type RestartPolicy = Value

--- a/src/main/scala/temple/generate/orchestration/kube/ast/Spec.scala
+++ b/src/main/scala/temple/generate/orchestration/kube/ast/Spec.scala
@@ -1,11 +1,11 @@
-package temple.generate.kube.ast.gen
+package temple.generate.orchestration.kube.ast
 
 import io.circe.Json
 import temple.generate.JsonEncodable
-import temple.generate.kube.ast.gen.KubeType.{Labels, Metadata}
-import temple.generate.kube.ast.gen.volume.AccessMode.AccessMode
-import temple.generate.kube.ast.gen.volume.ReclaimPolicy.ReclaimPolicy
-import temple.generate.kube.ast.gen.volume.StorageClass.StorageClass
+import temple.generate.orchestration.kube.ast.KubeType.{Labels, Metadata}
+import temple.generate.orchestration.kube.ast.volume.AccessMode.AccessMode
+import temple.generate.orchestration.kube.ast.volume.ReclaimPolicy.ReclaimPolicy
+import temple.generate.orchestration.kube.ast.volume.StorageClass.StorageClass
 
 import scala.Option.when
 

--- a/src/main/scala/temple/generate/orchestration/kube/ast/volume/AccessMode.scala
+++ b/src/main/scala/temple/generate/orchestration/kube/ast/volume/AccessMode.scala
@@ -1,4 +1,4 @@
-package temple.generate.kube.ast.gen.volume
+package temple.generate.orchestration.kube.ast.volume
 
 object AccessMode extends Enumeration {
   type AccessMode = Value

--- a/src/main/scala/temple/generate/orchestration/kube/ast/volume/ReclaimPolicy.scala
+++ b/src/main/scala/temple/generate/orchestration/kube/ast/volume/ReclaimPolicy.scala
@@ -1,4 +1,4 @@
-package temple.generate.kube.ast.gen.volume
+package temple.generate.orchestration.kube.ast.volume
 
 object ReclaimPolicy extends Enumeration {
   type ReclaimPolicy = Value

--- a/src/main/scala/temple/generate/orchestration/kube/ast/volume/StorageClass.scala
+++ b/src/main/scala/temple/generate/orchestration/kube/ast/volume/StorageClass.scala
@@ -1,4 +1,4 @@
-package temple.generate.kube.ast.gen.volume
+package temple.generate.orchestration.kube.ast.volume
 
 object StorageClass extends Enumeration {
   type StorageClass = Value

--- a/src/test/scala/temple/generate/orchestration/UnitTestData.scala
+++ b/src/test/scala/temple/generate/orchestration/UnitTestData.scala
@@ -1,7 +1,7 @@
-package temple.generate.kube
+package temple.generate.orchestration
 
-import temple.generate.kube.ast.OrchestrationType._
-import temple.generate.kube.ast.gen.LifecycleCommand
+import temple.generate.orchestration.ast.OrchestrationType.{DbStorage, OrchestrationRoot, Service}
+import temple.generate.orchestration.kube.ast.LifecycleCommand
 import temple.utils.FileUtils
 
 object UnitTestData {

--- a/src/test/scala/temple/generate/orchestration/dockercompose/DockerComposeGeneratorTest.scala
+++ b/src/test/scala/temple/generate/orchestration/dockercompose/DockerComposeGeneratorTest.scala
@@ -1,0 +1,14 @@
+package temple.generate.orchestration.dockercompose
+
+import org.scalatest.{FlatSpec, Matchers}
+import temple.generate.orchestration.UnitTestData
+
+class DockerComposeGeneratorTest extends FlatSpec with Matchers {
+
+  behavior of "DockerComposeGenerator"
+
+  it should "generate an empty file" in {
+    val generated = DockerComposeGenerator.generate("example", UnitTestData.basicOrchestrationRootWithMetrics)
+    generated.head._2 shouldBe ""
+  }
+}

--- a/src/test/scala/temple/generate/orchestration/kube/KongConfigGeneratorTest.scala
+++ b/src/test/scala/temple/generate/orchestration/kube/KongConfigGeneratorTest.scala
@@ -1,7 +1,8 @@
-package temple.generate.kube
+package temple.generate.orchestration.kube
 
 import org.scalatest.{FlatSpec, Matchers}
 import temple.generate.FileSystem.File
+import temple.generate.orchestration.UnitTestData
 
 class KongConfigGeneratorTest extends FlatSpec with Matchers {
 

--- a/src/test/scala/temple/generate/orchestration/kube/KubernetesGeneratorTest.scala
+++ b/src/test/scala/temple/generate/orchestration/kube/KubernetesGeneratorTest.scala
@@ -1,7 +1,8 @@
-package temple.generate.kube
+package temple.generate.orchestration.kube
 
 import org.scalatest.{FlatSpec, Matchers}
 import temple.generate.FileSystem.File
+import temple.generate.orchestration.UnitTestData
 
 class KubernetesGeneratorTest extends FlatSpec with Matchers {
 


### PR DESCRIPTION
Introduce a common "orchestration" package in the generators package, so that `docker-compose` and `Kubernetes` can share things.. :) 