### PR TITLE
Auth docker compose

### DIFF
--- a/src/it/scala/temple/generate/docker/DockerGeneratorIntegrationTest.scala
+++ b/src/it/scala/temple/generate/docker/DockerGeneratorIntegrationTest.scala
@@ -1,6 +1,7 @@
 package temple.generate.docker
 
 import org.scalatest.{BeforeAndAfter, Matchers}
+import temple.ast.Metadata.Provider
 import temple.ast.{ProjectBlock, Templefile}
 import temple.builder.DockerfileBuilder
 import temple.containers.HadolintSpec
@@ -53,7 +54,8 @@ class DockerGeneratorIntegrationTest extends HadolintSpec with Matchers with Bef
 
     templefile.services.foreach {
       case (name, service) =>
-        val dockerfile          = DockerfileBuilder.createServiceDockerfile(name.toLowerCase, service, 80)
+        val dockerfile =
+          DockerfileBuilder.createServiceDockerfile(name.toLowerCase, service, 80, Some(Provider.DockerCompose))
         val generatedDockerfile = DockerfileGenerator.generate(dockerfile)
         val validationErrors    = validate(generatedDockerfile)
         validationErrors shouldBe empty

--- a/src/main/resources/shell/wait-for-kong.sh
+++ b/src/main/resources/shell/wait-for-kong.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# https://docs.docker.com/compose/startup-order/
+
+set -e
+
+host="$1"
+shift
+cmd="$@"
+
+until curl -s $host 2>&1 1>/dev/null; do
+  >&2 echo "Kong is unavailable - sleeping"
+  sleep 1
+done
+
+>&2 echo "Kong is up - starting service"
+exec $cmd

--- a/src/main/scala/temple/builder/DockerfileBuilder.scala
+++ b/src/main/scala/temple/builder/DockerfileBuilder.scala
@@ -1,5 +1,6 @@
 package temple.builder
 
+import temple.ast.Metadata.Provider
 import temple.ast.{AbstractServiceBlock, Metadata}
 import temple.builder.project.ProjectConfig
 import temple.generate.docker.ast.Statement._
@@ -8,9 +9,28 @@ import temple.generate.docker.ast.{DockerfileRoot, Statement}
 /** Construct a Dockerfile from a Templefile service */
 object DockerfileBuilder {
 
-  def createServiceDockerfile(serviceName: String, service: AbstractServiceBlock, port: Int): DockerfileRoot = {
+  def createServiceDockerfile(
+    serviceName: String,
+    service: AbstractServiceBlock,
+    port: Int,
+    provider: Option[Provider],
+  ): DockerfileRoot = {
     val language    = service.lookupMetadata[Metadata.ServiceLanguage].getOrElse(ProjectConfig.defaultLanguage)
     val dockerImage = ProjectConfig.dockerImage(language)
+
+    // If using DockerCompose and this is the auth service, change the exec
+    val execStatements: Option[Seq[Statement]] = service match {
+      case AbstractServiceBlock.AuthServiceBlock =>
+        provider.collect {
+          case Provider.DockerCompose =>
+            Seq(
+              Run("apk", Seq("add", "curl")),
+              Run("chmod", Seq("+x", "wait-for-kong.sh")),
+              Cmd("./wait-for-kong.sh", Seq("kong:8001", "--", "./auth")),
+            )
+        }
+      case _ => None
+    }
 
     val commands: Seq[Statement] = language match {
       case Metadata.ServiceLanguage.Go =>
@@ -21,9 +41,9 @@ object DockerfileBuilder {
           Copy(".", "."),
           Copy("config.json", s"/etc/$serviceName-service/"),
           Run("go", Seq("build", "-o", serviceName)),
-          Entrypoint(s"./$serviceName", Seq()),
-          Expose(port),
-        )
+        ) ++ execStatements.getOrElse(
+          Seq(Entrypoint(s"./$serviceName", Seq())),
+        ) :+ Expose(port)
     }
 
     DockerfileRoot(From(dockerImage.image, Some(dockerImage.version)), commands)

--- a/src/main/scala/temple/builder/project/ProjectBuilder.scala
+++ b/src/main/scala/temple/builder/project/ProjectBuilder.scala
@@ -58,13 +58,15 @@ object ProjectBuilder {
         }
     }
 
-  private def buildDockerfiles(templefile: Templefile): Files =
+  private def buildDockerfiles(templefile: Templefile): Files = {
+    val provider = templefile.lookupMetadata[Provider]
     templefile.allServicesWithPorts.map {
       case (name, service, port) =>
-        val dockerfileRoot     = DockerfileBuilder.createServiceDockerfile(kebabCase(name), service, port.service)
+        val dockerfileRoot     = DockerfileBuilder.createServiceDockerfile(kebabCase(name), service, port.service, provider)
         val dockerfileContents = DockerfileGenerator.generate(dockerfileRoot)
         (File(s"${kebabCase(name)}", "Dockerfile"), dockerfileContents)
     }.toMap
+  }
 
   private def buildOpenAPI(templefile: Templefile): Files = {
     val openAPIRoot = OpenAPIBuilder.createOpenAPI(templefile)

--- a/src/test/scala/temple/builder/DockerfileBuilderTest.scala
+++ b/src/test/scala/temple/builder/DockerfileBuilderTest.scala
@@ -1,7 +1,8 @@
 package temple.builder
 
 import org.scalatest.{FlatSpec, Matchers}
-import temple.ast.Metadata.ServiceLanguage
+import temple.ast.AbstractServiceBlock.AuthServiceBlock
+import temple.ast.Metadata.{Provider, ServiceLanguage}
 import temple.ast.{ProjectBlock, Templefile}
 
 class DockerfileBuilderTest extends FlatSpec with Matchers {
@@ -18,13 +19,14 @@ class DockerfileBuilderTest extends FlatSpec with Matchers {
     )
 
     val dockerfile = templefile.services.head match {
-      case (name, service) => DockerfileBuilder.createServiceDockerfile(name.toLowerCase, service, 80)
+      case (name, service) =>
+        DockerfileBuilder.createServiceDockerfile(name.toLowerCase, service, 80, Some(Provider.Kubernetes))
     }
 
     dockerfile shouldBe DockerfileBuilderTestData.sampleServiceDockerfile
   }
 
-  it should "generate a Dockerfile for complex Go project" in {
+  it should "generate a Dockerfile for complex Go project with kubernetes" in {
     val templefile = Templefile(
       "ExampleProject",
       ProjectBlock(Seq(ServiceLanguage.Go)),
@@ -32,7 +34,8 @@ class DockerfileBuilderTest extends FlatSpec with Matchers {
     )
 
     val dockerfile = templefile.services.head match {
-      case (name, service) => DockerfileBuilder.createServiceDockerfile(name.toLowerCase, service, 80)
+      case (name, service) =>
+        DockerfileBuilder.createServiceDockerfile(name.toLowerCase, service, 80, Some(Provider.Kubernetes))
     }
 
     dockerfile shouldBe DockerfileBuilderTestData.sampleComplexServiceDockerfile
@@ -45,9 +48,21 @@ class DockerfileBuilderTest extends FlatSpec with Matchers {
     )
 
     val dockerfile = templefile.services.head match {
-      case (name, service) => DockerfileBuilder.createServiceDockerfile(name.toLowerCase, service, 80)
+      case (name, service) =>
+        DockerfileBuilder.createServiceDockerfile(name.toLowerCase, service, 80, Some(Provider.Kubernetes))
     }
 
     dockerfile shouldBe DockerfileBuilderTestData.sampleComplexServiceDockerfile
+  }
+
+  it should "generate the correct Dockerfile for a Go auth service when using DockerCompose" in {
+    val dockerfile =
+      DockerfileBuilder.createServiceDockerfile("auth", AuthServiceBlock, 80, Some(Provider.DockerCompose))
+    dockerfile shouldBe DockerfileBuilderTestData.sampleAuthServiceDockerComposeDockerfile
+  }
+
+  it should "generate the correct Dockerfile for a Go auth service when using Kubernetes" in {
+    val dockerfile = DockerfileBuilder.createServiceDockerfile("auth", AuthServiceBlock, 80, Some(Provider.Kubernetes))
+    dockerfile shouldBe DockerfileBuilderTestData.sampleAuthServiceKubernetesDockerfile
   }
 }

--- a/src/test/scala/temple/builder/DockerfileBuilderTest.scala
+++ b/src/test/scala/temple/builder/DockerfileBuilderTest.scala
@@ -1,9 +1,10 @@
 package temple.builder
 
 import org.scalatest.{FlatSpec, Matchers}
-import temple.ast.AbstractServiceBlock.AuthServiceBlock
+import temple.ast.AbstractAttribute.Attribute
+import temple.ast.AbstractServiceBlock.{AuthServiceBlock, ServiceBlock}
 import temple.ast.Metadata.{Provider, ServiceLanguage}
-import temple.ast.{ProjectBlock, Templefile}
+import temple.ast.{AttributeType, Metadata, ProjectBlock, Templefile}
 
 class DockerfileBuilderTest extends FlatSpec with Matchers {
 
@@ -56,13 +57,47 @@ class DockerfileBuilderTest extends FlatSpec with Matchers {
   }
 
   it should "generate the correct Dockerfile for a Go auth service when using DockerCompose" in {
+    val templefile = Templefile(
+      "ExampleProject",
+      services = Map(
+        "AuthyService" -> ServiceBlock(
+          attributes = Map("test" -> Attribute(AttributeType.StringType())),
+          metadata = Seq(Metadata.ServiceAuth.Email),
+          structs = Map(),
+        ),
+      ),
+    )
+
+    val authBlock = templefile.allServices
+      .collectFirst {
+        case (_, AuthServiceBlock) => AuthServiceBlock
+      }
+      .getOrElse(throw new RuntimeException("Auth block doesn't exist"))
+
     val dockerfile =
-      DockerfileBuilder.createServiceDockerfile("auth", AuthServiceBlock, 80, Some(Provider.DockerCompose))
+      DockerfileBuilder.createServiceDockerfile("auth", authBlock, 80, Some(Provider.DockerCompose))
     dockerfile shouldBe DockerfileBuilderTestData.sampleAuthServiceDockerComposeDockerfile
   }
 
   it should "generate the correct Dockerfile for a Go auth service when using Kubernetes" in {
-    val dockerfile = DockerfileBuilder.createServiceDockerfile("auth", AuthServiceBlock, 80, Some(Provider.Kubernetes))
+    val templefile = Templefile(
+      "ExampleProject",
+      services = Map(
+        "AuthyService" -> ServiceBlock(
+          attributes = Map("test" -> Attribute(AttributeType.StringType())),
+          metadata = Seq(Metadata.ServiceAuth.Email),
+          structs = Map(),
+        ),
+      ),
+    )
+
+    val authBlock = templefile.allServices
+      .collectFirst {
+        case (_, AuthServiceBlock) => AuthServiceBlock
+      }
+      .getOrElse(throw new RuntimeException("Auth block doesn't exist"))
+
+    val dockerfile = DockerfileBuilder.createServiceDockerfile("auth", authBlock, 80, Some(Provider.Kubernetes))
     dockerfile shouldBe DockerfileBuilderTestData.sampleAuthServiceKubernetesDockerfile
   }
 }

--- a/src/test/scala/temple/builder/DockerfileBuilderTestData.scala
+++ b/src/test/scala/temple/builder/DockerfileBuilderTestData.scala
@@ -32,4 +32,34 @@ object DockerfileBuilderTestData {
       Expose(80),
     ),
   )
+
+  val sampleAuthServiceDockerComposeDockerfile: DockerfileRoot = DockerfileRoot(
+    From("golang", Some("1.13.7-alpine")),
+    Seq(
+      WorkDir("/auth"),
+      Copy("go.mod", "./"),
+      Run("go", Seq("mod", "download")),
+      Copy(".", "."),
+      Copy("config.json", "/etc/auth-service/"),
+      Run("go", Seq("build", "-o", "auth")),
+      Run("apk", Seq("add", "curl")),
+      Run("chmod", Seq("+x", "wait-for-kong.sh")),
+      Cmd("./wait-for-kong.sh", Seq("kong:8001", "--", "./auth")),
+      Expose(80),
+    ),
+  )
+
+  val sampleAuthServiceKubernetesDockerfile: DockerfileRoot = DockerfileRoot(
+    From("golang", Some("1.13.7-alpine")),
+    Seq(
+      WorkDir("/auth"),
+      Copy("go.mod", "./"),
+      Run("go", Seq("mod", "download")),
+      Copy(".", "."),
+      Copy("config.json", "/etc/auth-service/"),
+      Run("go", Seq("build", "-o", "auth")),
+      Entrypoint("./auth", Seq()),
+      Expose(80),
+    ),
+  )
 }


### PR DESCRIPTION
When outputting an auth service for docker compose we need to use a special script that waits for Kong to be available before starting the service. See https://github.com/TempleEight/spec-golang/pull/20 for a full justification.

This adds support for that, as well as some unit tests.