### PR TITLE
[project-test] Remove explicit ID check and make createdBy @server

### DIFF
--- a/src/e2e/resources/simple-temple-expected/api/simple-temple-test.openapi.yaml
+++ b/src/e2e/resources/simple-temple-expected/api/simple-temple-test.openapi.yaml
@@ -290,9 +290,6 @@ paths:
                   id:
                     type: string
                     format: uuid
-                  createdBy:
-                    type: string
-                    format: uuid
         '400':
           $ref: '#/components/responses/Error400'
         '401':
@@ -321,9 +318,6 @@ paths:
                 type: object
                 properties:
                   id:
-                    type: string
-                    format: uuid
-                  createdBy:
                     type: string
                     format: uuid
         '400':
@@ -376,9 +370,6 @@ paths:
                   id:
                     type: string
                     format: uuid
-                  createdBy:
-                    type: string
-                    format: uuid
         '400':
           $ref: '#/components/responses/Error400'
         '401':
@@ -407,9 +398,6 @@ paths:
                 type: object
                 properties:
                   id:
-                    type: string
-                    format: uuid
-                  createdBy:
                     type: string
                     format: uuid
         '400':

--- a/src/main/scala/temple/ast/AbstractAttribute.scala
+++ b/src/main/scala/temple/ast/AbstractAttribute.scala
@@ -29,7 +29,7 @@ object AbstractAttribute {
 
   case object CreatedByAttribute extends AbstractAttribute {
     override def attributeType: AttributeType               = AttributeType.UUIDType
-    override def accessAnnotation: Option[AccessAnnotation] = Some(Annotation.ServerSet)
+    override def accessAnnotation: Option[AccessAnnotation] = Some(Annotation.Server)
     override def valueAnnotations: Set[ValueAnnotation]     = Set()
   }
 }

