### PR TITLE
[Tester] Add precision checks to temple-testing numerical fields

### DIFF
--- a/src/main/scala/temple/test/internal/ServiceTestUtils.scala
+++ b/src/main/scala/temple/test/internal/ServiceTestUtils.scala
@@ -147,13 +147,15 @@ object ServiceTestUtils {
               val minValue: Int  = min.getOrElse(0)
               val random         = Random.between(minValue, maxValue)
               StringUtils.randomString(random.toInt).asJson
-            case AttributeType.IntType(max, min, _) =>
-              // TODO: Switch on precision
+            case AttributeType.IntType(max, min, precision) =>
               val maxValue: Long = max.getOrElse(Long.MaxValue)
               val minValue: Long = min.getOrElse(Long.MinValue)
+              (Random.between(minValue, maxValue) % math.pow(2, precision)).toLong.asJson
+            case AttributeType.FloatType(max, min, precision) if precision <= 4 =>
+              val maxValue = max.getOrElse(Float.MaxValue.toDouble)
+              val minValue = min.getOrElse(Float.MinValue.toDouble)
               Random.between(minValue, maxValue).asJson
             case AttributeType.FloatType(max, min, _) =>
-              // TODO: Switch on precision
               val maxValue = max.getOrElse(Double.MaxValue)
               val minValue = min.getOrElse(Double.MinValue)
               Random.between(minValue, maxValue).asJson


### PR DESCRIPTION
Retrying the essence of #282, basically prevents doubles too large for a float being submitted to float fields by `temple test`
#