### PR TITLE
[go-gen] Add generation of metric server instantiation in main, and refactor main gen

### DIFF
--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -2,7 +2,7 @@
 
 BASE_REPO_URL=jaylees/templeeight
 SERVICE="shell2http"
-SERVICE_VERSION="1.4.2"
+SERVICE_VERSION="1.4.3"
 REPO_URL=${BASE_REPO_URL}-${SERVICE}
 
 docker build -t $SERVICE -f $SERVICE.Dockerfile .

--- a/docker/shell2http.Dockerfile
+++ b/docker/shell2http.Dockerfile
@@ -33,6 +33,6 @@ COPY configure_go.py configure_go.py
 
 ENTRYPOINT /app/shell2http -show-errors\
  -form GET:/hadolint "echo \$v_dockerfile | ./jq-linux64 -r .contents > Dockerfile && hadolint Dockerfile"\
- GET:/go "python3 configure_go.py && cd \$v_root && go mod tidy &>/dev/null; go build -o output 2>&1"\
+ GET:/go "python3 configure_go.py && cd \$v_root && go mod tidy && go mod download &>/dev/null; go build -o output 2>&1"\
  GET:/swagger "echo \"\${v_openapi}\" | ./jq-linux64 -r .contents > openapi.yaml && swagger-cli validate openapi.yaml 2>&1"\
  GET:/kube "python3 configure_go.py && cd \$v_root; find . -name '*.yaml' | xargs kubeval 2>&1"

