### PR TITLE
[go-gen] Extract DAO input to separate variable

### DIFF
--- a/src/e2e/resources/simple-temple-expected/booking/booking.go
+++ b/src/e2e/resources/simple-temple-expected/booking/booking.go
@@ -75,9 +75,10 @@ func jsonMiddleware(next http.Handler) http.Handler {
 }
 
 func checkAuthorization(env *env, bookingID uuid.UUID, auth *util.Auth) (bool, error) {
-	booking, err := env.dao.ReadBooking(dao.ReadBookingInput{
+	input := dao.ReadBookingInput{
 		ID: bookingID,
-	})
+	}
+	booking, err := env.dao.ReadBooking(input)
 	if err != nil {
 		return false, err
 	}
@@ -99,10 +100,12 @@ func (env *env) createBookingHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	booking, err := env.dao.CreateBooking(dao.CreateBookingInput{
+	input := dao.CreateBookingInput{
 		ID:     uuid,
 		AuthID: auth.ID,
-	})
+	}
+
+	booking, err := env.dao.CreateBooking(input)
 	if err != nil {
 		errMsg := util.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))
 		http.Error(w, errMsg, http.StatusInternalServerError)
@@ -146,9 +149,11 @@ func (env *env) readBookingHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	booking, err := env.dao.ReadBooking(dao.ReadBookingInput{
+	input := dao.ReadBookingInput{
 		ID: bookingID,
-	})
+	}
+
+	booking, err := env.dao.ReadBooking(input)
 	if err != nil {
 		switch err.(type) {
 		case dao.ErrBookingNotFound:
@@ -197,9 +202,11 @@ func (env *env) deleteBookingHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = env.dao.DeleteBooking(dao.DeleteBookingInput{
+	input := dao.DeleteBookingInput{
 		ID: bookingID,
-	})
+	}
+
+	err = env.dao.DeleteBooking(input)
 	if err != nil {
 		switch err.(type) {
 		case dao.ErrBookingNotFound:

--- a/src/e2e/resources/simple-temple-expected/simple-temple-test-group/simple-temple-test-group.go
+++ b/src/e2e/resources/simple-temple-expected/simple-temple-test-group/simple-temple-test-group.go
@@ -75,9 +75,10 @@ func jsonMiddleware(next http.Handler) http.Handler {
 }
 
 func checkAuthorization(env *env, simpleTempleTestGroupID uuid.UUID, auth *util.Auth) (bool, error) {
-	simpleTempleTestGroup, err := env.dao.ReadSimpleTempleTestGroup(dao.ReadSimpleTempleTestGroupInput{
+	input := dao.ReadSimpleTempleTestGroupInput{
 		ID: simpleTempleTestGroupID,
-	})
+	}
+	simpleTempleTestGroup, err := env.dao.ReadSimpleTempleTestGroup(input)
 	if err != nil {
 		return false, err
 	}
@@ -99,10 +100,12 @@ func (env *env) createSimpleTempleTestGroupHandler(w http.ResponseWriter, r *htt
 		return
 	}
 
-	simpleTempleTestGroup, err := env.dao.CreateSimpleTempleTestGroup(dao.CreateSimpleTempleTestGroupInput{
+	input := dao.CreateSimpleTempleTestGroupInput{
 		ID:     uuid,
 		AuthID: auth.ID,
-	})
+	}
+
+	simpleTempleTestGroup, err := env.dao.CreateSimpleTempleTestGroup(input)
 	if err != nil {
 		errMsg := util.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))
 		http.Error(w, errMsg, http.StatusInternalServerError)
@@ -146,9 +149,11 @@ func (env *env) readSimpleTempleTestGroupHandler(w http.ResponseWriter, r *http.
 		return
 	}
 
-	simpleTempleTestGroup, err := env.dao.ReadSimpleTempleTestGroup(dao.ReadSimpleTempleTestGroupInput{
+	input := dao.ReadSimpleTempleTestGroupInput{
 		ID: simpleTempleTestGroupID,
-	})
+	}
+
+	simpleTempleTestGroup, err := env.dao.ReadSimpleTempleTestGroup(input)
 	if err != nil {
 		switch err.(type) {
 		case dao.ErrSimpleTempleTestGroupNotFound:
@@ -197,9 +202,11 @@ func (env *env) deleteSimpleTempleTestGroupHandler(w http.ResponseWriter, r *htt
 		return
 	}
 
-	err = env.dao.DeleteSimpleTempleTestGroup(dao.DeleteSimpleTempleTestGroupInput{
+	input := dao.DeleteSimpleTempleTestGroupInput{
 		ID: simpleTempleTestGroupID,
-	})
+	}
+
+	err = env.dao.DeleteSimpleTempleTestGroup(input)
 	if err != nil {
 		switch err.(type) {
 		case dao.ErrSimpleTempleTestGroupNotFound:

--- a/src/e2e/resources/simple-temple-expected/simple-temple-test-user/simple-temple-test-user.go
+++ b/src/e2e/resources/simple-temple-expected/simple-temple-test-user/simple-temple-test-user.go
@@ -233,7 +233,7 @@ func (env *env) createSimpleTempleTestUserHandler(w http.ResponseWriter, r *http
 		return
 	}
 
-	simpleTempleTestUser, err := env.dao.CreateSimpleTempleTestUser(dao.CreateSimpleTempleTestUserInput{
+	input := dao.CreateSimpleTempleTestUserInput{
 		ID:                   auth.ID,
 		SimpleTempleTestUser: *req.SimpleTempleTestUser,
 		Email:                *req.Email,
@@ -244,7 +244,9 @@ func (env *env) createSimpleTempleTestUserHandler(w http.ResponseWriter, r *http
 		CurrentBankBalance:   *req.CurrentBankBalance,
 		BirthDate:            birthDate,
 		BreakfastTime:        breakfastTime,
-	})
+	}
+
+	simpleTempleTestUser, err := env.dao.CreateSimpleTempleTestUser(input)
 	if err != nil {
 		errMsg := util.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))
 		http.Error(w, errMsg, http.StatusInternalServerError)
@@ -279,9 +281,11 @@ func (env *env) readSimpleTempleTestUserHandler(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	simpleTempleTestUser, err := env.dao.ReadSimpleTempleTestUser(dao.ReadSimpleTempleTestUserInput{
+	input := dao.ReadSimpleTempleTestUserInput{
 		ID: simpleTempleTestUserID,
-	})
+	}
+
+	simpleTempleTestUser, err := env.dao.ReadSimpleTempleTestUser(input)
 	if err != nil {
 		switch err.(type) {
 		case dao.ErrSimpleTempleTestUserNotFound:
@@ -369,7 +373,7 @@ func (env *env) updateSimpleTempleTestUserHandler(w http.ResponseWriter, r *http
 		return
 	}
 
-	simpleTempleTestUser, err := env.dao.UpdateSimpleTempleTestUser(dao.UpdateSimpleTempleTestUserInput{
+	input := dao.UpdateSimpleTempleTestUserInput{
 		ID:                   simpleTempleTestUserID,
 		SimpleTempleTestUser: *req.SimpleTempleTestUser,
 		Email:                *req.Email,
@@ -380,7 +384,9 @@ func (env *env) updateSimpleTempleTestUserHandler(w http.ResponseWriter, r *http
 		CurrentBankBalance:   *req.CurrentBankBalance,
 		BirthDate:            birthDate,
 		BreakfastTime:        breakfastTime,
-	})
+	}
+
+	simpleTempleTestUser, err := env.dao.UpdateSimpleTempleTestUser(input)
 	if err != nil {
 		switch err.(type) {
 		case dao.ErrSimpleTempleTestUserNotFound:

--- a/src/main/scala/temple/generate/server/go/service/main/GoServiceMainDeleteHandlerGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/main/GoServiceMainDeleteHandlerGenerator.scala
@@ -1,5 +1,6 @@
 package temple.generate.server.go.service.main
 
+import temple.ast.AbstractAttribute
 import temple.ast.Metadata.Writable
 import temple.generate.CRUD.Delete
 import temple.generate.server.ServiceRoot
@@ -12,13 +13,19 @@ import scala.collection.immutable.ListMap
 
 object GoServiceMainDeleteHandlerGenerator {
 
+  private def generateDAOInput(root: ServiceRoot): String =
+    genDeclareAndAssign(
+      genPopulateStruct(s"dao.Delete${root.name}Input", ListMap("ID" -> s"${root.decapitalizedName}ID")),
+      "input",
+    )
+
   private def generateDAOCallBlock(root: ServiceRoot): String =
     mkCode.lines(
       genAssign(
         genMethodCall(
           "env.dao",
           s"Delete${root.name}",
-          genPopulateStruct(s"dao.Delete${root.name}Input", ListMap("ID" -> s"${root.decapitalizedName}ID")),
+          "input",
         ),
         "err",
       ),
@@ -34,6 +41,7 @@ object GoServiceMainDeleteHandlerGenerator {
           when(root.projectUsesAuth) { generateExtractAuthBlock(root.writable == Writable.This) },
           generateExtractIDBlock(root.decapitalizedName),
           when(root.writable == Writable.This) { generateCheckAuthorizationBlock(root) },
+          generateDAOInput(root),
           generateDAOCallBlock(root),
           genMethodCall(genMethodCall("json", "NewEncoder", "w"), "Encode", "struct{}{}"),
         ),

--- a/src/main/scala/temple/generate/server/go/service/main/GoServiceMainGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/main/GoServiceMainGenerator.scala
@@ -71,12 +71,18 @@ object GoServiceMainGenerator {
     )
   }
 
+  private[main] def generateDAOReadInput(root: ServiceRoot): String =
+    genDeclareAndAssign(
+      genPopulateStruct(s"dao.Read${root.name}Input", ListMap("ID" -> s"${root.decapitalizedName}ID")),
+      "input",
+    )
+
   private[main] def generateDAOReadCall(root: ServiceRoot): String =
     genDeclareAndAssign(
       genMethodCall(
         "env.dao",
         s"Read${root.name}",
-        genPopulateStruct(s"dao.Read${root.name}Input", ListMap("ID" -> s"${root.decapitalizedName}ID")),
+        "input",
       ),
       root.decapitalizedName,
       "err",
@@ -88,6 +94,7 @@ object GoServiceMainGenerator {
       Seq("env *env", s"${root.decapitalizedName}ID uuid.UUID", "auth *util.Auth"),
       Some(CodeWrap.parens(mkCode.list("bool", "error"))),
       mkCode.lines(
+        generateDAOReadInput(root),
         generateDAOReadCall(root),
         genCheckAndReturnError("false"),
         genReturn(s"${root.decapitalizedName}.CreatedBy == auth.ID", "nil"),

--- a/src/main/scala/temple/generate/server/go/service/main/GoServiceMainListHandlerGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/main/GoServiceMainListHandlerGenerator.scala
@@ -18,6 +18,16 @@ object GoServiceMainListHandlerGenerator {
     responseMap: ListMap[String, String],
     enumeratingByCreator: Boolean,
   ): String = {
+    val queryDAOInputBlock = when(enumeratingByCreator) {
+      genDeclareAndAssign(
+        genPopulateStruct(
+          s"dao.List${root.name}Input",
+          ListMap(s"AuthID" -> "auth.ID"),
+        ),
+        "input",
+      )
+    }
+
     // Fetch list from DAO
     val queryDAOBlock =
       genDeclareAndAssign(
@@ -25,10 +35,7 @@ object GoServiceMainListHandlerGenerator {
           "env.dao",
           s"List${root.name}",
           when(enumeratingByCreator) {
-            genPopulateStruct(
-              s"dao.List${root.name}Input",
-              ListMap(s"AuthID" -> "auth.ID"),
-            )
+            "input"
           },
         ),
         s"${root.decapitalizedName}List",
@@ -76,9 +83,12 @@ object GoServiceMainListHandlerGenerator {
       CodeWrap.curly.tabbed(
         mkCode.doubleLines(
           when(enumeratingByCreator) { generateExtractAuthBlock(usesVar = true) },
-          mkCode.lines(
-            queryDAOBlock,
-            queryDAOErrorBlock,
+          mkCode.doubleLines(
+            queryDAOInputBlock,
+            mkCode.lines(
+              queryDAOBlock,
+              queryDAOErrorBlock,
+            ),
           ),
           instantiateResponseBlock,
           mapResponseBlock,

--- a/src/main/scala/temple/generate/server/go/service/main/GoServiceMainReadHandlerGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/main/GoServiceMainReadHandlerGenerator.scala
@@ -3,7 +3,7 @@ package temple.generate.server.go.service.main
 import temple.ast.Metadata.Readable
 import temple.generate.CRUD.Read
 import temple.generate.server.ServiceRoot
-import temple.generate.server.go.service.main.GoServiceMainGenerator.generateDAOReadCall
+import temple.generate.server.go.service.main.GoServiceMainGenerator.{generateDAOReadCall, generateDAOReadInput}
 import temple.generate.server.go.service.main.GoServiceMainHandlersGenerator._
 import temple.generate.utils.CodeTerm.{CodeWrap, mkCode}
 
@@ -13,9 +13,12 @@ import scala.collection.immutable.ListMap
 object GoServiceMainReadHandlerGenerator {
 
   private def generateDAOCallBlock(root: ServiceRoot): String =
-    mkCode.lines(
-      generateDAOReadCall(root),
-      generateDAOCallErrorBlock(root),
+    mkCode.doubleLines(
+      generateDAOReadInput(root),
+      mkCode.lines(
+        generateDAOReadCall(root),
+        generateDAOCallErrorBlock(root),
+      ),
     )
 
   /** Generate the read handler function */

--- a/src/test/resources/project-builder-complex/complex-user/complex-user.go
+++ b/src/test/resources/project-builder-complex/complex-user/complex-user.go
@@ -200,7 +200,7 @@ func (env *env) createComplexUserHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	complexUser, err := env.dao.CreateComplexUser(dao.CreateComplexUserInput{
+	input := dao.CreateComplexUserInput{
 		ID:                 auth.ID,
 		SmallIntField:      *req.SmallIntField,
 		IntField:           *req.IntField,
@@ -214,7 +214,9 @@ func (env *env) createComplexUserHandler(w http.ResponseWriter, r *http.Request)
 		TimeField:          timeField,
 		DateTimeField:      dateTimeField,
 		BlobField:          *req.BlobField,
-	})
+	}
+
+	complexUser, err := env.dao.CreateComplexUser(input)
 	if err != nil {
 		errMsg := util.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))
 		http.Error(w, errMsg, http.StatusInternalServerError)
@@ -258,9 +260,11 @@ func (env *env) readComplexUserHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	complexUser, err := env.dao.ReadComplexUser(dao.ReadComplexUserInput{
+	input := dao.ReadComplexUserInput{
 		ID: complexUserID,
-	})
+	}
+
+	complexUser, err := env.dao.ReadComplexUser(input)
 	if err != nil {
 		switch err.(type) {
 		case dao.ErrComplexUserNotFound:
@@ -351,7 +355,7 @@ func (env *env) updateComplexUserHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	complexUser, err := env.dao.UpdateComplexUser(dao.UpdateComplexUserInput{
+	input := dao.UpdateComplexUserInput{
 		ID:                 complexUserID,
 		SmallIntField:      *req.SmallIntField,
 		IntField:           *req.IntField,
@@ -365,7 +369,9 @@ func (env *env) updateComplexUserHandler(w http.ResponseWriter, r *http.Request)
 		TimeField:          timeField,
 		DateTimeField:      dateTimeField,
 		BlobField:          *req.BlobField,
-	})
+	}
+
+	complexUser, err := env.dao.UpdateComplexUser(input)
 	if err != nil {
 		switch err.(type) {
 		case dao.ErrComplexUserNotFound:
@@ -414,9 +420,11 @@ func (env *env) deleteComplexUserHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	err = env.dao.DeleteComplexUser(dao.DeleteComplexUserInput{
+	input := dao.DeleteComplexUserInput{
 		ID: complexUserID,
-	})
+	}
+
+	err = env.dao.DeleteComplexUser(input)
 	if err != nil {
 		switch err.(type) {
 		case dao.ErrComplexUserNotFound:

--- a/src/test/resources/project-builder-simple/temple-user/temple-user.go
+++ b/src/test/resources/project-builder-simple/temple-user/temple-user.go
@@ -180,7 +180,7 @@ func (env *env) createTempleUserHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	templeUser, err := env.dao.CreateTempleUser(dao.CreateTempleUserInput{
+	input := dao.CreateTempleUserInput{
 		ID:            uuid,
 		IntField:      *req.IntField,
 		DoubleField:   *req.DoubleField,
@@ -190,7 +190,9 @@ func (env *env) createTempleUserHandler(w http.ResponseWriter, r *http.Request) 
 		TimeField:     timeField,
 		DateTimeField: dateTimeField,
 		BlobField:     *req.BlobField,
-	})
+	}
+
+	templeUser, err := env.dao.CreateTempleUser(input)
 	if err != nil {
 		errMsg := util.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))
 		http.Error(w, errMsg, http.StatusInternalServerError)
@@ -217,9 +219,11 @@ func (env *env) readTempleUserHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	templeUser, err := env.dao.ReadTempleUser(dao.ReadTempleUserInput{
+	input := dao.ReadTempleUserInput{
 		ID: templeUserID,
-	})
+	}
+
+	templeUser, err := env.dao.ReadTempleUser(input)
 	if err != nil {
 		switch err.(type) {
 		case dao.ErrTempleUserNotFound:
@@ -293,7 +297,7 @@ func (env *env) updateTempleUserHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	templeUser, err := env.dao.UpdateTempleUser(dao.UpdateTempleUserInput{
+	input := dao.UpdateTempleUserInput{
 		ID:            templeUserID,
 		IntField:      *req.IntField,
 		DoubleField:   *req.DoubleField,
@@ -303,7 +307,9 @@ func (env *env) updateTempleUserHandler(w http.ResponseWriter, r *http.Request) 
 		TimeField:     timeField,
 		DateTimeField: dateTimeField,
 		BlobField:     *req.BlobField,
-	})
+	}
+
+	templeUser, err := env.dao.UpdateTempleUser(input)
 	if err != nil {
 		switch err.(type) {
 		case dao.ErrTempleUserNotFound:
@@ -335,9 +341,11 @@ func (env *env) deleteTempleUserHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	err = env.dao.DeleteTempleUser(dao.DeleteTempleUserInput{
+	input := dao.DeleteTempleUserInput{
 		ID: templeUserID,
-	})
+	}
+
+	err = env.dao.DeleteTempleUser(input)
 	if err != nil {
 		switch err.(type) {
 		case dao.ErrTempleUserNotFound:

--- a/src/test/scala/temple/generate/server/go/testfiles/match/match.go.snippet
+++ b/src/test/scala/temple/generate/server/go/testfiles/match/match.go.snippet
@@ -121,9 +121,10 @@ func jsonMiddleware(next http.Handler) http.Handler {
 }
 
 func checkAuthorization(env *env, matchID uuid.UUID, auth *util.Auth) (bool, error) {
-	match, err := env.dao.ReadMatch(dao.ReadMatchInput{
+	input := dao.ReadMatchInput{
 		ID: matchID,
-	})
+	}
+	match, err := env.dao.ReadMatch(input)
 	if err != nil {
 		return false, err
 	}
@@ -138,9 +139,11 @@ func (env *env) listMatchHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	matchList, err := env.dao.ListMatch(dao.ListMatchInput{
+	input := dao.ListMatchInput{
 		AuthID: auth.ID,
-	})
+	}
+
+	matchList, err := env.dao.ListMatch(input)
 	if err != nil {
 		errMsg := util.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))
 		http.Error(w, errMsg, http.StatusInternalServerError)
@@ -223,12 +226,14 @@ func (env *env) createMatchHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	match, err := env.dao.CreateMatch(dao.CreateMatchInput{
+	input := dao.CreateMatchInput{
 		ID:      uuid,
 		AuthID:  auth.ID,
 		UserOne: *req.UserOne,
 		UserTwo: *req.UserTwo,
-	})
+	}
+
+	match, err := env.dao.CreateMatch(input)
 	if err != nil {
 		errMsg := util.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))
 		http.Error(w, errMsg, http.StatusInternalServerError)
@@ -275,9 +280,11 @@ func (env *env) readMatchHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	match, err := env.dao.ReadMatch(dao.ReadMatchInput{
+	input := dao.ReadMatchInput{
 		ID: matchID,
-	})
+	}
+
+	match, err := env.dao.ReadMatch(input)
 	if err != nil {
 		switch err.(type) {
 		case dao.ErrMatchNotFound:
@@ -374,11 +381,13 @@ func (env *env) updateMatchHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	match, err := env.dao.UpdateMatch(dao.UpdateMatchInput{
+	input := dao.UpdateMatchInput{
 		ID:      matchID,
 		UserOne: *req.UserOne,
 		UserTwo: *req.UserTwo,
-	})
+	}
+
+	match, err := env.dao.UpdateMatch(input)
 	if err != nil {
 		switch err.(type) {
 		case dao.ErrMatchNotFound:
@@ -430,9 +439,11 @@ func (env *env) deleteMatchHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = env.dao.DeleteMatch(dao.DeleteMatchInput{
+	input := dao.DeleteMatchInput{
 		ID: matchID,
-	})
+	}
+
+	err = env.dao.DeleteMatch(input)
 	if err != nil {
 		switch err.(type) {
 		case dao.ErrMatchNotFound:

--- a/src/test/scala/temple/generate/server/go/testfiles/user/user.go.snippet
+++ b/src/test/scala/temple/generate/server/go/testfiles/user/user.go.snippet
@@ -122,10 +122,12 @@ func (env *env) createUserHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	user, err := env.dao.CreateUser(dao.CreateUserInput{
+	input := dao.CreateUserInput{
 		ID:   auth.ID,
 		Name: *req.Name,
-	})
+	}
+
+	user, err := env.dao.CreateUser(input)
 	if err != nil {
 		errMsg := util.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))
 		http.Error(w, errMsg, http.StatusInternalServerError)
@@ -152,9 +154,11 @@ func (env *env) readUserHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	user, err := env.dao.ReadUser(dao.ReadUserInput{
+	input := dao.ReadUserInput{
 		ID: userID,
-	})
+	}
+
+	user, err := env.dao.ReadUser(input)
 	if err != nil {
 		switch err.(type) {
 		case dao.ErrUserNotFound:
@@ -213,10 +217,12 @@ func (env *env) updateUserHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	user, err := env.dao.UpdateUser(dao.UpdateUserInput{
+	input := dao.UpdateUserInput{
 		ID:   userID,
 		Name: *req.Name,
-	})
+	}
+
+	user, err := env.dao.UpdateUser(input)
 	if err != nil {
 		switch err.(type) {
 		case dao.ErrUserNotFound:
@@ -254,9 +260,11 @@ func (env *env) deleteUserHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = env.dao.DeleteUser(dao.DeleteUserInput{
+	input := dao.DeleteUserInput{
 		ID: userID,
-	})
+	}
+
+	err = env.dao.DeleteUser(input)
 	if err != nil {
 		switch err.(type) {
 		case dao.ErrUserNotFound:


### PR DESCRIPTION
Extract the DAO input into a separate variable.

This allows a hook call to be nicely squeezed in the middle (à la TempleEight/spec-golang#80)

This is currently only for non-auth services, will do auth next