### PR TITLE
[go-gen] Add setup.go and invoke from main function

### DIFF
--- a/src/e2e/resources/simple-temple-expected/auth/auth.go
+++ b/src/e2e/resources/simple-temple-expected/auth/auth.go
@@ -48,8 +48,8 @@ type loginAuthResponse struct {
 	AccessToken string
 }
 
-// router generates a router for this service
-func (env *env) router() *mux.Router {
+// defaultRouter generates a router for this service
+func defaultRouter(env *env) *mux.Router {
 	r := mux.NewRouter()
 	r.HandleFunc("/auth/register", env.registerAuthHandler).Methods(http.MethodPost)
 	r.HandleFunc("/auth/login", env.loginAuthHandler).Methods(http.MethodPost)
@@ -83,7 +83,11 @@ func main() {
 
 	env := env{d, c, jwtCredential}
 
-	log.Fatal(http.ListenAndServe(":1024", env.router()))
+	// Call into non-generated entry-point
+	router := defaultRouter(&env)
+	env.setup(router)
+
+	log.Fatal(http.ListenAndServe(":1024", router))
 }
 
 func jsonMiddleware(next http.Handler) http.Handler {

--- a/src/e2e/resources/simple-temple-expected/auth/setup.go
+++ b/src/e2e/resources/simple-temple-expected/auth/setup.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/gorilla/mux"
+
+func (env *env) setup(router *mux.Router) {
+	// Add user defined code here
+}

--- a/src/e2e/resources/simple-temple-expected/booking/booking.go
+++ b/src/e2e/resources/simple-temple-expected/booking/booking.go
@@ -29,8 +29,8 @@ type readBookingResponse struct {
 	ID uuid.UUID `json:"id"`
 }
 
-// router generates a router for this service
-func (env *env) router() *mux.Router {
+// defaultRouter generates a router for this service
+func defaultRouter(env *env) *mux.Router {
 	r := mux.NewRouter()
 	// Mux directs to first matching route, i.e. the order matters
 	r.HandleFunc("/booking", env.createBookingHandler).Methods(http.MethodPost)
@@ -59,7 +59,11 @@ func main() {
 
 	env := env{d}
 
-	log.Fatal(http.ListenAndServe(":1028", env.router()))
+	// Call into non-generated entry-point
+	router := defaultRouter(&env)
+	env.setup(router)
+
+	log.Fatal(http.ListenAndServe(":1028", router))
 }
 
 func jsonMiddleware(next http.Handler) http.Handler {

--- a/src/e2e/resources/simple-temple-expected/booking/setup.go
+++ b/src/e2e/resources/simple-temple-expected/booking/setup.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/gorilla/mux"
+
+func (env *env) setup(router *mux.Router) {
+	// Add user defined code here
+}

--- a/src/e2e/resources/simple-temple-expected/simple-temple-test-group/setup.go
+++ b/src/e2e/resources/simple-temple-expected/simple-temple-test-group/setup.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/gorilla/mux"
+
+func (env *env) setup(router *mux.Router) {
+	// Add user defined code here
+}

--- a/src/e2e/resources/simple-temple-expected/simple-temple-test-group/simple-temple-test-group.go
+++ b/src/e2e/resources/simple-temple-expected/simple-temple-test-group/simple-temple-test-group.go
@@ -29,8 +29,8 @@ type readSimpleTempleTestGroupResponse struct {
 	ID uuid.UUID `json:"id"`
 }
 
-// router generates a router for this service
-func (env *env) router() *mux.Router {
+// defaultRouter generates a router for this service
+func defaultRouter(env *env) *mux.Router {
 	r := mux.NewRouter()
 	// Mux directs to first matching route, i.e. the order matters
 	r.HandleFunc("/simple-temple-test-group", env.createSimpleTempleTestGroupHandler).Methods(http.MethodPost)
@@ -59,7 +59,11 @@ func main() {
 
 	env := env{d}
 
-	log.Fatal(http.ListenAndServe(":1030", env.router()))
+	// Call into non-generated entry-point
+	router := defaultRouter(&env)
+	env.setup(router)
+
+	log.Fatal(http.ListenAndServe(":1030", router))
 }
 
 func jsonMiddleware(next http.Handler) http.Handler {

--- a/src/e2e/resources/simple-temple-expected/simple-temple-test-user/setup.go
+++ b/src/e2e/resources/simple-temple-expected/simple-temple-test-user/setup.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/gorilla/mux"
+
+func (env *env) setup(router *mux.Router) {
+	// Add user defined code here
+}

--- a/src/e2e/resources/simple-temple-expected/simple-temple-test-user/simple-temple-test-user.go
+++ b/src/e2e/resources/simple-temple-expected/simple-temple-test-user/simple-temple-test-user.go
@@ -107,8 +107,8 @@ type updateSimpleTempleTestUserResponse struct {
 	BreakfastTime        string    `json:"breakfastTime"`
 }
 
-// router generates a router for this service
-func (env *env) router() *mux.Router {
+// defaultRouter generates a router for this service
+func defaultRouter(env *env) *mux.Router {
 	r := mux.NewRouter()
 	// Mux directs to first matching route, i.e. the order matters
 	r.HandleFunc("/simple-temple-test-user/all", env.listSimpleTempleTestUserHandler).Methods(http.MethodGet)
@@ -138,7 +138,11 @@ func main() {
 
 	env := env{d}
 
-	log.Fatal(http.ListenAndServe(":1026", env.router()))
+	// Call into non-generated entry-point
+	router := defaultRouter(&env)
+	env.setup(router)
+
+	log.Fatal(http.ListenAndServe(":1026", router))
 }
 
 func jsonMiddleware(next http.Handler) http.Handler {

--- a/src/main/resources/go/genFiles/auth/main/router.go.snippet
+++ b/src/main/resources/go/genFiles/auth/main/router.go.snippet
@@ -1,5 +1,5 @@
-// router generates a router for this service
-func (env *env) router() *mux.Router {
+// defaultRouter generates a router for this service
+func defaultRouter(env *env) *mux.Router {
 	r := mux.NewRouter()
 	r.HandleFunc("/auth/register", env.registerAuthHandler).Methods(http.MethodPost)
 	r.HandleFunc("/auth/login", env.loginAuthHandler).Methods(http.MethodPost)

--- a/src/main/scala/temple/generate/server/go/auth/GoAuthServiceGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/auth/GoAuthServiceGenerator.scala
@@ -23,6 +23,11 @@ object GoAuthServiceGenerator extends AuthServiceGenerator {
         GoAuthServiceMainGenerator.generateHandlers(),
         GoAuthServiceMainGenerator.generateCreateToken(),
       ),
+      File("auth", "setup.go") -> mkCode.doubleLines(
+        GoCommonGenerator.generatePackage("main"),
+        GoCommonSetupGenerator.generateImports,
+        GoCommonSetupGenerator.generateSetupMethod,
+      ),
       File("auth", "hook.go") -> mkCode.doubleLines(
         GoCommonGenerator.generatePackage("main"),
         GoCommonHookGenerator.generateImports(root.module),

--- a/src/main/scala/temple/generate/server/go/common/GoCommonMainGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/common/GoCommonMainGenerator.scala
@@ -72,10 +72,14 @@ object GoCommonMainGenerator {
           "env",
         ),
         "",
+        "// Call into non-generated entry-point",
+        genDeclareAndAssign(genFunctionCall("defaultRouter", "&env"), "router"),
+        genMethodCall("env", "setup", "router"),
+        "",
         genMethodCall(
           "log",
           "Fatal",
-          genMethodCall("http", "ListenAndServe", doubleQuote(s":$port"), genMethodCall("env", "router")),
+          genMethodCall("http", "ListenAndServe", doubleQuote(s":$port"), "router"),
         ),
       ),
     )

--- a/src/main/scala/temple/generate/server/go/common/GoCommonSetupGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/common/GoCommonSetupGenerator.scala
@@ -1,0 +1,20 @@
+package temple.generate.server.go.common
+
+import temple.generate.utils.CodeTerm.mkCode
+import temple.utils.StringUtils
+
+object GoCommonSetupGenerator {
+
+  def generateImports: String =
+    mkCode("import", StringUtils.doubleQuote("github.com/gorilla/mux"))
+
+  def generateSetupMethod: String =
+    GoCommonGenerator.genMethod(
+      objectName = "env",
+      objectType = "*env",
+      methodName = "setup",
+      methodArgs = Seq("router *mux.Router"),
+      methodReturn = None,
+      methodBody = "// Add user defined code here",
+    )
+}

--- a/src/main/scala/temple/generate/server/go/service/GoServiceGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/GoServiceGenerator.scala
@@ -60,6 +60,11 @@ object GoServiceGenerator extends ServiceGenerator {
         GoServiceMainHandlersGenerator
           .generateHandlers(root, operations, clientAttributes, usesComms, enumeratingByCreator),
       ),
+      File(root.kebabName, "setup.go") -> mkCode.doubleLines(
+        GoCommonGenerator.generatePackage("main"),
+        GoCommonSetupGenerator.generateImports,
+        GoCommonSetupGenerator.generateSetupMethod,
+      ),
       File(root.kebabName, "hook.go") -> mkCode.doubleLines(
         GoCommonGenerator.generatePackage("main"),
         GoCommonHookGenerator.generateImports(root.module),

--- a/src/main/scala/temple/generate/server/go/service/main/GoServiceMainGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/main/GoServiceMainGenerator.scala
@@ -57,9 +57,9 @@ object GoServiceMainGenerator {
         }
 
     mkCode.lines(
-      "// router generates a router for this service",
+      "// defaultRouter generates a router for this service",
       mkCode(
-        "func (env *env) router() *mux.Router",
+        "func defaultRouter(env *env) *mux.Router",
         CodeWrap.curly.tabbed(
           genDeclareAndAssign("mux.NewRouter()", "r"),
           "// Mux directs to first matching route, i.e. the order matters",

--- a/src/test/resources/project-builder-complex/auth/auth.go
+++ b/src/test/resources/project-builder-complex/auth/auth.go
@@ -48,8 +48,8 @@ type loginAuthResponse struct {
 	AccessToken string
 }
 
-// router generates a router for this service
-func (env *env) router() *mux.Router {
+// defaultRouter generates a router for this service
+func defaultRouter(env *env) *mux.Router {
 	r := mux.NewRouter()
 	r.HandleFunc("/auth/register", env.registerAuthHandler).Methods(http.MethodPost)
 	r.HandleFunc("/auth/login", env.loginAuthHandler).Methods(http.MethodPost)
@@ -83,7 +83,11 @@ func main() {
 
 	env := env{d, c, jwtCredential}
 
-	log.Fatal(http.ListenAndServe(":1024", env.router()))
+	// Call into non-generated entry-point
+	router := defaultRouter(&env)
+	env.setup(router)
+
+	log.Fatal(http.ListenAndServe(":1024", router))
 }
 
 func jsonMiddleware(next http.Handler) http.Handler {

--- a/src/test/resources/project-builder-complex/auth/setup.go
+++ b/src/test/resources/project-builder-complex/auth/setup.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/gorilla/mux"
+
+func (env *env) setup(router *mux.Router) {
+	// Add user defined code here
+}

--- a/src/test/resources/project-builder-complex/complex-user/complex-user.go
+++ b/src/test/resources/project-builder-complex/complex-user/complex-user.go
@@ -104,8 +104,8 @@ type updateComplexUserResponse struct {
 	BlobField          string    `json:"blobField"`
 }
 
-// router generates a router for this service
-func (env *env) router() *mux.Router {
+// defaultRouter generates a router for this service
+func defaultRouter(env *env) *mux.Router {
 	r := mux.NewRouter()
 	// Mux directs to first matching route, i.e. the order matters
 	r.HandleFunc("/complex-user", env.createComplexUserHandler).Methods(http.MethodPost)
@@ -135,7 +135,11 @@ func main() {
 
 	env := env{d}
 
-	log.Fatal(http.ListenAndServe(":1026", env.router()))
+	// Call into non-generated entry-point
+	router := defaultRouter(&env)
+	env.setup(router)
+
+	log.Fatal(http.ListenAndServe(":1026", router))
 }
 
 func jsonMiddleware(next http.Handler) http.Handler {

--- a/src/test/resources/project-builder-complex/complex-user/setup.go
+++ b/src/test/resources/project-builder-complex/complex-user/setup.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/gorilla/mux"
+
+func (env *env) setup(router *mux.Router) {
+	// Add user defined code here
+}

--- a/src/test/resources/project-builder-simple/temple-user/setup.go
+++ b/src/test/resources/project-builder-simple/temple-user/setup.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/gorilla/mux"
+
+func (env *env) setup(router *mux.Router) {
+	// Add user defined code here
+}

--- a/src/test/resources/project-builder-simple/temple-user/temple-user.go
+++ b/src/test/resources/project-builder-simple/temple-user/temple-user.go
@@ -84,8 +84,8 @@ type updateTempleUserResponse struct {
 	BlobField     string    `json:"blobField"`
 }
 
-// router generates a router for this service
-func (env *env) router() *mux.Router {
+// defaultRouter generates a router for this service
+func defaultRouter(env *env) *mux.Router {
 	r := mux.NewRouter()
 	// Mux directs to first matching route, i.e. the order matters
 	r.HandleFunc("/temple-user", env.createTempleUserHandler).Methods(http.MethodPost)
@@ -115,7 +115,11 @@ func main() {
 
 	env := env{d}
 
-	log.Fatal(http.ListenAndServe(":1026", env.router()))
+	// Call into non-generated entry-point
+	router := defaultRouter(&env)
+	env.setup(router)
+
+	log.Fatal(http.ListenAndServe(":1026", router))
 }
 
 func jsonMiddleware(next http.Handler) http.Handler {

--- a/src/test/scala/temple/generate/server/go/GoAuthServiceGeneratorTest.scala
+++ b/src/test/scala/temple/generate/server/go/GoAuthServiceGeneratorTest.scala
@@ -1,6 +1,7 @@
-package temple.generate.server.go.auth
+package temple.generate.server.go
 
 import org.scalatest.{FlatSpec, Matchers}
+import temple.generate.server.go.auth.GoAuthServiceGenerator
 
 class GoAuthServiceGeneratorTest extends FlatSpec with Matchers {
 

--- a/src/test/scala/temple/generate/server/go/GoAuthServiceGeneratorTestData.scala
+++ b/src/test/scala/temple/generate/server/go/GoAuthServiceGeneratorTestData.scala
@@ -1,4 +1,4 @@
-package temple.generate.server.go.auth
+package temple.generate.server.go
 
 import temple.ast.AttributeType
 import temple.ast.Metadata.ServiceAuth
@@ -18,9 +18,10 @@ object GoAuthServiceGeneratorTestData {
   )
 
   val authServiceFiles: Files = Map(
-    File("auth", "go.mod")  -> readFile("src/test/scala/temple/generate/server/go/testfiles/auth/go.mod.snippet"),
-    File("auth", "auth.go") -> readFile("src/test/scala/temple/generate/server/go/testfiles/auth/auth.go.snippet"),
-    File("auth", "hook.go") -> readFile("src/test/scala/temple/generate/server/go/testfiles/auth/hook.go.snippet"),
+    File("auth", "go.mod")   -> readFile("src/test/scala/temple/generate/server/go/testfiles/auth/go.mod.snippet"),
+    File("auth", "auth.go")  -> readFile("src/test/scala/temple/generate/server/go/testfiles/auth/auth.go.snippet"),
+    File("auth", "setup.go") -> readFile("src/test/scala/temple/generate/server/go/testfiles/auth/setup.go.snippet"),
+    File("auth", "hook.go")  -> readFile("src/test/scala/temple/generate/server/go/testfiles/auth/hook.go.snippet"),
     File("auth/dao", "errors.go") -> readFile(
       "src/test/scala/temple/generate/server/go/testfiles/auth/dao/errors.go.snippet",
     ),

--- a/src/test/scala/temple/generate/server/go/GoServiceGeneratorTestData.scala
+++ b/src/test/scala/temple/generate/server/go/GoServiceGeneratorTestData.scala
@@ -39,7 +39,8 @@ object GoServiceGeneratorTestData {
     File("user", "user.go") -> readFile(
       "src/test/scala/temple/generate/server/go/testfiles/user/user.go.snippet",
     ),
-    File("user", "hook.go") -> readFile("src/test/scala/temple/generate/server/go/testfiles/user/hook.go.snippet"),
+    File("user", "setup.go") -> readFile("src/test/scala/temple/generate/server/go/testfiles/user/setup.go.snippet"),
+    File("user", "hook.go")  -> readFile("src/test/scala/temple/generate/server/go/testfiles/user/hook.go.snippet"),
     File("user/dao", "errors.go") -> readFile(
       "src/test/scala/temple/generate/server/go/testfiles/user/dao/errors.go.snippet",
     ),
@@ -89,7 +90,8 @@ object GoServiceGeneratorTestData {
     File("match", "match.go") -> readFile(
       "src/test/scala/temple/generate/server/go/testfiles/match/match.go.snippet",
     ),
-    File("match", "hook.go") -> readFile("src/test/scala/temple/generate/server/go/testfiles/match/hook.go.snippet"),
+    File("match", "setup.go") -> readFile("src/test/scala/temple/generate/server/go/testfiles/match/setup.go.snippet"),
+    File("match", "hook.go")  -> readFile("src/test/scala/temple/generate/server/go/testfiles/match/hook.go.snippet"),
     File("match/dao", "errors.go") -> readFile(
       "src/test/scala/temple/generate/server/go/testfiles/match/dao/errors.go.snippet",
     ),

--- a/src/test/scala/temple/generate/server/go/testfiles/auth/auth.go.snippet
+++ b/src/test/scala/temple/generate/server/go/testfiles/auth/auth.go.snippet
@@ -48,8 +48,8 @@ type loginAuthResponse struct {
 	AccessToken string
 }
 
-// router generates a router for this service
-func (env *env) router() *mux.Router {
+// defaultRouter generates a router for this service
+func defaultRouter(env *env) *mux.Router {
 	r := mux.NewRouter()
 	r.HandleFunc("/auth/register", env.registerAuthHandler).Methods(http.MethodPost)
 	r.HandleFunc("/auth/login", env.loginAuthHandler).Methods(http.MethodPost)
@@ -83,7 +83,11 @@ func main() {
 
 	env := env{d, c, jwtCredential}
 
-	log.Fatal(http.ListenAndServe(":82", env.router()))
+	// Call into non-generated entry-point
+	router := defaultRouter(&env)
+	env.setup(router)
+
+	log.Fatal(http.ListenAndServe(":82", router))
 }
 
 func jsonMiddleware(next http.Handler) http.Handler {

--- a/src/test/scala/temple/generate/server/go/testfiles/auth/setup.go.snippet
+++ b/src/test/scala/temple/generate/server/go/testfiles/auth/setup.go.snippet
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/gorilla/mux"
+
+func (env *env) setup(router *mux.Router) {
+	// Add user defined code here
+}

--- a/src/test/scala/temple/generate/server/go/testfiles/match/match.go.snippet
+++ b/src/test/scala/temple/generate/server/go/testfiles/match/match.go.snippet
@@ -71,8 +71,8 @@ type updateMatchResponse struct {
 	MatchedOn string    `json:"matchedOn"`
 }
 
-// router generates a router for this service
-func (env *env) router() *mux.Router {
+// defaultRouter generates a router for this service
+func defaultRouter(env *env) *mux.Router {
 	r := mux.NewRouter()
 	// Mux directs to first matching route, i.e. the order matters
 	r.HandleFunc("/match/all", env.listMatchHandler).Methods(http.MethodGet)
@@ -105,7 +105,11 @@ func main() {
 
 	env := env{d, c}
 
-	log.Fatal(http.ListenAndServe(":81", env.router()))
+	// Call into non-generated entry-point
+	router := defaultRouter(&env)
+	env.setup(router)
+
+	log.Fatal(http.ListenAndServe(":81", router))
 }
 
 func jsonMiddleware(next http.Handler) http.Handler {

--- a/src/test/scala/temple/generate/server/go/testfiles/match/setup.go.snippet
+++ b/src/test/scala/temple/generate/server/go/testfiles/match/setup.go.snippet
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/gorilla/mux"
+
+func (env *env) setup(router *mux.Router) {
+	// Add user defined code here
+}

--- a/src/test/scala/temple/generate/server/go/testfiles/user/setup.go.snippet
+++ b/src/test/scala/temple/generate/server/go/testfiles/user/setup.go.snippet
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/gorilla/mux"
+
+func (env *env) setup(router *mux.Router) {
+	// Add user defined code here
+}

--- a/src/test/scala/temple/generate/server/go/testfiles/user/user.go.snippet
+++ b/src/test/scala/temple/generate/server/go/testfiles/user/user.go.snippet
@@ -47,8 +47,8 @@ type updateUserResponse struct {
 	Name string    `json:"name"`
 }
 
-// router generates a router for this service
-func (env *env) router() *mux.Router {
+// defaultRouter generates a router for this service
+func defaultRouter(env *env) *mux.Router {
 	r := mux.NewRouter()
 	// Mux directs to first matching route, i.e. the order matters
 	r.HandleFunc("/user", env.createUserHandler).Methods(http.MethodPost)
@@ -78,7 +78,11 @@ func main() {
 
 	env := env{d}
 
-	log.Fatal(http.ListenAndServe(":80", env.router()))
+	// Call into non-generated entry-point
+	router := defaultRouter(&env)
+	env.setup(router)
+
+	log.Fatal(http.ListenAndServe(":80", router))
 }
 
 func jsonMiddleware(next http.Handler) http.Handler {


### PR DESCRIPTION
This PR does 2 main things:
- Add `setup.go`, which includes a `setup` function for users to add their own hooks / logic / routes etc.
- Refactor the router so it is no longer defined on the environment, instead it is returned and passed to the user for modification

### Test Plan
- Existing integration tests cover that the code complies and endpoints still produce correct responses