--- a/src/main/scala/temple/test/internal/EndpointTest.scala
+++ b/src/main/scala/temple/test/internal/EndpointTest.scala
@@ -17,49 +17,57 @@ private[internal] class EndpointTest(service: String, endpointName: String) {
   private def validateResponseType(key: String, responseForKey: Json, attribute: AbstractAttribute): Unit =
     attribute.attributeType match {
       case AttributeType.ForeignKey(_) | AttributeType.UUIDType =>
-        val stringValue = responseForKey.asString.getOrElse(fail(s"$key is not a valid string"))
-        assert(Try(UUID.fromString(stringValue)).isSuccess, s"$key is not a valid UUID")
+        val stringValue = responseForKey.asString.getOrElse(fail(s"$key is not a valid string, found $responseForKey"))
+        assert(Try(UUID.fromString(stringValue)).isSuccess, s"$key is not a valid UUID, found $responseForKey")
       case AttributeType.BoolType =>
-        assert(responseForKey.isBoolean, s"$key is not of type bool")
+        assert(responseForKey.isBoolean, s"$key is not of type bool, found $responseForKey")
       case AttributeType.DateType =>
-        val stringValue = responseForKey.asString.getOrElse(fail(s"$key is not a valid string"))
-        assert(Try(new SimpleDateFormat("yyyy-MM-dd").parse(stringValue)).isSuccess, s"$key is not a valid date")
+        val stringValue = responseForKey.asString.getOrElse(fail(s"$key is not a valid string, found $responseForKey"))
+        assert(
+          Try(new SimpleDateFormat("yyyy-MM-dd").parse(stringValue)).isSuccess,
+          s"$key is not a valid date, found $responseForKey",
+        )
       case AttributeType.DateTimeType =>
-        val stringValue = responseForKey.asString.getOrElse(fail(s"$key is not a valid string"))
+        val stringValue = responseForKey.asString.getOrElse(fail(s"$key is not a valid string, found $responseForKey"))
         assert(
           Try(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX").parse(stringValue)).isSuccess,
-          s"$key is not a valid datetime",
+          s"$key is not a valid datetime, found $responseForKey",
         )
       case AttributeType.TimeType =>
-        val stringValue = responseForKey.asString.getOrElse(fail(s"$key is not a valid string"))
-        assert(Try(new SimpleDateFormat("HH:mm:ssXXX").parse(stringValue)).isSuccess, s"$key is not a valid time")
+        val stringValue = responseForKey.asString.getOrElse(fail(s"$key is not a valid string, found $responseForKey"))
+        assert(
+          Try(new SimpleDateFormat("HH:mm:ss").parse(stringValue)).isSuccess,
+          s"$key is not a valid time, found $responseForKey",
+        )
       case AttributeType.BlobType(_) =>
-        assert(responseForKey.isString, s"$key is not a valid string")
+        assert(responseForKey.isString, s"$key is not a valid string, found $responseForKey")
       case AttributeType.StringType(max, min) =>
-        val stringValue = responseForKey.asString.getOrElse(fail(s"$key is not a valid string"))
+        val stringValue = responseForKey.asString.getOrElse(fail(s"$key is not a valid string, found $responseForKey"))
         min.foreach { minValue =>
-          assert(stringValue.length >= minValue, s"$key does not satisfy min bound of $minValue")
+          assert(stringValue.length >= minValue, s"$key does not satisfy min bound of $minValue, found $stringValue")
         }
         max.foreach { maxValue =>
-          assert(stringValue.length <= maxValue, s"$key does not satisfy max bound of $maxValue")
+          assert(stringValue.length <= maxValue, s"$key does not satisfy max bound of $maxValue, found $stringValue")
         }
       case AttributeType.IntType(max, min, _) =>
         // TODO: precision
-        val intValue = responseForKey.asNumber.flatMap(_.toInt).getOrElse(fail(s"$key is not a valid number"))
+        val intValue =
+          responseForKey.asNumber.flatMap(_.toInt).getOrElse(fail(s"$key is not a valid number, found $responseForKey"))
         min.foreach { minValue =>
-          assert(intValue >= minValue, s"$key does not satisfy min bound of $minValue")
+          assert(intValue >= minValue, s"$key does not satisfy min bound of $minValue, found $intValue")
         }
         max.foreach { maxValue =>
-          assert(intValue <= maxValue, s"$key does not satisfy max bound of $maxValue")
+          assert(intValue <= maxValue, s"$key does not satisfy max bound of $maxValue, found $intValue")
         }
       case AttributeType.FloatType(max, min, _) =>
         // TODO: precision
-        val floatValue = responseForKey.asNumber.map(_.toFloat).getOrElse(fail(s"$key is not a valid float"))
+        val floatValue =
+          responseForKey.asNumber.map(_.toFloat).getOrElse(fail(s"$key is not a valid float, found $responseForKey"))
         min.foreach { minValue =>
-          assert(floatValue >= minValue, s"$key does not satisfy min bound of $minValue")
+          assert(floatValue >= minValue, s"$key does not satisfy min bound of $minValue, found $floatValue")
         }
         max.foreach { maxValue =>
-          assert(floatValue <= maxValue, s"$key does not satisfy max bound of $maxValue")
+          assert(floatValue <= maxValue, s"$key does not satisfy max bound of $maxValue, found $floatValue")
         }
     }
 
@@ -70,14 +78,14 @@ private[internal] class EndpointTest(service: String, endpointName: String) {
   ): Unit = {
     // The response should contain exactly the keys in attributes, PLUS an ID attribute, MINUS anything that is @server
     val expectedAttributes     = attributes.filter { case (_, attribute) => attribute.inResponse }
-    val expectedAttributeNames = (Set("ID") ++ expectedAttributes.keys).map(_.capitalize)
+    val expectedAttributeNames = expectedAttributes.keys.toSet
     val foundAttributeNames    = response.keys.toSet
     assertEqual(expectedAttributeNames, foundAttributeNames)
 
     expectedAttributes.foreach {
       case (name, attribute) =>
         // Validate that the response JSON is of the expected types
-        val responseForKey = response(name.capitalize).getOrElse(fail(s"could not find key $name in response body"))
+        val responseForKey = response(name).getOrElse(fail(s"could not find key $name in response body"))
         validateResponseType(name, responseForKey, attribute)
 
         request.foreach { request =>
@@ -92,7 +100,7 @@ private[internal] class EndpointTest(service: String, endpointName: String) {
 
   def assertEqual(expected: Any, found: Any, message: String = ""): Unit =
     if (!expected.equals(found))
-      fail(s"Expected $expected but found $found.\n$message")
+      fail(s"expected $expected but found $found.\n$message")
 
   def assert(value: Boolean, failMsg: String): Unit =
     if (!value) fail(failMsg)

--- a/src/main/scala/temple/test/internal/ServiceTestUtils.scala
+++ b/src/main/scala/temple/test/internal/ServiceTestUtils.scala
@@ -182,9 +182,9 @@ object ServiceTestUtils {
         requestBody,
         newAccessToken,
       )
-    val idJSON = createJSON("ID").getOrElse(test.fail(s"response to create $serviceName did not contain an ID key"))
+    val idJSON = createJSON("id").getOrElse(test.fail(s"response to create $serviceName did not contain an id key"))
     val id =
-      idJSON.asString.getOrElse(test.fail(s"response to create $serviceName contained field ID, but was not a string"))
+      idJSON.asString.getOrElse(test.fail(s"response to create $serviceName contained field id, but was not a string"))
     CreateResponse(id, newAccessToken)
   }
 

--- a/src/test/scala/temple/testfiles/simple-dc.temple
+++ b/src/test/scala/temple/testfiles/simple-dc.temple
@@ -10,7 +10,7 @@ User: service {
   lastName: string;
   createdAt: datetime;
   numberOfDogs: int;
-  yeets: bool @unique @server; // Don't send this to the client
+  yeets: bool @server; // Don't send this to the client
   currentBankBalance: float(min: 0.0, precision: 2);
   birthDate: date;
   breakfastTime: time;


### PR DESCRIPTION
- `createdBy` is now `@server` rather than `@serverSet`, since it's never returned
- Fixed some fail statements so they're easier to debug
- Remove explicit addition of `ID` field, since this is added by the templefile validator
- Remove `@unique` from boolean field in `simple-dc.temple`, since this makes it hard to test > 2 values
- Remove capitalisation of field names after #287 