### PR TITLE
[DSL] Move auth method to be specified in the project block

### DIFF
--- a/src/e2e/scala/temple/DSL/ParserE2ETest.scala
+++ b/src/e2e/scala/temple/DSL/ParserE2ETest.scala
@@ -26,6 +26,7 @@ class ParserE2ETest extends FlatSpec with Matchers with DSLParserMatchers {
         metadata = Seq(
           Metrics.Prometheus,
           Provider.Kubernetes,
+          AuthMethod.Email,
         ),
       ),
       services = Map(
@@ -48,7 +49,7 @@ class ParserE2ETest extends FlatSpec with Matchers with DSLParserMatchers {
             Omit(Set(Endpoint.Delete)),
             Readable.All,
             Writable.This,
-            ServiceAuth.Email,
+            ServiceAuth,
             Uses(Seq("Booking", "SimpleTempleTestGroup")),
           ),
           structs = Map(

--- a/src/main/scala/temple/DSL/semantics/Analyzer.scala
+++ b/src/main/scala/temple/DSL/semantics/Analyzer.scala
@@ -160,7 +160,7 @@ object Analyzer {
     registerEmptyKeyword("enumerable")(ServiceEnumerable)
     registerKeywordWithContext("readable", "by", TokenArgType)(Readable)
     registerKeywordWithContext("writable", "by", TokenArgType)(Writable)
-    registerKeywordWithContext("auth", "type", TokenArgType)(ServiceAuth)
+    registerEmptyKeyword("auth")(ServiceAuth)
     registerKeyword("uses", "services", ListArgType(TokenArgType))(Uses)
     registerKeywordWithContext("omit", "endpoints", ListArgType(TokenArgType))(Omit)
   }
@@ -179,6 +179,7 @@ object Analyzer {
     registerKeywordWithContext("database", TokenArgType)(Database)
     registerKeywordWithContext("provider", TokenArgType)(Provider)
     registerKeywordWithContext("metrics", TokenArgType)(Metrics)
+    registerKeywordWithContext("authMethod", "method", TokenArgType)(AuthMethod)
     registerKeywordWithContext("readable", "by", TokenArgType)(Readable)
     registerKeywordWithContext("writable", "by", TokenArgType)(Writable)
   }

--- a/src/main/scala/temple/DSL/semantics/ServiceRenamer.scala
+++ b/src/main/scala/temple/DSL/semantics/ServiceRenamer.scala
@@ -19,6 +19,7 @@ case class ServiceRenamer(renamingMap: Map[String, String]) {
     // currently `identity`, as no metadata contains a service name
     ProjectBlock(
       block.metadata.map {
+        case authMethod: Metadata.AuthMethod    => authMethod
         case language: Metadata.ServiceLanguage => language
         case provider: Metadata.Provider        => provider
         case database: Metadata.Database        => database

--- a/src/main/scala/temple/ast/Metadata.scala
+++ b/src/main/scala/temple/ast/Metadata.scala
@@ -92,12 +92,15 @@ object Metadata {
       Omit(names.map(Endpoint.parse(_)).toSet)
   }
 
-  sealed abstract class ServiceAuth private (name: String) extends EnumEntry(name) with ServiceMetadata
+  sealed abstract class AuthMethod private (name: String) extends EnumEntry(name) with ProjectMetadata
 
-  object ServiceAuth extends Enum[ServiceAuth] {
-    override def values: IndexedSeq[ServiceAuth] = findValues
-    case object Email extends ServiceAuth("email")
+  object AuthMethod extends Enum[AuthMethod] {
+    override def values: IndexedSeq[AuthMethod] = findValues
+    case object Email extends AuthMethod("email")
   }
+
+  type ServiceAuth = ServiceAuth.type
+  case object ServiceAuth extends ServiceMetadata
 
   sealed abstract class Metrics private (name: String) extends EnumEntry(name) with ProjectMetadata
 

--- a/src/main/scala/temple/ast/TempleBlock.scala
+++ b/src/main/scala/temple/ast/TempleBlock.scala
@@ -49,5 +49,5 @@ abstract class TempleBlock[+M <: Metadata] extends TempleNode {
     * For binary metadata (e.g. enumerable), this is just whether it’s set, else whether an exact value of the metadata
     * is provided locally.
     */
-  final override def hasMetadata(m: Metadata): Boolean = metadata contains m
+  final def hasMetadata(m: Metadata): Boolean = metadata contains m
 }

--- a/src/main/scala/temple/ast/TempleBlock.scala
+++ b/src/main/scala/temple/ast/TempleBlock.scala
@@ -42,4 +42,12 @@ abstract class TempleBlock[+M <: Metadata] extends TempleNode {
     */
   final def lookupMetadata[T <: ProjectMetadata: ClassTag]: Option[T] =
     lookupLocalMetadata[T] orElse lookupDefaultMetadata[T]
+
+  /**
+    * Whether a specific metadata value is given.
+    *
+    * For binary metadata (e.g. enumerable), this is just whether it’s set, else whether an exact value of the metadata
+    * is provided locally.
+    */
+  final override def hasMetadata(m: Metadata): Boolean = metadata contains m
 }

--- a/src/main/scala/temple/ast/TempleNode.scala
+++ b/src/main/scala/temple/ast/TempleNode.scala
@@ -12,6 +12,4 @@ trait TempleNode {
     * @return an option of the metadata item
     */
   def lookupMetadata[T <: ProjectMetadata: ClassTag]: Option[T]
-
-  def hasMetadata(m: Metadata): Boolean
 }

--- a/src/main/scala/temple/ast/TempleNode.scala
+++ b/src/main/scala/temple/ast/TempleNode.scala
@@ -12,4 +12,6 @@ trait TempleNode {
     * @return an option of the metadata item
     */
   def lookupMetadata[T <: ProjectMetadata: ClassTag]: Option[T]
+
+  def hasMetadata(m: Metadata): Boolean
 }

--- a/src/main/scala/temple/ast/Templefile.scala
+++ b/src/main/scala/temple/ast/Templefile.scala
@@ -1,7 +1,6 @@
 package temple.ast
 
 import temple.ast.AbstractServiceBlock._
-import temple.ast.Metadata.ServiceAuth
 import temple.ast.Templefile.Ports
 import temple.builder.project.ProjectConfig
 
@@ -23,9 +22,7 @@ case class Templefile(
   val providedServices: Map[String, ServiceBlock] = services
 
   // Whether or not to generate an auth service - based on whether any service has #auth
-  val usesAuth: Boolean = services.exists {
-    case (_, service) => service.lookupLocalMetadata[ServiceAuth].nonEmpty
-  }
+  val usesAuth: Boolean = lookupMetadata[Metadata.AuthMethod].isDefined
 
   val providedServicesWithPorts: Iterable[(String, ServiceBlock, Ports)] =
     providedServices
@@ -64,6 +61,8 @@ case class Templefile(
   /** Get a block by name, either as a service or a block */
   def getBlock(name: String): AttributeBlock[_] =
     services.getOrElse(name, services(structLocations(name)).structs(name))
+
+  override def hasMetadata(m: Metadata): Boolean = projectBlock hasMetadata m
 }
 
 object Templefile {

--- a/src/main/scala/temple/ast/Templefile.scala
+++ b/src/main/scala/temple/ast/Templefile.scala
@@ -61,8 +61,6 @@ case class Templefile(
   /** Get a block by name, either as a service or a block */
   def getBlock(name: String): AttributeBlock[_] =
     services.getOrElse(name, services(structLocations(name)).structs(name))
-
-  override def hasMetadata(m: Metadata): Boolean = projectBlock hasMetadata m
 }
 
 object Templefile {

--- a/src/main/scala/temple/builder/ServerBuilder.scala
+++ b/src/main/scala/temple/builder/ServerBuilder.scala
@@ -3,7 +3,7 @@ package temple.builder
 import temple.ast.AbstractAttribute.Attribute
 import temple.ast.AttributeType.ForeignKey
 import temple.ast.Metadata.{Database, ServiceAuth, ServiceLanguage}
-import temple.ast.{Metadata, _}
+import temple.ast._
 import temple.builder.project.LanguageConfig.GoLanguageConfig
 import temple.builder.project.ProjectConfig
 import temple.detail.LanguageDetail
@@ -99,12 +99,11 @@ object ServerBuilder {
       case GoLanguageDetail(modulePath) => s"$modulePath/auth"
     }
 
-    // TODO: look this up from the project block
     // TODO: support usernames
-    val serviceAuth = ProjectConfig.defaultAuth
+    val authMethod = templefile.lookupMetadata[Metadata.AuthMethod] getOrElse ProjectConfig.defaultAuth
 
-    val attributes: Map[String, Attribute] = serviceAuth match {
-      case ServiceAuth.Email =>
+    val attributes: Map[String, Attribute] = authMethod match {
+      case Metadata.AuthMethod.Email =>
         Map(
           "id"       -> Attribute(AttributeType.UUIDType),
           "email"    -> Attribute(AttributeType.StringType()),
@@ -131,7 +130,7 @@ object ServerBuilder {
     AuthServiceRoot(
       moduleName,
       port,
-      AuthAttribute(serviceAuth, AttributeType.StringType()),
+      AuthAttribute(authMethod, AttributeType.StringType()),
       server.IDAttribute("id"),
       createQuery,
       readQuery,

--- a/src/main/scala/temple/builder/project/ProjectBuilder.scala
+++ b/src/main/scala/temple/builder/project/ProjectBuilder.scala
@@ -44,7 +44,8 @@ object ProjectBuilder {
           }
       }
     // Add read all endpoint if defined
-    service.lookupLocalMetadata[Metadata.ServiceEnumerable].fold(endpoints)(_ => endpoints + List)
+    if (service hasMetadata Metadata.ServiceEnumerable) endpoints + List
+    else endpoints
   }
 
   private def buildDatabaseCreationScripts(templefile: Templefile): Files =

--- a/src/main/scala/temple/builder/project/ProjectConfig.scala
+++ b/src/main/scala/temple/builder/project/ProjectConfig.scala
@@ -13,7 +13,7 @@ object ProjectConfig {
   val registryURL                      = "localhost:5000"
   val defaultLanguage: ServiceLanguage = ServiceLanguage.Go
   val defaultDatabase: Database        = Database.Postgres
-  val defaultAuth: ServiceAuth         = ServiceAuth.Email
+  val defaultAuth: AuthMethod          = AuthMethod.Email
   val authPort: Int                    = 1024
   val authMetricPort: Int              = 1025
   val serviceStartPort: Int            = 1026

--- a/src/main/scala/temple/generate/server/AuthAttribute.scala
+++ b/src/main/scala/temple/generate/server/AuthAttribute.scala
@@ -1,6 +1,6 @@
 package temple.generate.server
 
 import temple.ast.AttributeType
-import temple.ast.Metadata.ServiceAuth
+import temple.ast.Metadata.AuthMethod
 
-case class AuthAttribute(authType: ServiceAuth, attributeType: AttributeType)
+case class AuthAttribute(authMethod: AuthMethod, attributeType: AttributeType)

--- a/src/main/scala/temple/generate/server/go/auth/GoAuthServiceDAOGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/auth/GoAuthServiceDAOGenerator.scala
@@ -45,9 +45,11 @@ object GoAuthServiceDAOGenerator {
     )
 
   private[auth] def generateStructs(root: AuthServiceRoot): String = {
-    val id       = ListMap(root.idAttribute.name.toUpperCase           -> generateGoType(AttributeType.UUIDType))
-    val auth     = ListMap(root.authAttribute.authType.name.capitalize -> generateGoType(root.authAttribute.attributeType))
-    val password = ListMap("Password"                                  -> "string")
+    val id = ListMap(root.idAttribute.name.toUpperCase -> generateGoType(AttributeType.UUIDType))
+    val auth = ListMap(
+      root.authAttribute.authMethod.name.capitalize -> generateGoType(root.authAttribute.attributeType),
+    )
+    val password = ListMap("Password" -> "string")
     mkCode.lines(
       "// Auth encapsulates the object stored in the datastore",
       genStruct("Auth", id ++ auth ++ password),
@@ -73,7 +75,7 @@ object GoAuthServiceDAOGenerator {
         "dao.DB",
         doubleQuote(root.createQuery),
         s"input.${root.idAttribute.name.toUpperCase}",
-        s"input.${root.authAttribute.authType.name.capitalize}",
+        s"input.${root.authAttribute.authMethod.name.capitalize}",
         s"input.Password",
       ),
       "row",
@@ -118,7 +120,7 @@ object GoAuthServiceDAOGenerator {
         "executeQueryWithRowResponse",
         "dao.DB",
         doubleQuote(root.readQuery),
-        s"input.${root.authAttribute.authType.name.capitalize}",
+        s"input.${root.authAttribute.authMethod.name.capitalize}",
       ),
       "row",
     )
@@ -133,7 +135,7 @@ object GoAuthServiceDAOGenerator {
     )
 
     mkCode.lines(
-      s"// ReadAuth returns the auth in the datastore for a given ${root.authAttribute.authType.name}",
+      s"// ReadAuth returns the auth in the datastore for a given ${root.authAttribute.authMethod.name}",
       mkCode(
         "func (dao *DAO) ReadAuth(input ReadAuthInput) (*Auth, error)",
         CodeWrap.curly.tabbed(
@@ -151,7 +153,7 @@ object GoAuthServiceDAOGenerator {
     val scanFunctionCall = genFunctionCall(
       "Scan",
       s"&auth.${root.idAttribute.name.toUpperCase}",
-      s"&auth.${root.authAttribute.authType.name.capitalize}",
+      s"&auth.${root.authAttribute.authMethod.name.capitalize}",
       s"&auth.Password",
     )
     mkCode.doubleLines(
@@ -166,7 +168,7 @@ object GoAuthServiceDAOGenerator {
       "",
       s"import ${doubleQuote("errors")}",
       "",
-      s"// ErrAuthNotFound is returned when the provided ${root.authAttribute.authType.name} was not found",
+      s"// ErrAuthNotFound is returned when the provided ${root.authAttribute.authMethod.name} was not found",
       s"var ErrAuthNotFound = errors.New(${doubleQuote("auth not found")})",
       "",
       "// ErrDuplicateAuth is returned when an auth already exists",

--- a/src/main/scala/temple/test/ProjectTester.scala
+++ b/src/main/scala/temple/test/ProjectTester.scala
@@ -4,7 +4,7 @@ import java.io.IOException
 import java.net.HttpURLConnection
 
 import scalaj.http.Http
-import temple.ast.Metadata.{Provider, ServiceAuth}
+import temple.ast.Metadata.{AuthMethod, Provider}
 import temple.ast.{Metadata, Templefile}
 import temple.test.internal.{AuthServiceTest, CRUDServiceTest, ProjectConfig}
 
@@ -111,11 +111,10 @@ object ProjectTester {
 
   /** Execute the tests on each generated service */
   private def performTests(templefile: Templefile, generatedPath: String, url: String): Unit = {
-    // TODO: refactor for central auth method
-    val serviceAuths = templefile.services.values.flatMap(_.lookupLocalMetadata[ServiceAuth]).toSet
-    var anyFailed    = false
-    if (serviceAuths.nonEmpty) {
-      anyFailed = AuthServiceTest.test(serviceAuths, url) || anyFailed
+    val authMethod = templefile.lookupMetadata[AuthMethod]
+    var anyFailed  = false
+    authMethod.foreach { auth =>
+      anyFailed = AuthServiceTest.test(auth, url) || anyFailed
     }
     templefile.providedServices.foreach {
       case (name, block) =>

--- a/src/main/scala/temple/test/internal/AuthServiceTest.scala
+++ b/src/main/scala/temple/test/internal/AuthServiceTest.scala
@@ -1,8 +1,8 @@
 package temple.test.internal
 
-import temple.ast.Metadata.ServiceAuth
-import temple.utils.StringUtils
 import io.circe.syntax._
+import temple.ast.Metadata.AuthMethod
+import temple.utils.StringUtils
 
 object AuthServiceTest extends ServiceTest("Auth") {
 
@@ -34,10 +34,9 @@ object AuthServiceTest extends ServiceTest("Auth") {
   }
 
   // Test each type of auth that is present in the project
-  // TODO: refactor for central auth method
-  def test(auths: Set[ServiceAuth], baseURL: String): Boolean = {
-    auths.foreach {
-      case ServiceAuth.Email => testEmailAuth(baseURL)
+  def test(authMethod: AuthMethod, baseURL: String): Boolean = {
+    authMethod match {
+      case AuthMethod.Email => testEmailAuth(baseURL)
     }
     anyTestFailed
   }

--- a/src/test/scala/temple/DSL/parser/DSLParserTest.scala
+++ b/src/test/scala/temple/DSL/parser/DSLParserTest.scala
@@ -58,6 +58,7 @@ class DSLParserTest extends FlatSpec with DSLParserMatchers {
         Seq(
           Metadata("metrics", Args(Seq(Arg.TokenArg("prometheus")))),
           Metadata("provider", Args(Seq(Arg.TokenArg("kubernetes")))),
+          Metadata("authMethod", Args(Seq(Arg.TokenArg("email")))),
         ),
       ),
       DSLRootItem(
@@ -93,7 +94,7 @@ class DSLParserTest extends FlatSpec with DSLParserMatchers {
           Metadata("omit", Args(Seq(Arg.ListArg(Seq(Arg.TokenArg("delete")))))),
           Metadata("readable", Args(kwargs = Seq("by" -> Arg.TokenArg("all")))),
           Metadata("writable", Args(kwargs = Seq("by" -> Arg.TokenArg("this")))),
-          Metadata("auth", Args(Seq(Arg.TokenArg("email")))),
+          Metadata("auth"),
           Metadata("uses", Args(Seq(Arg.ListArg(Seq(Arg.TokenArg("Booking"), Arg.TokenArg("Group")))))),
         ),
       ),

--- a/src/test/scala/temple/DSL/semantics/SemanticAnalyzerTest.scala
+++ b/src/test/scala/temple/DSL/semantics/SemanticAnalyzerTest.scala
@@ -304,7 +304,7 @@ class SemanticAnalyzerTest extends FlatSpec with Matchers {
               Entry.Attribute("id", syntax.AttributeType.Primitive("int")),
               Entry.Metadata("enumerable"),
               Entry.Metadata("uses", Args(kwargs = Seq("services" -> ListArg(Seq(TokenArg("Box")))))),
-              Entry.Metadata("auth", Args(Seq(TokenArg("email")))),
+              Entry.Metadata("auth"),
             ),
           ),
           DSLRootItem("Box", "service", Seq()),

--- a/src/test/scala/temple/builder/DockerfileBuilderTest.scala
+++ b/src/test/scala/temple/builder/DockerfileBuilderTest.scala
@@ -3,7 +3,7 @@ package temple.builder
 import org.scalatest.{FlatSpec, Matchers}
 import temple.ast.AbstractAttribute.Attribute
 import temple.ast.AbstractServiceBlock.{AuthServiceBlock, ServiceBlock}
-import temple.ast.Metadata.{Provider, ServiceLanguage}
+import temple.ast.Metadata.{AuthMethod, Provider, ServiceLanguage}
 import temple.ast.{AttributeType, Metadata, ProjectBlock, Templefile}
 
 class DockerfileBuilderTest extends FlatSpec with Matchers {
@@ -59,10 +59,11 @@ class DockerfileBuilderTest extends FlatSpec with Matchers {
   it should "generate the correct Dockerfile for a Go auth service when using DockerCompose" in {
     val templefile = Templefile(
       "ExampleProject",
+      projectBlock = ProjectBlock(Seq(AuthMethod.Email)),
       services = Map(
         "AuthyService" -> ServiceBlock(
           attributes = Map("test" -> Attribute(AttributeType.StringType())),
-          metadata = Seq(Metadata.ServiceAuth.Email),
+          metadata = Seq(Metadata.ServiceAuth),
           structs = Map(),
         ),
       ),
@@ -82,19 +83,18 @@ class DockerfileBuilderTest extends FlatSpec with Matchers {
   it should "generate the correct Dockerfile for a Go auth service when using Kubernetes" in {
     val templefile = Templefile(
       "ExampleProject",
+      projectBlock = ProjectBlock(Seq(AuthMethod.Email)),
       services = Map(
         "AuthyService" -> ServiceBlock(
           attributes = Map("test" -> Attribute(AttributeType.StringType())),
-          metadata = Seq(Metadata.ServiceAuth.Email),
+          metadata = Seq(Metadata.ServiceAuth),
           structs = Map(),
         ),
       ),
     )
 
     val authBlock = templefile.allServices
-      .collectFirst {
-        case (_, AuthServiceBlock) => AuthServiceBlock
-      }
+      .collectFirst { case (_, AuthServiceBlock) => AuthServiceBlock }
       .getOrElse(throw new RuntimeException("Auth block doesn't exist"))
 
     val dockerfile = DockerfileBuilder.createServiceDockerfile("auth", authBlock, 80, Some(Provider.Kubernetes))

--- a/src/test/scala/temple/builder/ServerBuilderTest.scala
+++ b/src/test/scala/temple/builder/ServerBuilderTest.scala
@@ -4,7 +4,7 @@ import org.scalatest.{FlatSpec, Matchers}
 import temple.ast.AbstractAttribute.Attribute
 import temple.ast.AttributeType
 import temple.ast.AttributeType._
-import temple.ast.Metadata.{Database, Readable, ServiceAuth, Writable}
+import temple.ast.Metadata.{AuthMethod, Database, Readable, ServiceAuth, Writable}
 import temple.detail.LanguageDetail.GoLanguageDetail
 import temple.generate.CRUD._
 import temple.generate.server._
@@ -165,7 +165,7 @@ class ServerBuilderTest extends FlatSpec with Matchers {
     authServiceRoot shouldBe AuthServiceRoot(
       "github.com/squat/and/dab/auth",
       1000,
-      AuthAttribute(ServiceAuth.Email, AttributeType.StringType()),
+      AuthAttribute(AuthMethod.Email, AttributeType.StringType()),
       IDAttribute("id"),
       "INSERT INTO auth (id, email, password) VALUES ($1, $2, $3) RETURNING id, email, password;",
       "SELECT id, email, password FROM auth WHERE email = $1;",

--- a/src/test/scala/temple/builder/project/ProjectBuilderTestData.scala
+++ b/src/test/scala/temple/builder/project/ProjectBuilderTestData.scala
@@ -3,7 +3,7 @@ package temple.builder.project
 import temple.ast.AbstractAttribute.{Attribute, IDAttribute}
 import temple.ast.AbstractServiceBlock._
 import temple.ast.AttributeType._
-import temple.ast.Metadata.{Database, ServiceAuth}
+import temple.ast.Metadata.{AuthMethod, Database, ServiceAuth}
 import temple.ast._
 
 import scala.collection.immutable.ListMap
@@ -86,12 +86,13 @@ object ProjectBuilderTestData {
       metadata = Seq(
         Metadata.Metrics.Prometheus,
         Metadata.Provider.Kubernetes,
+        AuthMethod.Email,
       ),
     ),
     services = Map(
       "ComplexUser" -> ServiceBlock(
         complexServiceAttributes,
-        metadata = Seq(ServiceAuth.Email),
+        metadata = Seq(ServiceAuth),
         structs = Map("TempleUser" -> StructBlock(simpleServiceAttributes)),
       ),
     ),

--- a/src/test/scala/temple/generate/server/go/GoAuthServiceGeneratorTestData.scala
+++ b/src/test/scala/temple/generate/server/go/GoAuthServiceGeneratorTestData.scala
@@ -1,8 +1,8 @@
 package temple.generate.server.go
 
 import temple.ast.AttributeType
+import temple.ast.Metadata.AuthMethod
 import temple.ast.Metadata.Metrics.Prometheus
-import temple.ast.Metadata.ServiceAuth
 import temple.generate.FileSystem._
 import temple.generate.server.{AuthAttribute, AuthServiceRoot, IDAttribute}
 import temple.utils.FileUtils._
@@ -12,7 +12,7 @@ object GoAuthServiceGeneratorTestData {
   val authServiceRoot: AuthServiceRoot = AuthServiceRoot(
     "github.com/TempleEight/spec-golang/auth",
     82,
-    AuthAttribute(ServiceAuth.Email, AttributeType.StringType()),
+    AuthAttribute(AuthMethod.Email, AttributeType.StringType()),
     IDAttribute("id"),
     "INSERT INTO auth (id, email, password) VALUES ($1, $2, $3) RETURNING id, name, password",
     "SELECT id, email, password FROM auth WHERE email = $1",

--- a/src/test/scala/temple/testfiles/simple-dc.temple
+++ b/src/test/scala/temple/testfiles/simple-dc.temple
@@ -1,6 +1,7 @@
 SimpleTempleTest: project {
   #metrics(prometheus);
   #provider(dockerCompose);
+  #authMethod(email);
 }
 
 User: service {
@@ -28,7 +29,7 @@ User: service {
   #readable(by: all);
   #writable(by: this);
 
-  #auth(email);
+  #auth;
   #uses [Booking, Group, /* Reservations */];
 }
 

--- a/src/test/scala/temple/testfiles/simple.temple
+++ b/src/test/scala/temple/testfiles/simple.temple
@@ -1,6 +1,7 @@
 SimpleTempleTest: project {
   #metrics(prometheus);
   #provider(kubernetes);
+  #authMethod(email);
 }
 
 User: service {
@@ -28,7 +29,7 @@ User: service {
   #readable(by: all);
   #writable(by: this);
 
-  #auth(email);
+  #auth;
   #uses [Booking, Group, /* Reservations */];
 }
 


### PR DESCRIPTION
Instead of `#auth(method)` in the service block, we now have `#authMethod(method)` in the project block, and bare `#auth` in the service block