### PR TITLE
[Validator] Add cycle detection to the validator, using Tarjan’s algo

### DIFF
--- a/src/main/scala/temple/DSL/semantics/Tarjan.scala
+++ b/src/main/scala/temple/DSL/semantics/Tarjan.scala
@@ -1,0 +1,45 @@
+package temple.DSL.semantics
+
+import scala.collection.mutable
+
+/** Apply Tarjan’s strongly connected components algorithm to find cycles in the graph */
+class Tarjan[T] private (graph: Map[T, Iterable[T]]) {
+
+  private val stack: mutable.Stack[T]    = mutable.Stack.empty
+  private val index: mutable.Map[T, Int] = mutable.Map.empty
+
+  /** The smallest index of any node known to be reachable from v, including v itself */
+  private val lowLink: mutable.Map[T, Int]      = mutable.Map.empty
+  private val sccBuffer: mutable.Buffer[Seq[T]] = mutable.Buffer.empty
+
+  lazy val sccs: Set[Seq[T]] = {
+    for (v <- graph.keys) if (!index.contains(v)) visit(v)
+    sccBuffer.toSet
+  }
+
+  private def visit(node: T): Unit = {
+    // Set the depth index for v to the smallest unused index
+    index(node) = index.size
+    lowLink(node) = index(node)
+    stack.push(node)
+    for (neighbour <- graph.getOrElse(node, Nil)) {
+      if (!index.contains(neighbour)) { // neighbour has not yet been visited; recurse on it
+        visit(neighbour)
+        lowLink(node) = math.min(lowLink(node), lowLink(neighbour))
+      } else if (stack.contains(neighbour)) { // neighbour is in stack S and hence in the current SCC
+        lowLink(node) = math.min(lowLink(node), index(neighbour))
+      } // If neighbour is not on stack, then w is already in an scc, so we ignore it
+    }
+    // If this node is a root node, pop the stack and generate an SCC
+    if (lowLink(node) == index(node)) {
+      // Pop all elements from the stack until and including this element itself
+      val scc = (stack.popWhile(_ != node) :+ stack.pop()).toSeq
+      sccBuffer += scc
+    }
+  }
+
+}
+
+object Tarjan {
+  def apply[T](graph: Map[T, Iterable[T]]): Set[Seq[T]] = new Tarjan(graph).sccs
+}

