### PR TITLE
[docker-compose] Generate kong config for docker compose

### DIFF
--- a/src/main/scala/temple/generate/orchestration/KongConfigGenerator.scala
+++ b/src/main/scala/temple/generate/orchestration/KongConfigGenerator.scala
@@ -1,4 +1,4 @@
-package temple.generate.orchestration.kube
+package temple.generate.orchestration
 
 import temple.generate.FileSystem.{File, FileContent}
 import temple.generate.orchestration.ast.OrchestrationType.{OrchestrationRoot, Service}

--- a/src/main/scala/temple/generate/orchestration/dockercompose/DockerComposeGenerator.scala
+++ b/src/main/scala/temple/generate/orchestration/dockercompose/DockerComposeGenerator.scala
@@ -3,10 +3,12 @@ package temple.generate.orchestration.dockercompose
 import io.circe.yaml.Printer
 import io.circe.syntax._
 import temple.generate.FileSystem.{File, Files}
+import temple.generate.orchestration.KongConfigGenerator
 import temple.generate.orchestration.ast.OrchestrationType
 import temple.generate.orchestration.ast.OrchestrationType.OrchestrationRoot
 import temple.generate.orchestration.dockercompose.ast.Service.{ExternalService, LocalService}
 import temple.generate.orchestration.dockercompose.ast.{DockerComposeRoot, Service}
+
 import Option.when
 
 object DockerComposeGenerator {
@@ -61,6 +63,6 @@ object DockerComposeGenerator {
 
     val composeRoot = DockerComposeRoot(services, allNetworks)
     val yaml        = Printer(preserveOrder = true).pretty(composeRoot.asJson)
-    Map(File("", "docker-compose.yml") -> yaml)
+    Map(File("", "docker-compose.yml") -> yaml, KongConfigGenerator.generate(orchestrationRoot))
   }
 }

--- a/src/main/scala/temple/generate/orchestration/kube/KubernetesGenerator.scala
+++ b/src/main/scala/temple/generate/orchestration/kube/KubernetesGenerator.scala
@@ -4,6 +4,7 @@ import io.circe.generic.auto._
 import io.circe.syntax._
 import io.circe.yaml.Printer
 import temple.generate.FileSystem._
+import temple.generate.orchestration.KongConfigGenerator
 import temple.generate.orchestration.ast.OrchestrationType._
 import temple.generate.orchestration.kube.ast.KubeType._
 import temple.generate.orchestration.kube.ast.Spec._

--- a/src/test/scala/temple/generate/orchestration/kube/KongConfigGeneratorTest.scala
+++ b/src/test/scala/temple/generate/orchestration/kube/KongConfigGeneratorTest.scala
@@ -2,7 +2,7 @@ package temple.generate.orchestration.kube
 
 import org.scalatest.{FlatSpec, Matchers}
 import temple.generate.FileSystem.File
-import temple.generate.orchestration.UnitTestData
+import temple.generate.orchestration.{KongConfigGenerator, UnitTestData}
 
 class KongConfigGeneratorTest extends FlatSpec with Matchers {
 


### PR DESCRIPTION
Make KongConfigGenerator accessible outside the Kube package and invoke it from DockerCompose