### PR TITLE
[AST] Add attribute method for determining whether in request/response

### DIFF
--- a/src/main/scala/temple/DSL/semantics/Validator.scala
+++ b/src/main/scala/temple/DSL/semantics/Validator.scala
@@ -123,10 +123,7 @@ private class Validator private (templefile: Templefile) {
   ): Seq[M] = {
     validateMetadata(metadata, context)
 
-    val removeUpdateEndpoint = attributes.valuesIterator.forall(attributes =>
-      attributes.accessAnnotation.contains(Annotation.Server)
-      || attributes.accessAnnotation.contains(Annotation.ServerSet),
-    )
+    val removeUpdateEndpoint = attributes.valuesIterator.forall(!_.inRequest)
     if (removeUpdateEndpoint) {
       val (endpoints, otherMetadata) = metadata partitionMap {
           case Metadata.Omit(endpoints) => Left(endpoints)

--- a/src/main/scala/temple/ast/AbstractAttribute.scala
+++ b/src/main/scala/temple/ast/AbstractAttribute.scala
@@ -6,6 +6,11 @@ sealed trait AbstractAttribute {
   def attributeType: AttributeType
   def accessAnnotation: Option[AccessAnnotation]
   def valueAnnotations: Set[ValueAnnotation]
+
+  def inRequest: Boolean =
+    !accessAnnotation.contains(Annotation.Server) && !accessAnnotation.contains(Annotation.ServerSet)
+
+  def inResponse: Boolean = !accessAnnotation.contains(Annotation.Server)
 }
 
 object AbstractAttribute {

--- a/src/main/scala/temple/generate/server/go/service/GoServiceGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/GoServiceGenerator.scala
@@ -1,7 +1,7 @@
 package temple.generate.server.go.service
 
+import temple.ast.AttributeType
 import temple.ast.Metadata.{Readable, Writable}
-import temple.ast.{Annotation, AttributeType}
 import temple.generate.CRUD
 import temple.generate.FileSystem._
 import temple.generate.server.go.common._
@@ -33,10 +33,7 @@ object GoServiceGenerator extends ServiceGenerator {
     val usesBase64 = root.attributes.values.map(_.attributeType).toSet.contains(AttributeType.BlobType())
 
     // Attributes filtered by which are client-provided
-    val clientAttributes = root.attributes.filterNot {
-      case (_, attr) =>
-        attr.accessAnnotation.contains(Annotation.Server) || attr.accessAnnotation.contains(Annotation.ServerSet)
-    }
+    val clientAttributes = root.attributes.filter { case (_, attr) => attr.inRequest }
 
     // Whether or not this service is enumerating by creator
     lazy val enumeratingByCreator = root.readable match {

--- a/src/main/scala/temple/generate/server/go/service/main/GoServiceMainHandlersGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/main/GoServiceMainHandlersGenerator.scala
@@ -39,7 +39,7 @@ object GoServiceMainHandlersGenerator {
     // Includes ID attribute and all attributes without the @server annotation
     ListMap(root.idAttribute.name.toUpperCase -> s"${root.decapitalizedName}.${root.idAttribute.name.toUpperCase}") ++
     root.attributes.collect {
-      case name -> attribute if !attribute.accessAnnotation.contains(Annotation.Server) =>
+      case name -> attribute if attribute.inResponse =>
         name.capitalize -> generateResponseMapFormat(root, name, attribute.attributeType)
     }
 

--- a/src/main/scala/temple/generate/server/go/service/main/GoServiceMainStructGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/main/GoServiceMainStructGenerator.scala
@@ -1,7 +1,7 @@
 package temple.generate.server.go.service.main
 
 import temple.ast.AttributeType.{BlobType, DateTimeType, DateType, TimeType}
-import temple.ast.{AbstractAttribute, Annotation, AttributeType}
+import temple.ast.{AbstractAttribute, AttributeType}
 import temple.generate.CRUD
 import temple.generate.CRUD.{CRUD, Create, Read, Update}
 import temple.generate.server.ServiceRoot
@@ -117,8 +117,8 @@ object GoServiceMainStructGenerator {
     // Response struct fields include ID and user-defined attributes without the @server annotation
     val fields = ListMap(root.idAttribute.name.toUpperCase -> generateRequestResponseType(AttributeType.UUIDType)) ++
       root.attributes.collect {
-        case (name, attribute) if !attribute.accessAnnotation.contains(Annotation.Server) =>
-          (name.capitalize, generateRequestResponseType(attribute.attributeType))
+        case (name, attribute) if attribute.inResponse =>
+          name.capitalize -> generateRequestResponseType(attribute.attributeType)
       }
     mkCode.doubleLines(
       when(operations.contains(CRUD.List)) { generateListResponseStructs(root, fields) },

--- a/src/main/scala/temple/generate/target/openapi/OpenAPIGenerator.scala
+++ b/src/main/scala/temple/generate/target/openapi/OpenAPIGenerator.scala
@@ -45,12 +45,6 @@ private class OpenAPIGenerator private (name: String, version: String, descripti
     paths.getOrElseUpdate(url, Path.Mutable(parameters = Seq(parameter))).handlers
   }
 
-  private def isServerAttribute(attribute: AbstractAttribute): Boolean =
-    attribute.accessAnnotation contains Annotation.Server
-
-  private def isClientAttribute(attribute: AbstractAttribute): Boolean =
-    attribute.accessAnnotation.isEmpty || (attribute.accessAnnotation contains Annotation.Client)
-
   private def attributeToOpenAPIType(attribute: AbstractAttribute): OpenAPISimpleType = attribute.attributeType match {
     case UUIDType     => OpenAPISimpleType("string", "uuid")
     case BoolType     => OpenAPISimpleType("boolean")
@@ -78,14 +72,14 @@ private class OpenAPIGenerator private (name: String, version: String, descripti
 
   private def generateItemType(attributes: Map[String, AbstractAttribute]): OpenAPIObject = OpenAPIObject(
     attributes.iterator
-      .filter { case _ -> attribute => !isServerAttribute(attribute) }
+      .filter { case _ -> attribute => attribute.inResponse }
       .map { case str -> attribute => str -> attributeToOpenAPIType(attribute) }
       .to(attributes.mapFactory),
   )
 
   private def generateItemInputType(attributes: Map[String, AbstractAttribute]): OpenAPIObject = OpenAPIObject(
     attributes.iterator
-      .filter { case _ -> attribute => isClientAttribute(attribute) }
+      .filter { case _ -> attribute => attribute.inRequest }
       .map { case str -> attribute => str -> attributeToOpenAPIType(attribute) }
       .to(attributes.mapFactory),
   )

--- a/src/main/scala/temple/test/internal/EndpointTest.scala
+++ b/src/main/scala/temple/test/internal/EndpointTest.scala
@@ -68,9 +68,7 @@ private[internal] class EndpointTest(service: String, endpointName: String) {
     attributes: Map[String, AbstractAttribute],
   ): Unit = {
     // The response should contain exactly the keys in attributes, PLUS an ID attribute, MINUS anything that is @server
-    val expectedAttributes = attributes.filter {
-      case (_, attribute) => !attribute.accessAnnotation.contains(Annotation.Server)
-    }
+    val expectedAttributes     = attributes.filter { case (_, attribute) => attribute.inResponse }
     val expectedAttributeNames = (Set("ID") ++ expectedAttributes.keys).map(_.capitalize)
     val foundAttributeNames    = response.keys.toSet
     assertEqual(expectedAttributeNames, foundAttributeNames)

--- a/src/main/scala/temple/test/internal/ServiceTestUtils.scala
+++ b/src/main/scala/temple/test/internal/ServiceTestUtils.scala
@@ -1,6 +1,6 @@
 package temple.test.internal
 
-import java.sql.{Date, Time, Timestamp}
+import java.sql.Date
 import java.text.SimpleDateFormat
 import java.util.UUID
 
@@ -9,7 +9,7 @@ import io.circe.syntax._
 import io.circe.{Json, JsonObject}
 import scalaj.http.Http
 import temple.ast.AbstractServiceBlock.ServiceBlock
-import temple.ast.{AbstractAttribute, Annotation, AttributeType, Metadata}
+import temple.ast.{AbstractAttribute, AttributeType, Metadata}
 import temple.utils.MonadUtils.FromEither
 import temple.utils.StringUtils
 
@@ -116,12 +116,7 @@ object ServiceTestUtils {
   ): Json =
     // Drop any attributes that are @server or @serverSet
     attributes
-      .filterNot {
-        case (_, attribute) =>
-          attribute.accessAnnotation.contains(Annotation.Server) || attribute.accessAnnotation.contains(
-            Annotation.ServerSet,
-          )
-      }
+      .filter { case (_, attribute) => attribute.inRequest }
       .map {
         case (name, attribute) =>
           val value: Json = attribute.attributeType match {


### PR DESCRIPTION
Rather than constantly checking for `attribute.accessAnnotation.contains` everywhere, add methods on `attribute` for determining whether it should be present in a request to or a response from the server.

Codecov down due only to reduction in LOC.