--- a/src/main/scala/temple/DSL/semantics/Tarjan.scala
+++ b/src/main/scala/temple/DSL/semantics/Tarjan.scala
@@ -10,9 +10,9 @@ class Tarjan[T] private (graph: Map[T, Iterable[T]]) {
 
   /** The smallest index of any node known to be reachable from v, including v itself */
   private val lowLink: mutable.Map[T, Int]      = mutable.Map.empty
-  private val sccBuffer: mutable.Buffer[Seq[T]] = mutable.Buffer.empty
+  private val sccBuffer: mutable.Buffer[Set[T]] = mutable.Buffer.empty
 
-  lazy val sccs: Set[Seq[T]] = {
+  lazy val sccs: Set[Set[T]] = {
     for (v <- graph.keys) if (!index.contains(v)) visit(v)
     sccBuffer.toSet
   }
@@ -33,7 +33,7 @@ class Tarjan[T] private (graph: Map[T, Iterable[T]]) {
     // If this node is a root node, pop the stack and generate an SCC
     if (lowLink(node) == index(node)) {
       // Pop all elements from the stack until and including this element itself
-      val scc = (stack.popWhile(_ != node) :+ stack.pop()).toSeq
+      val scc = (stack.popWhile(_ != node) :+ stack.pop()).toSet
       sccBuffer += scc
     }
   }
@@ -41,5 +41,5 @@ class Tarjan[T] private (graph: Map[T, Iterable[T]]) {
 }
 
 object Tarjan {
-  def apply[T](graph: Map[T, Iterable[T]]): Set[Seq[T]] = new Tarjan(graph).sccs
+  def apply[T](graph: Map[T, Iterable[T]]): Set[Set[T]] = new Tarjan(graph).sccs
 }

--- a/src/main/scala/temple/DSL/semantics/Validator.scala
+++ b/src/main/scala/temple/DSL/semantics/Validator.scala
@@ -206,7 +206,7 @@ private class Validator private (templefile: Templefile) {
   private def validateBlockOfMetadata[T <: Metadata](target: TempleBlock[T], context: SemanticContext): Unit =
     validateMetadata(target.metadata, context)
 
-  private val referenceCycles: Set[Seq[String]] = {
+  private val referenceCycles: Set[Set[String]] = {
     val graph = templefile.providedBlockNames.map { blockName =>
       blockName -> templefile.getBlock(blockName).attributes.values.collect {
         case Attribute(ForeignKey(references), _, annotations) if !annotations.contains(Nullable) => references
@@ -251,10 +251,8 @@ private class Validator private (templefile: Templefile) {
     }
 
     if (referenceCycles.nonEmpty) {
-      val referenceCycleStrings = referenceCycles.map { elems =>
-        (elems.reverseIterator ++ Iterator(elems.last)).mkString("(", " -> ", ")")
-      }
-      errors += ("Cycle(s) were detected in foreign keys: " + referenceCycleStrings.mkString(", "))
+      val referenceCycleStrings = referenceCycles.map(_.mkString("{ ", ", ", " }"))
+      errors += ("Cycle(s) were detected in foreign keys, between elements: " + referenceCycleStrings.mkString(", "))
     }
 
     errors.toSeq

--- a/src/main/scala/temple/ast/Templefile.scala
+++ b/src/main/scala/temple/ast/Templefile.scala
@@ -1,6 +1,5 @@
 package temple.ast
 
-import temple.DSL.semantics.SemanticParsingException
 import temple.ast.AbstractServiceBlock._
 import temple.ast.Metadata.ServiceAuth
 import temple.ast.Templefile.Ports
@@ -64,11 +63,9 @@ case class Templefile(
   def structNames: Iterable[String]        = structLocations.keys
   lazy val providedBlockNames: Set[String] = (services.keys ++ structNames).toSet
 
-  /** Get a block by name, either as a service or a block. If neither exist, throw an error */
+  /** Get a block by name, either as a service or a block */
   def getBlock(name: String): AttributeBlock[_] =
-    services.get(name).orElse(services.get(structLocations(name)).map(_.structs(name))).getOrElse {
-      throw new SemanticParsingException(s"Cannot find block with name $name")
-    }
+    services.getOrElse(name, services(structLocations(name)).structs(name))
 }
 
 object Templefile {

--- a/src/test/scala/temple/DSL/semantics/ValidatorTest.scala
+++ b/src/test/scala/temple/DSL/semantics/ValidatorTest.scala
@@ -280,7 +280,7 @@ class ValidatorTest extends FlatSpec with Matchers {
           "Square" -> ServiceBlock(Map("user"   -> Attribute(ForeignKey("User")))),
         ),
       ),
-    ) shouldBe Set("Cycle(s) were detected in foreign keys: (User -> Box -> Cube -> Square -> User)")
+    ) shouldBe Set("Cycle(s) were detected in foreign keys, between elements: { Square, Cube, Box, User }")
   }
 
   it should "throw errors when validating" in {

--- a/src/test/scala/temple/DSL/semantics/ValidatorTest.scala
+++ b/src/test/scala/temple/DSL/semantics/ValidatorTest.scala
@@ -15,7 +15,7 @@ class ValidatorTest extends FlatSpec with Matchers {
 
   behavior of "Validator"
 
-  it should "validationErrors" in {
+  it should "throw no errors with a correct templefile" in {
     validationErrors(
       Templefile(
         "MyProject",
@@ -44,7 +44,9 @@ class ValidatorTest extends FlatSpec with Matchers {
         ),
       ),
     ) shouldBe empty
+  }
 
+  it should "identify duplicate usage of structs" in {
     validationErrors(
       Templefile(
         "MyProject",
@@ -68,7 +70,7 @@ class ValidatorTest extends FlatSpec with Matchers {
       Templefile(
         "Box",
         projectBlock = ProjectBlock(Seq(Database.Postgres)),
-        targets = Map("User" -> TargetBlock(Seq(TargetLanguage.JavaScript)), "Box" -> TargetBlock()),
+        targets = Map("User" -> TargetBlock(Seq(TargetLanguage.JavaScript))),
         services = Map(
           "User" -> ServiceBlock(
             attributes = Map(
@@ -79,15 +81,17 @@ class ValidatorTest extends FlatSpec with Matchers {
               "Box"  -> StructBlock(Map()),
             ),
           ),
+          "Other" -> ServiceBlock(
+            attributes = Map("a" -> Attribute(IntType())),
+            structs = Map(
+              "User" -> StructBlock(Map()),
+            ),
+          ),
         ),
       ),
     ) shouldBe Set(
-      "Project, targets and structs must be globally unique, duplicates found: Box (struct, target, project), User (service, struct, target)",
+      "Project, targets and structs must be globally unique, duplicates found: Box (project, struct), User (service, struct, target)",
     )
-
-    validationErrors(
-      Templefile("myProject"),
-    ) shouldBe Set("Invalid name: myProject (project), it should start with a capital letter")
 
     validationErrors(
       Templefile(
@@ -102,9 +106,17 @@ class ValidatorTest extends FlatSpec with Matchers {
         ),
       ),
     ) shouldBe Set(
-      "Project, targets and structs must be globally unique, duplicate found: User (service, project)",
+      "Project, targets and structs must be globally unique, duplicate found: User (project, service)",
     )
+  }
 
+  it should "enforce capitalization of project names" in {
+    validationErrors(
+      Templefile("myProject"),
+    ) shouldBe Set("Invalid name: myProject (project), it should start with a capital letter")
+  }
+
+  it should "identify repeated use of metadata" in {
     validationErrors(
       Templefile(
         "User",
@@ -115,9 +127,25 @@ class ValidatorTest extends FlatSpec with Matchers {
     )
 
     validationErrors(
+      Templefile(
+        "MyProject",
+        services = Map(
+          "User" -> ServiceBlock(
+            attributes = Map("a" -> Attribute(IntType())),
+            metadata = Seq(ServiceAuth.Email, Readable.All, Readable.This),
+          ),
+        ),
+      ),
+    ) shouldBe Set("Multiple occurrences of Readable metadata in User")
+  }
+
+  it should "enforce capitalization of attributes" in {
+    validationErrors(
       templefileWithUserAttributes("A" -> Attribute(BoolType)),
     ) shouldBe Set("Invalid attribute name A, it must start with a lowercase letter, in User")
+  }
 
+  it should "validate constraints on attributes" in {
     validationErrors(
       templefileWithUserAttributes("a" -> Attribute(IntType(max = Some(0), min = Some(1)))),
     ) shouldBe Set("IntType max not above min in a, in User")
@@ -153,7 +181,9 @@ class ValidatorTest extends FlatSpec with Matchers {
       "StringType max is negative in c, in User",
       "StringType max not above min in d, in User",
     )
+  }
 
+  it should "identify unknown foreign keys" in {
     validationErrors(
       templefileWithUserAttributes("c" -> Attribute(ForeignKey("Unknown"))),
     ) shouldBe Set("Invalid foreign key Unknown in c, in User")
@@ -172,20 +202,9 @@ class ValidatorTest extends FlatSpec with Matchers {
         ),
       ),
     ) shouldBe Set("No such service Box referenced in #uses in User")
+  }
 
-    validationErrors(
-      Templefile(
-        "MyProject",
-        services = Map(
-          "User" -> ServiceBlock(
-            attributes = Map("a" -> Attribute(IntType())),
-            metadata = Seq(ServiceAuth.Email, Readable.All, Readable.This),
-          ),
-        ),
-      ),
-    ) shouldBe Set("Multiple occurrences of Readable metadata in User")
-
-    // check that the auth block is found, regardless of which block it’s in
+  it should "enforce the existance of an auth block when other dependent metadata are used" in {
     validationErrors(
       Templefile(
         "MyProject",
@@ -196,11 +215,11 @@ class ValidatorTest extends FlatSpec with Matchers {
           ),
           "Box" -> ServiceBlock(
             attributes = Map(),
-            metadata = Seq(Readable.All, Readable.This),
+            metadata = Seq(Readable.This),
           ),
         ),
       ),
-    ) shouldBe Set("Multiple occurrences of Readable metadata in Box")
+    ) shouldBe Set()
 
     validationErrors(
       Templefile(
@@ -213,7 +232,9 @@ class ValidatorTest extends FlatSpec with Matchers {
         ),
       ),
     ) shouldBe Set("#readable(this) requires at least one service to have #auth in User")
+  }
 
+  it should "identify incompatible metadata" in {
     validationErrors(
       Templefile(
         "MyProject",
@@ -227,7 +248,7 @@ class ValidatorTest extends FlatSpec with Matchers {
     ) shouldBe Set("#writable(all) is not compatible with #readable(this) in User")
   }
 
-  it should "validate" in {
+  it should "throw errors when validating" in {
     noException shouldBe thrownBy {
       validate(
         Templefile(


### PR DESCRIPTION
This uses Tarjan’s algorithm to break the foreign key dependency graph into strongly connected components. If any SCC contains more than one node, there is a cycle, and so an error is raised.