--- a/src/e2e/resources/simple-temple-expected/auth/auth.go
+++ b/src/e2e/resources/simple-temple-expected/auth/auth.go
@@ -12,11 +12,14 @@ import (
 
 	"github.com/squat/and/dab/auth/comm"
 	"github.com/squat/and/dab/auth/dao"
+	"github.com/squat/and/dab/auth/metric"
 	"github.com/squat/and/dab/auth/util"
 	valid "github.com/asaskevich/govalidator"
 	"github.com/dgrijalva/jwt-go"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 // env defines the environment that requests should be executed within
@@ -69,6 +72,16 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	// Prometheus metrics
+	promPort, ok := config.Ports["prometheus"]
+	if !ok {
+		log.Fatal("A port for the key prometheus was not found")
+	}
+	go func() {
+		http.Handle("/metrics", promhttp.Handler())
+		http.ListenAndServe(fmt.Sprintf(":%d", promPort), nil)
+	}()
 
 	d, err := dao.Init(config)
 	if err != nil {

--- a/src/e2e/resources/simple-temple-expected/auth/auth.go
+++ b/src/e2e/resources/simple-temple-expected/auth/auth.go
@@ -12,13 +12,11 @@ import (
 
 	"github.com/squat/and/dab/auth/comm"
 	"github.com/squat/and/dab/auth/dao"
-	"github.com/squat/and/dab/auth/metric"
 	"github.com/squat/and/dab/auth/util"
 	valid "github.com/asaskevich/govalidator"
 	"github.com/dgrijalva/jwt-go"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 

--- a/src/e2e/resources/simple-temple-expected/auth/util/util.go
+++ b/src/e2e/resources/simple-temple-expected/auth/util/util.go
@@ -12,6 +12,7 @@ type Config struct {
 	Host     string            `json:"host"`
 	SSLMode  string            `json:"sslMode"`
 	Services map[string]string `json:"services"`
+	Ports    map[string]int    `json:"ports"`
 }
 
 // GetConfig returns a configuration object from decoding the given configuration file

--- a/src/e2e/resources/simple-temple-expected/booking/booking.go
+++ b/src/e2e/resources/simple-temple-expected/booking/booking.go
@@ -8,12 +8,10 @@ import (
 	"net/http"
 
 	"github.com/squat/and/dab/booking/dao"
-	"github.com/squat/and/dab/booking/metric"
 	"github.com/squat/and/dab/booking/util"
 	valid "github.com/asaskevich/govalidator"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 

--- a/src/e2e/resources/simple-temple-expected/booking/booking.go
+++ b/src/e2e/resources/simple-temple-expected/booking/booking.go
@@ -8,10 +8,13 @@ import (
 	"net/http"
 
 	"github.com/squat/and/dab/booking/dao"
+	"github.com/squat/and/dab/booking/metric"
 	"github.com/squat/and/dab/booking/util"
 	valid "github.com/asaskevich/govalidator"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 // env defines the environment that requests should be executed within
@@ -52,6 +55,16 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	// Prometheus metrics
+	promPort, ok := config.Ports["prometheus"]
+	if !ok {
+		log.Fatal("A port for the key prometheus was not found")
+	}
+	go func() {
+		http.Handle("/metrics", promhttp.Handler())
+		http.ListenAndServe(fmt.Sprintf(":%d", promPort), nil)
+	}()
 
 	d, err := dao.Init(config)
 	if err != nil {

--- a/src/e2e/resources/simple-temple-expected/booking/util/util.go
+++ b/src/e2e/resources/simple-temple-expected/booking/util/util.go
@@ -18,6 +18,7 @@ type Config struct {
 	Host     string            `json:"host"`
 	SSLMode  string            `json:"sslMode"`
 	Services map[string]string `json:"services"`
+	Ports    map[string]int    `json:"ports"`
 }
 
 // Auth contains the unique identifier for a given auth

--- a/src/e2e/resources/simple-temple-expected/simple-temple-test-group/simple-temple-test-group.go
+++ b/src/e2e/resources/simple-temple-expected/simple-temple-test-group/simple-temple-test-group.go
@@ -8,12 +8,10 @@ import (
 	"net/http"
 
 	"github.com/squat/and/dab/simple-temple-test-group/dao"
-	"github.com/squat/and/dab/simple-temple-test-group/metric"
 	"github.com/squat/and/dab/simple-temple-test-group/util"
 	valid "github.com/asaskevich/govalidator"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 

--- a/src/e2e/resources/simple-temple-expected/simple-temple-test-group/simple-temple-test-group.go
+++ b/src/e2e/resources/simple-temple-expected/simple-temple-test-group/simple-temple-test-group.go
@@ -8,10 +8,13 @@ import (
 	"net/http"
 
 	"github.com/squat/and/dab/simple-temple-test-group/dao"
+	"github.com/squat/and/dab/simple-temple-test-group/metric"
 	"github.com/squat/and/dab/simple-temple-test-group/util"
 	valid "github.com/asaskevich/govalidator"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 // env defines the environment that requests should be executed within
@@ -52,6 +55,16 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	// Prometheus metrics
+	promPort, ok := config.Ports["prometheus"]
+	if !ok {
+		log.Fatal("A port for the key prometheus was not found")
+	}
+	go func() {
+		http.Handle("/metrics", promhttp.Handler())
+		http.ListenAndServe(fmt.Sprintf(":%d", promPort), nil)
+	}()
 
 	d, err := dao.Init(config)
 	if err != nil {

--- a/src/e2e/resources/simple-temple-expected/simple-temple-test-group/util/util.go
+++ b/src/e2e/resources/simple-temple-expected/simple-temple-test-group/util/util.go
@@ -18,6 +18,7 @@ type Config struct {
 	Host     string            `json:"host"`
 	SSLMode  string            `json:"sslMode"`
 	Services map[string]string `json:"services"`
+	Ports    map[string]int    `json:"ports"`
 }
 
 // Auth contains the unique identifier for a given auth

--- a/src/e2e/resources/simple-temple-expected/simple-temple-test-user/simple-temple-test-user.go
+++ b/src/e2e/resources/simple-temple-expected/simple-temple-test-user/simple-temple-test-user.go
@@ -9,10 +9,13 @@ import (
 	"time"
 
 	"github.com/squat/and/dab/simple-temple-test-user/dao"
+	"github.com/squat/and/dab/simple-temple-test-user/metric"
 	"github.com/squat/and/dab/simple-temple-test-user/util"
 	valid "github.com/asaskevich/govalidator"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 // env defines the environment that requests should be executed within
@@ -131,6 +134,16 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	// Prometheus metrics
+	promPort, ok := config.Ports["prometheus"]
+	if !ok {
+		log.Fatal("A port for the key prometheus was not found")
+	}
+	go func() {
+		http.Handle("/metrics", promhttp.Handler())
+		http.ListenAndServe(fmt.Sprintf(":%d", promPort), nil)
+	}()
 
 	d, err := dao.Init(config)
 	if err != nil {

--- a/src/e2e/resources/simple-temple-expected/simple-temple-test-user/simple-temple-test-user.go
+++ b/src/e2e/resources/simple-temple-expected/simple-temple-test-user/simple-temple-test-user.go
@@ -9,12 +9,10 @@ import (
 	"time"
 
 	"github.com/squat/and/dab/simple-temple-test-user/dao"
-	"github.com/squat/and/dab/simple-temple-test-user/metric"
 	"github.com/squat/and/dab/simple-temple-test-user/util"
 	valid "github.com/asaskevich/govalidator"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 

--- a/src/e2e/resources/simple-temple-expected/simple-temple-test-user/util/util.go
+++ b/src/e2e/resources/simple-temple-expected/simple-temple-test-user/util/util.go
@@ -18,6 +18,7 @@ type Config struct {
 	Host     string            `json:"host"`
 	SSLMode  string            `json:"sslMode"`
 	Services map[string]string `json:"services"`
+	Ports    map[string]int    `json:"ports"`
 }
 
 // Auth contains the unique identifier for a given auth

--- a/src/it/scala/temple/containers/DockerShell2HttpService.scala
+++ b/src/it/scala/temple/containers/DockerShell2HttpService.scala
@@ -9,7 +9,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 /** DockerShell2HttpService configures a docker container for our custom Shell2Http container */
 abstract class DockerShell2HttpService(externalPort: Int) extends FlatSpec with DockerKit {
-  val image             = "jaylees/templeeight-shell2http:1.4.2"
+  val image             = "jaylees/templeeight-shell2http:1.4.3"
   val internalPort      = 8080
   val hadolintVerifyUrl = s"http://localhost:$externalPort/hadolint"
   val golangVerifyUrl   = s"http://localhost:$externalPort/go"

--- a/src/main/resources/go/genFiles/common/util/config_struct.go.snippet
+++ b/src/main/resources/go/genFiles/common/util/config_struct.go.snippet
@@ -5,4 +5,5 @@ type Config struct {
 	Host     string            `json:"host"`
 	SSLMode  string            `json:"sslMode"`
 	Services map[string]string `json:"services"`
+	Ports    map[string]int    `json:"ports"`
 }

--- a/src/main/scala/temple/generate/server/ServiceRoot.scala
+++ b/src/main/scala/temple/generate/server/ServiceRoot.scala
@@ -17,12 +17,12 @@ import scala.collection.immutable.ListMap
   * @param idAttribute the name of the ID field
   * @param createdByAttribute whether or not this service has a createdBy attribute. Also indicates whether this service has an auth block.
   * @param attributes the user-defined fields of the resource handled by this service
-  * @param datastore the datastore being used
+  * @param datastore the datastore being used TODO: Does not switch on datastore, assumes Postgres
   * @param readable whether this service is readable by this or by all
   * @param writable whether this service is writable by this or by all
   * @param projectUsesAuth whether or not the project uses auth
   * @param hasAuthBlock whether or not this service has an auth block
-  * @param metrics whether or not this service has metrics, and if so, which framework is used
+  * @param metrics whether or not this service has metrics, and if so, which framework is used. TODO: Does not switch on framework, assumes Prometheus
   */
 case class ServiceRoot(
   override val name: String,

--- a/src/main/scala/temple/generate/server/go/auth/GoAuthServiceGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/auth/GoAuthServiceGenerator.scala
@@ -18,10 +18,11 @@ object GoAuthServiceGenerator extends AuthServiceGenerator {
       File("auth", "go.mod") -> GoCommonGenerator.generateMod(root.module),
       File("auth", "auth.go") -> mkCode.doubleLines(
         GoCommonGenerator.generatePackage("main"),
-        GoAuthServiceMainGenerator.generateImports(root),
+        GoAuthServiceMainGenerator.generateImports(root, usesMetrics),
         GoAuthServiceMainGenerator.generateStructs(),
         GoAuthServiceMainGenerator.generateRouter(),
-        GoCommonMainGenerator.generateMain(ServiceName("Auth"), root.port, usesComms = true, isAuth = true),
+        GoCommonMainGenerator
+          .generateMain(ServiceName("Auth"), root.port, usesComms = true, isAuth = true, usesMetrics),
         GoCommonMainGenerator.generateJsonMiddleware(),
         GoAuthServiceMainGenerator.generateHandlers(),
         GoAuthServiceMainGenerator.generateCreateToken(),

--- a/src/main/scala/temple/generate/server/go/auth/GoAuthServiceMainGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/auth/GoAuthServiceMainGenerator.scala
@@ -17,7 +17,8 @@ object GoAuthServiceMainGenerator {
     val customImports = mkCode.lines(
       doubleQuote(s"${root.module}/comm"),
       doubleQuote(s"${root.module}/dao"),
-      when(usesMetrics) { doubleQuote(s"${root.module}/metric") },
+      // TODO: Uncomment when metrics are added to handlers
+      //when(usesMetrics) { doubleQuote(s"${root.module}/metric") },
       doubleQuote(s"${root.module}/util"),
       s"valid ${doubleQuote("github.com/asaskevich/govalidator")}",
       doubleQuote("github.com/dgrijalva/jwt-go"),
@@ -25,7 +26,8 @@ object GoAuthServiceMainGenerator {
       doubleQuote("github.com/gorilla/mux"),
       when(usesMetrics) {
         mkCode.lines(
-          doubleQuote("github.com/prometheus/client_golang/prometheus"),
+          // TODO: Uncomment when metrics are added to handlers
+          //doubleQuote("github.com/prometheus/client_golang/prometheus"),
           doubleQuote("github.com/prometheus/client_golang/prometheus/promhttp"),
         )
       },

--- a/src/main/scala/temple/generate/server/go/auth/GoAuthServiceMainGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/auth/GoAuthServiceMainGenerator.scala
@@ -5,24 +5,33 @@ import temple.generate.utils.CodeTerm.{CodeWrap, mkCode}
 import temple.utils.FileUtils
 import temple.utils.StringUtils.doubleQuote
 
+import scala.Option.when
+
 object GoAuthServiceMainGenerator {
 
-  private[auth] def generateImports(root: AuthServiceRoot): String = {
-    val standardImports = Seq("encoding/json", "flag", "fmt", "log", "net/http", "time").map(doubleQuote)
+  private[auth] def generateImports(root: AuthServiceRoot, usesMetrics: Boolean): String = {
+    val standardImports = mkCode.lines(Seq("encoding/json", "flag", "fmt", "log", "net/http", "time").map(doubleQuote))
 
     val officialImports = doubleQuote("golang.org/x/crypto/bcrypt")
 
-    val customImports = Seq(
+    val customImports = mkCode.lines(
       doubleQuote(s"${root.module}/comm"),
       doubleQuote(s"${root.module}/dao"),
+      when(usesMetrics) { doubleQuote(s"${root.module}/metric") },
       doubleQuote(s"${root.module}/util"),
       s"valid ${doubleQuote("github.com/asaskevich/govalidator")}",
       doubleQuote("github.com/dgrijalva/jwt-go"),
       doubleQuote("github.com/google/uuid"),
       doubleQuote("github.com/gorilla/mux"),
+      when(usesMetrics) {
+        mkCode.lines(
+          doubleQuote("github.com/prometheus/client_golang/prometheus"),
+          doubleQuote("github.com/prometheus/client_golang/prometheus/promhttp"),
+        )
+      },
     )
 
-    mkCode("import", CodeWrap.parens.tabbed(standardImports, "", officialImports, "", customImports))
+    mkCode("import", CodeWrap.parens.tabbed(mkCode.doubleLines(standardImports, officialImports, customImports)))
   }
 
   private[auth] def generateStructs(): String =

--- a/src/main/scala/temple/generate/server/go/common/GoCommonGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/common/GoCommonGenerator.scala
@@ -144,7 +144,7 @@ object GoCommonGenerator {
       CodeWrap.curly.tabbed(methodBody),
     )
 
-  /** Generation a function */
+  /** Generate a function */
   private[go] def genFunc(
     funcName: String,
     funcArgs: Seq[String],
@@ -156,6 +156,18 @@ object GoCommonGenerator {
       CodeWrap.parens.prefix(funcName).list(funcArgs),
       funcReturn,
       CodeWrap.curly.tabbed(funcBody),
+    )
+
+  /** Generate an anonymous goroutine */
+  private[go] def genAnonGoroutine(
+    args: Seq[String],
+    body: String,
+    invocationArgs: Seq[String],
+  ): String =
+    mkCode(
+      "go",
+      CodeWrap.parens.prefix("func").list(args),
+      CodeWrap.parens.prefix(CodeWrap.curly.tabbed(body))(invocationArgs),
     )
 
   /** Generate an if statement */

--- a/src/main/scala/temple/generate/server/go/service/GoServiceGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/GoServiceGenerator.scala
@@ -48,14 +48,15 @@ object GoServiceGenerator extends ServiceGenerator {
       File(s"${root.kebabName}", "go.mod") -> GoCommonGenerator.generateMod(root.module),
       File(root.kebabName, s"${root.kebabName}.go") -> mkCode.doubleLines(
         GoCommonGenerator.generatePackage("main"),
-        GoServiceMainGenerator.generateImports(root, usesBase64, usesTime, usesComms, clientAttributes, operations),
+        GoServiceMainGenerator
+          .generateImports(root, usesBase64, usesTime, usesComms, usesMetrics, clientAttributes, operations),
         GoServiceMainStructGenerator.generateEnvStruct(usesComms),
         when(clientAttributes.nonEmpty && (operations.contains(CRUD.Create) || operations.contains(CRUD.Update))) {
           GoServiceMainStructGenerator.generateRequestStructs(root, operations, clientAttributes)
         },
         GoServiceMainStructGenerator.generateResponseStructs(root, operations),
         GoServiceMainGenerator.generateRouter(root, operations),
-        GoCommonMainGenerator.generateMain(root, root.port, usesComms, isAuth = false),
+        GoCommonMainGenerator.generateMain(root, root.port, usesComms, isAuth = false, usesMetrics),
         GoCommonMainGenerator.generateJsonMiddleware(),
         when((root.readable == Readable.This || root.writable == Writable.This) && !root.hasAuthBlock) {
           GoServiceMainGenerator.generateCheckAuthorization(root)

--- a/src/main/scala/temple/generate/server/go/service/main/GoServiceMainGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/main/GoServiceMainGenerator.scala
@@ -17,6 +17,7 @@ object GoServiceMainGenerator {
     usesBase64: Boolean,
     usesTime: Boolean,
     usesComms: Boolean,
+    usesMetrics: Boolean,
     clientAttributes: ListMap[String, AbstractAttribute],
     operations: Set[CRUD],
   ): String =
@@ -33,10 +34,17 @@ object GoServiceMainGenerator {
         "",
         when(usesComms) { doubleQuote(s"${root.module}/comm") },
         doubleQuote(s"${root.module}/dao"),
+        when(usesMetrics) { doubleQuote(s"${root.module}/metric") },
         doubleQuote(s"${root.module}/util"),
         s"valid ${doubleQuote("github.com/asaskevich/govalidator")}",
         doubleQuote("github.com/google/uuid"),
         doubleQuote("github.com/gorilla/mux"),
+        when(usesMetrics) {
+          mkCode.lines(
+            doubleQuote("github.com/prometheus/client_golang/prometheus"),
+            doubleQuote("github.com/prometheus/client_golang/prometheus/promhttp"),
+          )
+        },
       ),
     )
 

--- a/src/main/scala/temple/generate/server/go/service/main/GoServiceMainGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/main/GoServiceMainGenerator.scala
@@ -34,14 +34,16 @@ object GoServiceMainGenerator {
         "",
         when(usesComms) { doubleQuote(s"${root.module}/comm") },
         doubleQuote(s"${root.module}/dao"),
-        when(usesMetrics) { doubleQuote(s"${root.module}/metric") },
+        // TODO: Uncomment when metrics are added to handlers
+        //when(usesMetrics) { doubleQuote(s"${root.module}/metric") },
         doubleQuote(s"${root.module}/util"),
         s"valid ${doubleQuote("github.com/asaskevich/govalidator")}",
         doubleQuote("github.com/google/uuid"),
         doubleQuote("github.com/gorilla/mux"),
         when(usesMetrics) {
           mkCode.lines(
-            doubleQuote("github.com/prometheus/client_golang/prometheus"),
+            // TODO: Uncomment when metrics are added to handlers
+            //doubleQuote("github.com/prometheus/client_golang/prometheus"),
             doubleQuote("github.com/prometheus/client_golang/prometheus/promhttp"),
           )
         },

--- a/src/test/resources/project-builder-complex/auth/auth.go
+++ b/src/test/resources/project-builder-complex/auth/auth.go
@@ -12,11 +12,14 @@ import (
 
 	"github.com/squat/and/dab/auth/comm"
 	"github.com/squat/and/dab/auth/dao"
+	"github.com/squat/and/dab/auth/metric"
 	"github.com/squat/and/dab/auth/util"
 	valid "github.com/asaskevich/govalidator"
 	"github.com/dgrijalva/jwt-go"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 // env defines the environment that requests should be executed within
@@ -69,6 +72,16 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	// Prometheus metrics
+	promPort, ok := config.Ports["prometheus"]
+	if !ok {
+		log.Fatal("A port for the key prometheus was not found")
+	}
+	go func() {
+		http.Handle("/metrics", promhttp.Handler())
+		http.ListenAndServe(fmt.Sprintf(":%d", promPort), nil)
+	}()
 
 	d, err := dao.Init(config)
 	if err != nil {

--- a/src/test/resources/project-builder-complex/auth/auth.go
+++ b/src/test/resources/project-builder-complex/auth/auth.go
@@ -12,13 +12,11 @@ import (
 
 	"github.com/squat/and/dab/auth/comm"
 	"github.com/squat/and/dab/auth/dao"
-	"github.com/squat/and/dab/auth/metric"
 	"github.com/squat/and/dab/auth/util"
 	valid "github.com/asaskevich/govalidator"
 	"github.com/dgrijalva/jwt-go"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 

--- a/src/test/resources/project-builder-complex/auth/util/util.go
+++ b/src/test/resources/project-builder-complex/auth/util/util.go
@@ -12,6 +12,7 @@ type Config struct {
 	Host     string            `json:"host"`
 	SSLMode  string            `json:"sslMode"`
 	Services map[string]string `json:"services"`
+	Ports    map[string]int    `json:"ports"`
 }
 
 // GetConfig returns a configuration object from decoding the given configuration file

--- a/src/test/resources/project-builder-complex/complex-user/complex-user.go
+++ b/src/test/resources/project-builder-complex/complex-user/complex-user.go
@@ -10,10 +10,13 @@ import (
 	"time"
 
 	"github.com/squat/and/dab/complex-user/dao"
+	"github.com/squat/and/dab/complex-user/metric"
 	"github.com/squat/and/dab/complex-user/util"
 	valid "github.com/asaskevich/govalidator"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 // env defines the environment that requests should be executed within
@@ -128,6 +131,16 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	// Prometheus metrics
+	promPort, ok := config.Ports["prometheus"]
+	if !ok {
+		log.Fatal("A port for the key prometheus was not found")
+	}
+	go func() {
+		http.Handle("/metrics", promhttp.Handler())
+		http.ListenAndServe(fmt.Sprintf(":%d", promPort), nil)
+	}()
 
 	d, err := dao.Init(config)
 	if err != nil {

--- a/src/test/resources/project-builder-complex/complex-user/complex-user.go
+++ b/src/test/resources/project-builder-complex/complex-user/complex-user.go
@@ -10,12 +10,10 @@ import (
 	"time"
 
 	"github.com/squat/and/dab/complex-user/dao"
-	"github.com/squat/and/dab/complex-user/metric"
 	"github.com/squat/and/dab/complex-user/util"
 	valid "github.com/asaskevich/govalidator"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 

--- a/src/test/resources/project-builder-complex/complex-user/util/util.go
+++ b/src/test/resources/project-builder-complex/complex-user/util/util.go
@@ -18,6 +18,7 @@ type Config struct {
 	Host     string            `json:"host"`
 	SSLMode  string            `json:"sslMode"`
 	Services map[string]string `json:"services"`
+	Ports    map[string]int    `json:"ports"`
 }
 
 // Auth contains the unique identifier for a given auth

--- a/src/test/resources/project-builder-simple/temple-user/util/util.go
+++ b/src/test/resources/project-builder-simple/temple-user/util/util.go
@@ -18,6 +18,7 @@ type Config struct {
 	Host     string            `json:"host"`
 	SSLMode  string            `json:"sslMode"`
 	Services map[string]string `json:"services"`
+	Ports    map[string]int    `json:"ports"`
 }
 
 // Auth contains the unique identifier for a given auth

--- a/src/test/scala/temple/generate/server/go/testfiles/auth/auth.go.snippet
+++ b/src/test/scala/temple/generate/server/go/testfiles/auth/auth.go.snippet
@@ -12,11 +12,14 @@ import (
 
 	"github.com/TempleEight/spec-golang/auth/comm"
 	"github.com/TempleEight/spec-golang/auth/dao"
+	"github.com/TempleEight/spec-golang/auth/metric"
 	"github.com/TempleEight/spec-golang/auth/util"
 	valid "github.com/asaskevich/govalidator"
 	"github.com/dgrijalva/jwt-go"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 // env defines the environment that requests should be executed within
@@ -69,6 +72,16 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	// Prometheus metrics
+	promPort, ok := config.Ports["prometheus"]
+	if !ok {
+		log.Fatal("A port for the key prometheus was not found")
+	}
+	go func() {
+		http.Handle("/metrics", promhttp.Handler())
+		http.ListenAndServe(fmt.Sprintf(":%d", promPort), nil)
+	}()
 
 	d, err := dao.Init(config)
 	if err != nil {

--- a/src/test/scala/temple/generate/server/go/testfiles/auth/auth.go.snippet
+++ b/src/test/scala/temple/generate/server/go/testfiles/auth/auth.go.snippet
@@ -12,13 +12,11 @@ import (
 
 	"github.com/TempleEight/spec-golang/auth/comm"
 	"github.com/TempleEight/spec-golang/auth/dao"
-	"github.com/TempleEight/spec-golang/auth/metric"
 	"github.com/TempleEight/spec-golang/auth/util"
 	valid "github.com/asaskevich/govalidator"
 	"github.com/dgrijalva/jwt-go"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 

--- a/src/test/scala/temple/generate/server/go/testfiles/auth/util/util.go.snippet
+++ b/src/test/scala/temple/generate/server/go/testfiles/auth/util/util.go.snippet
@@ -12,6 +12,7 @@ type Config struct {
 	Host     string            `json:"host"`
 	SSLMode  string            `json:"sslMode"`
 	Services map[string]string `json:"services"`
+	Ports    map[string]int    `json:"ports"`
 }
 
 // GetConfig returns a configuration object from decoding the given configuration file

--- a/src/test/scala/temple/generate/server/go/testfiles/match/match.go.snippet
+++ b/src/test/scala/temple/generate/server/go/testfiles/match/match.go.snippet
@@ -10,12 +10,10 @@ import (
 
 	"github.com/TempleEight/spec-golang/match/comm"
 	"github.com/TempleEight/spec-golang/match/dao"
-	"github.com/TempleEight/spec-golang/match/metric"
 	"github.com/TempleEight/spec-golang/match/util"
 	valid "github.com/asaskevich/govalidator"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 

--- a/src/test/scala/temple/generate/server/go/testfiles/match/match.go.snippet
+++ b/src/test/scala/temple/generate/server/go/testfiles/match/match.go.snippet
@@ -10,10 +10,13 @@ import (
 
 	"github.com/TempleEight/spec-golang/match/comm"
 	"github.com/TempleEight/spec-golang/match/dao"
+	"github.com/TempleEight/spec-golang/match/metric"
 	"github.com/TempleEight/spec-golang/match/util"
 	valid "github.com/asaskevich/govalidator"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 // env defines the environment that requests should be executed within
@@ -96,6 +99,16 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	// Prometheus metrics
+	promPort, ok := config.Ports["prometheus"]
+	if !ok {
+		log.Fatal("A port for the key prometheus was not found")
+	}
+	go func() {
+		http.Handle("/metrics", promhttp.Handler())
+		http.ListenAndServe(fmt.Sprintf(":%d", promPort), nil)
+	}()
 
 	d, err := dao.Init(config)
 	if err != nil {

--- a/src/test/scala/temple/generate/server/go/testfiles/match/util/util.go.snippet
+++ b/src/test/scala/temple/generate/server/go/testfiles/match/util/util.go.snippet
@@ -18,6 +18,7 @@ type Config struct {
 	Host     string            `json:"host"`
 	SSLMode  string            `json:"sslMode"`
 	Services map[string]string `json:"services"`
+	Ports    map[string]int    `json:"ports"`
 }
 
 // Auth contains the unique identifier for a given auth

--- a/src/test/scala/temple/generate/server/go/testfiles/user/user.go.snippet
+++ b/src/test/scala/temple/generate/server/go/testfiles/user/user.go.snippet
@@ -8,10 +8,13 @@ import (
 	"net/http"
 
 	"github.com/TempleEight/spec-golang/user/dao"
+	"github.com/TempleEight/spec-golang/user/metric"
 	"github.com/TempleEight/spec-golang/user/util"
 	valid "github.com/asaskevich/govalidator"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 // env defines the environment that requests should be executed within
@@ -71,6 +74,16 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	// Prometheus metrics
+	promPort, ok := config.Ports["prometheus"]
+	if !ok {
+		log.Fatal("A port for the key prometheus was not found")
+	}
+	go func() {
+		http.Handle("/metrics", promhttp.Handler())
+		http.ListenAndServe(fmt.Sprintf(":%d", promPort), nil)
+	}()
 
 	d, err := dao.Init(config)
 	if err != nil {

--- a/src/test/scala/temple/generate/server/go/testfiles/user/user.go.snippet
+++ b/src/test/scala/temple/generate/server/go/testfiles/user/user.go.snippet
@@ -8,12 +8,10 @@ import (
 	"net/http"
 
 	"github.com/TempleEight/spec-golang/user/dao"
-	"github.com/TempleEight/spec-golang/user/metric"
 	"github.com/TempleEight/spec-golang/user/util"
 	valid "github.com/asaskevich/govalidator"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 

--- a/src/test/scala/temple/generate/server/go/testfiles/user/util/util.go.snippet
+++ b/src/test/scala/temple/generate/server/go/testfiles/user/util/util.go.snippet
@@ -18,6 +18,7 @@ type Config struct {
 	Host     string            `json:"host"`
 	SSLMode  string            `json:"sslMode"`
 	Services map[string]string `json:"services"`
+	Ports    map[string]int    `json:"ports"`
 }
 
 // Auth contains the unique identifier for a given auth


### PR DESCRIPTION
* Adds generation of the code in the main functions to spin up a Prometheus metric server
  * For both auth and non-auth services
* Tidies up the main function generation
* Adds Ports to the `util.go` `config` struct

You will notice I've commented out metric imports ready for my next PR where I add the actual metric calls to the handlers.