### PR TITLE
[Validator] Safe test number sizing

### DIFF
--- a/src/main/scala/temple/DSL/semantics/Validator.scala
+++ b/src/main/scala/temple/DSL/semantics/Validator.scala
@@ -199,6 +199,10 @@ private class Validator private (templefile: Templefile) {
       case IntType(Some(max), Some(min), _) if max < min => errors += context.errorMessage(s"IntType max not above min")
       case IntType(_, _, precision) if precision <= 0 || precision > 8 =>
         errors += context.errorMessage(s"IntType precision not between 1 and 8")
+      case intType: IntType if intType.minValue > intType.precisionMax =>
+        errors += context.errorMessage(s"IntType min is out of range for the precision ${intType.precision}")
+      case intType: IntType if intType.maxValue < intType.precisionMin =>
+        errors += context.errorMessage(s"IntType max is out of range for the precision ${intType.precision}")
       case IntType(_, _, _) => // all good
 
       case FloatType(Some(max), Some(min), _) if max < min =>

--- a/src/main/scala/temple/ast/AttributeType.scala
+++ b/src/main/scala/temple/ast/AttributeType.scala
@@ -30,7 +30,7 @@ object AttributeType {
       else -math.pow(2, 8 * precision - 1).toLong
 
     def maxValue: Long = max getOrElse precisionMax
-    def minValue: Long = max getOrElse precisionMin
+    def minValue: Long = min getOrElse precisionMin
   }
 
   case class FloatType(max: Option[Double] = None, min: Option[Double] = None, precision: Byte = 8)

--- a/src/main/scala/temple/ast/AttributeType.scala
+++ b/src/main/scala/temple/ast/AttributeType.scala
@@ -19,8 +19,32 @@ object AttributeType {
   case class StringType(max: Option[Long] = None, min: Option[Int] = None) extends PrimitiveAttributeType
 
   case class IntType(max: Option[Long] = None, min: Option[Long] = None, precision: Byte = 4)
-      extends PrimitiveAttributeType
+      extends PrimitiveAttributeType {
+
+    def precisionMax: Long =
+      if (precision >= 8) Long.MaxValue
+      else math.pow(2, 8 * precision - 1).toLong - 1
+
+    def precisionMin: Long =
+      if (precision >= 8) Long.MaxValue
+      else -math.pow(2, 8 * precision - 1).toLong
+
+    def maxValue: Long = max getOrElse precisionMax
+    def minValue: Long = max getOrElse precisionMin
+  }
 
   case class FloatType(max: Option[Double] = None, min: Option[Double] = None, precision: Byte = 8)
-      extends PrimitiveAttributeType
+      extends PrimitiveAttributeType {
+    def isDouble: Boolean = precision > 4
+
+    def maxValue: Double = max.getOrElse {
+      if (isDouble) Double.MaxValue
+      else Float.MaxValue
+    }
+
+    def minValue: Double = max.getOrElse {
+      if (isDouble) Double.MinValue
+      else Float.MinValue
+    }
+  }
 }

--- a/src/main/scala/temple/generate/target/openapi/OpenAPIGenerator.scala
+++ b/src/main/scala/temple/generate/target/openapi/OpenAPIGenerator.scala
@@ -68,10 +68,10 @@ private class OpenAPIGenerator private (name: String, version: String, descripti
       val minimum = min.map("minimum" -> _.asJson)
       val maximum = max.map("maximum" -> _.asJson)
       OpenAPISimpleType("number", if (precision > 4) "int64" else "int32", Seq(minimum, maximum).flatten: _*)
-    case FloatType(max, min, precision) =>
+    case floatType @ FloatType(max, min, _) =>
       val minimum = min.map("minimum" -> _.asJson)
       val maximum = max.map("maximum" -> _.asJson)
-      OpenAPISimpleType("number", if (precision > 4) "double" else "float", Seq(minimum, maximum).flatten: _*)
+      OpenAPISimpleType("number", if (floatType.isDouble) "double" else "float", Seq(minimum, maximum).flatten: _*)
     case ForeignKey(references) =>
       OpenAPISimpleType("number", "int32", "description" -> s"Reference to $references ID".asJson)
   }

--- a/src/main/scala/temple/test/internal/ServiceTestUtils.scala
+++ b/src/main/scala/temple/test/internal/ServiceTestUtils.scala
@@ -1,6 +1,6 @@
 package temple.test.internal
 
-import java.sql.{Date, Time, Timestamp}
+import java.sql.Date
 import java.text.SimpleDateFormat
 import java.util.UUID
 
@@ -145,20 +145,12 @@ object ServiceTestUtils {
             case AttributeType.StringType(max, min) =>
               val maxValue: Long = max.getOrElse(20)
               val minValue: Int  = min.getOrElse(0)
-              val random         = Random.between(minValue, maxValue)
+              val random         = Random.between(minValue, maxValue + 1)
               StringUtils.randomString(random.toInt).asJson
-            case AttributeType.IntType(max, min, precision) =>
-              val maxValue: Long = max.getOrElse(Long.MaxValue)
-              val minValue: Long = min.getOrElse(Long.MinValue)
-              (Random.between(minValue, maxValue) % math.pow(2, precision)).toLong.asJson
-            case AttributeType.FloatType(max, min, precision) if precision <= 4 =>
-              val maxValue = max.getOrElse(Float.MaxValue.toDouble)
-              val minValue = min.getOrElse(Float.MinValue.toDouble)
-              Random.between(minValue, maxValue).asJson
-            case AttributeType.FloatType(max, min, _) =>
-              val maxValue = max.getOrElse(Double.MaxValue)
-              val minValue = min.getOrElse(Double.MinValue)
-              Random.between(minValue, maxValue).asJson
+            case intType: AttributeType.IntType =>
+              Random.between(intType.minValue, intType.maxValue + 1).asJson
+            case floatType: AttributeType.FloatType =>
+              Random.between(floatType.minValue, floatType.maxValue).asJson
           }
           (name, value)
       }

--- a/src/test/scala/temple/DSL/semantics/ValidatorTest.scala
+++ b/src/test/scala/temple/DSL/semantics/ValidatorTest.scala
@@ -123,6 +123,16 @@ class ValidatorTest extends FlatSpec with Matchers {
     ) shouldBe Set("IntType max not above min in a, in User")
 
     validationErrors(
+      templefileWithUserAttributes(
+        "a" -> Attribute(IntType(min = Some(1024), precision = 1)),
+        "b" -> Attribute(IntType(max = Some(-50_000), precision = 2)),
+      ),
+    ) shouldBe Set(
+      "IntType min is out of range for the precision 1 in a, in User",
+      "IntType max is out of range for the precision 2 in b, in User",
+    )
+
+    validationErrors(
       templefileWithUserAttributes("a" -> Attribute(IntType(precision = 16))),
     ) shouldBe Set("IntType precision not between 1 and 8 in a, in User")
 


### PR DESCRIPTION
Check that the provided minimum IntType bound is less than the maximum allowed for the given precision, and that the maximum IntType bound is greater than the minimum allowed.

This also shares the new methods for determining these bounds with the tester in its generation of random values.