### PR TITLE
[go-gen] Add generation of timing and request success metrics

### DIFF
--- a/src/e2e/resources/simple-temple-expected/auth/auth.go
+++ b/src/e2e/resources/simple-temple-expected/auth/auth.go
@@ -12,11 +12,13 @@ import (
 
 	"github.com/squat/and/dab/auth/comm"
 	"github.com/squat/and/dab/auth/dao"
+	"github.com/squat/and/dab/auth/metric"
 	"github.com/squat/and/dab/auth/util"
 	valid "github.com/asaskevich/govalidator"
 	"github.com/dgrijalva/jwt-go"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -155,7 +157,9 @@ func (env *env) registerAuthHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	timer := prometheus.NewTimer(metric.DatabaseRequestDuration.WithLabelValues(metric.RequestRegister))
 	auth, err := env.dao.CreateAuth(input)
+	timer.ObserveDuration()
 	if err != nil {
 		switch err {
 		case dao.ErrDuplicateAuth:
@@ -177,6 +181,8 @@ func (env *env) registerAuthHandler(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(registerAuthResponse{
 		AccessToken: accessToken,
 	})
+
+	metric.RequestSuccess.WithLabelValues(metric.RequestRegister).Inc()
 }
 
 func (env *env) loginAuthHandler(w http.ResponseWriter, r *http.Request) {
@@ -207,7 +213,9 @@ func (env *env) loginAuthHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	timer := prometheus.NewTimer(metric.DatabaseRequestDuration.WithLabelValues(metric.RequestLogin))
 	auth, err := env.dao.ReadAuth(input)
+	timer.ObserveDuration()
 	if err != nil {
 		switch err {
 		case dao.ErrAuthNotFound:
@@ -237,6 +245,8 @@ func (env *env) loginAuthHandler(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(loginAuthResponse{
 		AccessToken: accessToken,
 	})
+
+	metric.RequestSuccess.WithLabelValues(metric.RequestLogin).Inc()
 }
 
 // Create an access token with a 24 hour lifetime

--- a/src/e2e/resources/simple-temple-expected/booking/booking.go
+++ b/src/e2e/resources/simple-temple-expected/booking/booking.go
@@ -8,10 +8,12 @@ import (
 	"net/http"
 
 	"github.com/squat/and/dab/booking/dao"
+	"github.com/squat/and/dab/booking/metric"
 	"github.com/squat/and/dab/booking/util"
 	valid "github.com/asaskevich/govalidator"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -125,7 +127,9 @@ func (env *env) createBookingHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	timer := prometheus.NewTimer(metric.DatabaseRequestDuration.WithLabelValues(metric.RequestCreate))
 	booking, err := env.dao.CreateBooking(input)
+	timer.ObserveDuration()
 	if err != nil {
 		errMsg := util.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))
 		http.Error(w, errMsg, http.StatusInternalServerError)
@@ -135,6 +139,8 @@ func (env *env) createBookingHandler(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(createBookingResponse{
 		ID: booking.ID,
 	})
+
+	metric.RequestSuccess.WithLabelValues(metric.RequestCreate).Inc()
 }
 
 func (env *env) readBookingHandler(w http.ResponseWriter, r *http.Request) {
@@ -181,7 +187,9 @@ func (env *env) readBookingHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	timer := prometheus.NewTimer(metric.DatabaseRequestDuration.WithLabelValues(metric.RequestRead))
 	booking, err := env.dao.ReadBooking(input)
+	timer.ObserveDuration()
 	if err != nil {
 		switch err.(type) {
 		case dao.ErrBookingNotFound:
@@ -196,6 +204,8 @@ func (env *env) readBookingHandler(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(readBookingResponse{
 		ID: booking.ID,
 	})
+
+	metric.RequestSuccess.WithLabelValues(metric.RequestRead).Inc()
 }
 
 func (env *env) deleteBookingHandler(w http.ResponseWriter, r *http.Request) {
@@ -242,7 +252,9 @@ func (env *env) deleteBookingHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	timer := prometheus.NewTimer(metric.DatabaseRequestDuration.WithLabelValues(metric.RequestDelete))
 	err = env.dao.DeleteBooking(input)
+	timer.ObserveDuration()
 	if err != nil {
 		switch err.(type) {
 		case dao.ErrBookingNotFound:
@@ -255,4 +267,6 @@ func (env *env) deleteBookingHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	json.NewEncoder(w).Encode(struct{}{})
+
+	metric.RequestSuccess.WithLabelValues(metric.RequestDelete).Inc()
 }

--- a/src/e2e/resources/simple-temple-expected/simple-temple-test-group/simple-temple-test-group.go
+++ b/src/e2e/resources/simple-temple-expected/simple-temple-test-group/simple-temple-test-group.go
@@ -8,10 +8,12 @@ import (
 	"net/http"
 
 	"github.com/squat/and/dab/simple-temple-test-group/dao"
+	"github.com/squat/and/dab/simple-temple-test-group/metric"
 	"github.com/squat/and/dab/simple-temple-test-group/util"
 	valid "github.com/asaskevich/govalidator"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -125,7 +127,9 @@ func (env *env) createSimpleTempleTestGroupHandler(w http.ResponseWriter, r *htt
 		}
 	}
 
+	timer := prometheus.NewTimer(metric.DatabaseRequestDuration.WithLabelValues(metric.RequestCreate))
 	simpleTempleTestGroup, err := env.dao.CreateSimpleTempleTestGroup(input)
+	timer.ObserveDuration()
 	if err != nil {
 		errMsg := util.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))
 		http.Error(w, errMsg, http.StatusInternalServerError)
@@ -135,6 +139,8 @@ func (env *env) createSimpleTempleTestGroupHandler(w http.ResponseWriter, r *htt
 	json.NewEncoder(w).Encode(createSimpleTempleTestGroupResponse{
 		ID: simpleTempleTestGroup.ID,
 	})
+
+	metric.RequestSuccess.WithLabelValues(metric.RequestCreate).Inc()
 }
 
 func (env *env) readSimpleTempleTestGroupHandler(w http.ResponseWriter, r *http.Request) {
@@ -181,7 +187,9 @@ func (env *env) readSimpleTempleTestGroupHandler(w http.ResponseWriter, r *http.
 		}
 	}
 
+	timer := prometheus.NewTimer(metric.DatabaseRequestDuration.WithLabelValues(metric.RequestRead))
 	simpleTempleTestGroup, err := env.dao.ReadSimpleTempleTestGroup(input)
+	timer.ObserveDuration()
 	if err != nil {
 		switch err.(type) {
 		case dao.ErrSimpleTempleTestGroupNotFound:
@@ -196,6 +204,8 @@ func (env *env) readSimpleTempleTestGroupHandler(w http.ResponseWriter, r *http.
 	json.NewEncoder(w).Encode(readSimpleTempleTestGroupResponse{
 		ID: simpleTempleTestGroup.ID,
 	})
+
+	metric.RequestSuccess.WithLabelValues(metric.RequestRead).Inc()
 }
 
 func (env *env) deleteSimpleTempleTestGroupHandler(w http.ResponseWriter, r *http.Request) {
@@ -242,7 +252,9 @@ func (env *env) deleteSimpleTempleTestGroupHandler(w http.ResponseWriter, r *htt
 		}
 	}
 
+	timer := prometheus.NewTimer(metric.DatabaseRequestDuration.WithLabelValues(metric.RequestDelete))
 	err = env.dao.DeleteSimpleTempleTestGroup(input)
+	timer.ObserveDuration()
 	if err != nil {
 		switch err.(type) {
 		case dao.ErrSimpleTempleTestGroupNotFound:
@@ -255,4 +267,6 @@ func (env *env) deleteSimpleTempleTestGroupHandler(w http.ResponseWriter, r *htt
 	}
 
 	json.NewEncoder(w).Encode(struct{}{})
+
+	metric.RequestSuccess.WithLabelValues(metric.RequestDelete).Inc()
 }

--- a/src/e2e/resources/simple-temple-expected/simple-temple-test-user/simple-temple-test-user.go
+++ b/src/e2e/resources/simple-temple-expected/simple-temple-test-user/simple-temple-test-user.go
@@ -9,10 +9,12 @@ import (
 	"time"
 
 	"github.com/squat/and/dab/simple-temple-test-user/dao"
+	"github.com/squat/and/dab/simple-temple-test-user/metric"
 	"github.com/squat/and/dab/simple-temple-test-user/util"
 	valid "github.com/asaskevich/govalidator"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -174,7 +176,9 @@ func (env *env) listSimpleTempleTestUserHandler(w http.ResponseWriter, r *http.R
 		}
 	}
 
+	timer := prometheus.NewTimer(metric.DatabaseRequestDuration.WithLabelValues(metric.RequestList))
 	simpleTempleTestUserList, err := env.dao.ListSimpleTempleTestUser()
+	timer.ObserveDuration()
 	if err != nil {
 		errMsg := util.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))
 		http.Error(w, errMsg, http.StatusInternalServerError)
@@ -201,6 +205,8 @@ func (env *env) listSimpleTempleTestUserHandler(w http.ResponseWriter, r *http.R
 	}
 
 	json.NewEncoder(w).Encode(simpleTempleTestUserListResp)
+
+	metric.RequestSuccess.WithLabelValues(metric.RequestList).Inc()
 }
 
 func (env *env) createSimpleTempleTestUserHandler(w http.ResponseWriter, r *http.Request) {
@@ -274,7 +280,9 @@ func (env *env) createSimpleTempleTestUserHandler(w http.ResponseWriter, r *http
 		}
 	}
 
+	timer := prometheus.NewTimer(metric.DatabaseRequestDuration.WithLabelValues(metric.RequestCreate))
 	simpleTempleTestUser, err := env.dao.CreateSimpleTempleTestUser(input)
+	timer.ObserveDuration()
 	if err != nil {
 		errMsg := util.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))
 		http.Error(w, errMsg, http.StatusInternalServerError)
@@ -293,6 +301,8 @@ func (env *env) createSimpleTempleTestUserHandler(w http.ResponseWriter, r *http
 		BirthDate:            simpleTempleTestUser.BirthDate.Format("2006-01-02"),
 		BreakfastTime:        simpleTempleTestUser.BreakfastTime.Format("15:04:05.999999999"),
 	})
+
+	metric.RequestSuccess.WithLabelValues(metric.RequestCreate).Inc()
 }
 
 func (env *env) readSimpleTempleTestUserHandler(w http.ResponseWriter, r *http.Request) {
@@ -321,7 +331,9 @@ func (env *env) readSimpleTempleTestUserHandler(w http.ResponseWriter, r *http.R
 		}
 	}
 
+	timer := prometheus.NewTimer(metric.DatabaseRequestDuration.WithLabelValues(metric.RequestRead))
 	simpleTempleTestUser, err := env.dao.ReadSimpleTempleTestUser(input)
+	timer.ObserveDuration()
 	if err != nil {
 		switch err.(type) {
 		case dao.ErrSimpleTempleTestUserNotFound:
@@ -345,6 +357,8 @@ func (env *env) readSimpleTempleTestUserHandler(w http.ResponseWriter, r *http.R
 		BirthDate:            simpleTempleTestUser.BirthDate.Format("2006-01-02"),
 		BreakfastTime:        simpleTempleTestUser.BreakfastTime.Format("15:04:05.999999999"),
 	})
+
+	metric.RequestSuccess.WithLabelValues(metric.RequestRead).Inc()
 }
 
 func (env *env) updateSimpleTempleTestUserHandler(w http.ResponseWriter, r *http.Request) {
@@ -430,7 +444,9 @@ func (env *env) updateSimpleTempleTestUserHandler(w http.ResponseWriter, r *http
 		}
 	}
 
+	timer := prometheus.NewTimer(metric.DatabaseRequestDuration.WithLabelValues(metric.RequestUpdate))
 	simpleTempleTestUser, err := env.dao.UpdateSimpleTempleTestUser(input)
+	timer.ObserveDuration()
 	if err != nil {
 		switch err.(type) {
 		case dao.ErrSimpleTempleTestUserNotFound:
@@ -454,4 +470,6 @@ func (env *env) updateSimpleTempleTestUserHandler(w http.ResponseWriter, r *http
 		BirthDate:            simpleTempleTestUser.BirthDate.Format("2006-01-02"),
 		BreakfastTime:        simpleTempleTestUser.BreakfastTime.Format("15:04:05.999999999"),
 	})
+
+	metric.RequestSuccess.WithLabelValues(metric.RequestUpdate).Inc()
 }

--- a/src/main/resources/go/genFiles/auth/main/handlers.go.snippet
+++ b/src/main/resources/go/genFiles/auth/main/handlers.go.snippet
@@ -43,7 +43,9 @@ func (env *env) registerAuthHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	timer := prometheus.NewTimer(metric.DatabaseRequestDuration.WithLabelValues(metric.RequestRegister))
 	auth, err := env.dao.CreateAuth(input)
+	timer.ObserveDuration()
 	if err != nil {
 		switch err {
 		case dao.ErrDuplicateAuth:
@@ -65,6 +67,8 @@ func (env *env) registerAuthHandler(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(registerAuthResponse{
 		AccessToken: accessToken,
 	})
+
+	metric.RequestSuccess.WithLabelValues(metric.RequestRegister).Inc()
 }
 
 func (env *env) loginAuthHandler(w http.ResponseWriter, r *http.Request) {
@@ -95,7 +99,9 @@ func (env *env) loginAuthHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	timer := prometheus.NewTimer(metric.DatabaseRequestDuration.WithLabelValues(metric.RequestLogin))
 	auth, err := env.dao.ReadAuth(input)
+	timer.ObserveDuration()
 	if err != nil {
 		switch err {
 		case dao.ErrAuthNotFound:
@@ -125,4 +131,6 @@ func (env *env) loginAuthHandler(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(loginAuthResponse{
 		AccessToken: accessToken,
 	})
+
+	metric.RequestSuccess.WithLabelValues(metric.RequestLogin).Inc()
 }

--- a/src/main/scala/temple/generate/server/go/auth/GoAuthServiceMainGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/auth/GoAuthServiceMainGenerator.scala
@@ -17,8 +17,7 @@ object GoAuthServiceMainGenerator {
     val customImports = mkCode.lines(
       doubleQuote(s"${root.module}/comm"),
       doubleQuote(s"${root.module}/dao"),
-      // TODO: Uncomment when metrics are added to handlers
-      //when(usesMetrics) { doubleQuote(s"${root.module}/metric") },
+      when(usesMetrics) { doubleQuote(s"${root.module}/metric") },
       doubleQuote(s"${root.module}/util"),
       s"valid ${doubleQuote("github.com/asaskevich/govalidator")}",
       doubleQuote("github.com/dgrijalva/jwt-go"),
@@ -26,8 +25,7 @@ object GoAuthServiceMainGenerator {
       doubleQuote("github.com/gorilla/mux"),
       when(usesMetrics) {
         mkCode.lines(
-          // TODO: Uncomment when metrics are added to handlers
-          //doubleQuote("github.com/prometheus/client_golang/prometheus"),
+          doubleQuote("github.com/prometheus/client_golang/prometheus"),
           doubleQuote("github.com/prometheus/client_golang/prometheus/promhttp"),
         )
       },

--- a/src/main/scala/temple/generate/server/go/common/GoCommonMainGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/common/GoCommonMainGenerator.scala
@@ -1,6 +1,6 @@
 package temple.generate.server.go.common
 
-import temple.generate.server.{ServiceName, ServiceRoot}
+import temple.generate.server.ServiceName
 import temple.generate.server.go.common.GoCommonGenerator._
 import temple.generate.utils.CodeTerm.{CodeWrap, mkCode}
 import temple.utils.StringUtils.doubleQuote
@@ -128,4 +128,23 @@ object GoCommonMainGenerator {
         ),
       ),
     )
+
+  /** Generate the metric timer declaration, ready to measure the duration of a DAO call */
+  private[go] def generateMetricTimerDecl(metricSuffix: String): String =
+    genDeclareAndAssign(
+      genMethodCall(
+        "prometheus",
+        "NewTimer",
+        genMethodCall("metric.DatabaseRequestDuration", "WithLabelValues", s"metric.Request$metricSuffix"),
+      ),
+      "timer",
+    )
+
+  /** Generate the metric timer observation, to log the duration of a DAO call */
+  private[go] def generateMetricTimerObservation(): String =
+    genMethodCall("timer", "ObserveDuration")
+
+  /** Generate the metric call to log a successful request */
+  private[go] def generateMetricSuccess(metricSuffix: String): String =
+    genMethodCall(genMethodCall("metric.RequestSuccess", "WithLabelValues", s"metric.Request$metricSuffix"), "Inc")
 }

--- a/src/main/scala/temple/generate/server/go/service/GoServiceGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/GoServiceGenerator.scala
@@ -62,7 +62,7 @@ object GoServiceGenerator extends ServiceGenerator {
           GoServiceMainGenerator.generateCheckAuthorization(root)
         },
         GoServiceMainHandlersGenerator
-          .generateHandlers(root, operations, clientAttributes, usesComms, enumeratingByCreator),
+          .generateHandlers(root, operations, clientAttributes, usesComms, enumeratingByCreator, usesMetrics),
       ),
       File(root.kebabName, "setup.go") -> mkCode.doubleLines(
         GoCommonGenerator.generatePackage("main"),

--- a/src/main/scala/temple/generate/server/go/service/main/GoServiceMainCreateHandlerGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/main/GoServiceMainCreateHandlerGenerator.scala
@@ -36,8 +36,9 @@ object GoServiceMainCreateHandlerGenerator {
     )
   }
 
-  private def generateDAOCallBlock(root: ServiceRoot): String =
+  private def generateDAOCallBlock(root: ServiceRoot, usesMetrics: Boolean): String =
     mkCode.lines(
+      when(usesMetrics) { generateMetricTimerDecl(Create) },
       genDeclareAndAssign(
         genMethodCall(
           "env.dao",
@@ -47,6 +48,7 @@ object GoServiceMainCreateHandlerGenerator {
         root.decapitalizedName,
         "err",
       ),
+      when(usesMetrics) { generateMetricTimerObservation() },
       genIfErr(
         generateHTTPErrorReturn(
           StatusInternalServerError,
@@ -63,6 +65,7 @@ object GoServiceMainCreateHandlerGenerator {
     usesComms: Boolean,
     responseMap: ListMap[String, String],
     clientUsesTime: Boolean,
+    usesMetrics: Boolean,
   ): String =
     mkCode(
       generateHandlerDecl(root, Create),
@@ -82,8 +85,9 @@ object GoServiceMainCreateHandlerGenerator {
           when(!root.hasAuthBlock) { generateNewUUIDBlock() },
           generateDAOInput(root, clientAttributes),
           generateInvokeBeforeHookBlock(root, clientAttributes, Create),
-          generateDAOCallBlock(root),
+          generateDAOCallBlock(root, usesMetrics),
           generateJSONResponse(s"create${root.name}", responseMap),
+          when(usesMetrics) { generateMetricSuccess(Create) },
         ),
       ),
     )

--- a/src/main/scala/temple/generate/server/go/service/main/GoServiceMainCreateHandlerGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/main/GoServiceMainCreateHandlerGenerator.scala
@@ -5,7 +5,8 @@ import temple.generate.CRUD.Create
 import temple.generate.server.ServiceRoot
 import temple.generate.server.go.GoHTTPStatus.StatusInternalServerError
 import temple.generate.server.go.common.GoCommonGenerator._
-import temple.generate.server.go.service.main.GoServiceMainHandlersGenerator.{generateHandlerDecl, _}
+import temple.generate.server.go.common.GoCommonMainGenerator._
+import temple.generate.server.go.service.main.GoServiceMainHandlersGenerator._
 import temple.generate.utils.CodeTerm.{CodeWrap, mkCode}
 
 import scala.Option.when
@@ -38,7 +39,7 @@ object GoServiceMainCreateHandlerGenerator {
 
   private def generateDAOCallBlock(root: ServiceRoot, usesMetrics: Boolean): String =
     mkCode.lines(
-      when(usesMetrics) { generateMetricTimerDecl(Create) },
+      when(usesMetrics) { generateMetricTimerDecl(Create.toString) },
       genDeclareAndAssign(
         genMethodCall(
           "env.dao",
@@ -87,7 +88,7 @@ object GoServiceMainCreateHandlerGenerator {
           generateInvokeBeforeHookBlock(root, clientAttributes, Create),
           generateDAOCallBlock(root, usesMetrics),
           generateJSONResponse(s"create${root.name}", responseMap),
-          when(usesMetrics) { generateMetricSuccess(Create) },
+          when(usesMetrics) { generateMetricSuccess(Create.toString) },
         ),
       ),
     )

--- a/src/main/scala/temple/generate/server/go/service/main/GoServiceMainDeleteHandlerGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/main/GoServiceMainDeleteHandlerGenerator.scala
@@ -4,6 +4,7 @@ import temple.ast.Metadata.Writable
 import temple.generate.CRUD.Delete
 import temple.generate.server.ServiceRoot
 import temple.generate.server.go.common.GoCommonGenerator._
+import temple.generate.server.go.common.GoCommonMainGenerator._
 import temple.generate.server.go.service.main.GoServiceMainHandlersGenerator._
 import temple.generate.utils.CodeTerm.{CodeWrap, mkCode}
 
@@ -20,7 +21,7 @@ object GoServiceMainDeleteHandlerGenerator {
 
   private def generateDAOCallBlock(root: ServiceRoot, usesMetrics: Boolean): String =
     mkCode.lines(
-      when(usesMetrics) { generateMetricTimerDecl(Delete) },
+      when(usesMetrics) { generateMetricTimerDecl(Delete.toString) },
       genAssign(
         genMethodCall(
           "env.dao",
@@ -46,7 +47,7 @@ object GoServiceMainDeleteHandlerGenerator {
           generateInvokeBeforeHookBlock(root, ListMap(), Delete),
           generateDAOCallBlock(root, usesMetrics),
           genMethodCall(genMethodCall("json", "NewEncoder", "w"), "Encode", "struct{}{}"),
-          when(usesMetrics) { generateMetricSuccess(Delete) },
+          when(usesMetrics) { generateMetricSuccess(Delete.toString) },
         ),
       ),
     )

--- a/src/main/scala/temple/generate/server/go/service/main/GoServiceMainDeleteHandlerGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/main/GoServiceMainDeleteHandlerGenerator.scala
@@ -18,8 +18,9 @@ object GoServiceMainDeleteHandlerGenerator {
       "input",
     )
 
-  private def generateDAOCallBlock(root: ServiceRoot): String =
+  private def generateDAOCallBlock(root: ServiceRoot, usesMetrics: Boolean): String =
     mkCode.lines(
+      when(usesMetrics) { generateMetricTimerDecl(Delete) },
       genAssign(
         genMethodCall(
           "env.dao",
@@ -28,11 +29,12 @@ object GoServiceMainDeleteHandlerGenerator {
         ),
         "err",
       ),
+      when(usesMetrics) { generateMetricTimerObservation() },
       generateDAOCallErrorBlock(root),
     )
 
   /** Generate the delete handler function */
-  private[main] def generateDeleteHandler(root: ServiceRoot): String =
+  private[main] def generateDeleteHandler(root: ServiceRoot, usesMetrics: Boolean): String =
     mkCode(
       generateHandlerDecl(root, Delete),
       CodeWrap.curly.tabbed(
@@ -42,8 +44,9 @@ object GoServiceMainDeleteHandlerGenerator {
           when(root.writable == Writable.This) { generateCheckAuthorizationBlock(root) },
           generateDAOInput(root),
           generateInvokeBeforeHookBlock(root, ListMap(), Delete),
-          generateDAOCallBlock(root),
+          generateDAOCallBlock(root, usesMetrics),
           genMethodCall(genMethodCall("json", "NewEncoder", "w"), "Encode", "struct{}{}"),
+          when(usesMetrics) { generateMetricSuccess(Delete) },
         ),
       ),
     )

--- a/src/main/scala/temple/generate/server/go/service/main/GoServiceMainGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/main/GoServiceMainGenerator.scala
@@ -34,16 +34,14 @@ object GoServiceMainGenerator {
         "",
         when(usesComms) { doubleQuote(s"${root.module}/comm") },
         doubleQuote(s"${root.module}/dao"),
-        // TODO: Uncomment when metrics are added to handlers
-        //when(usesMetrics) { doubleQuote(s"${root.module}/metric") },
+        when(usesMetrics) { doubleQuote(s"${root.module}/metric") },
         doubleQuote(s"${root.module}/util"),
         s"valid ${doubleQuote("github.com/asaskevich/govalidator")}",
         doubleQuote("github.com/google/uuid"),
         doubleQuote("github.com/gorilla/mux"),
         when(usesMetrics) {
           mkCode.lines(
-            // TODO: Uncomment when metrics are added to handlers
-            //doubleQuote("github.com/prometheus/client_golang/prometheus"),
+            doubleQuote("github.com/prometheus/client_golang/prometheus"),
             doubleQuote("github.com/prometheus/client_golang/prometheus/promhttp"),
           )
         },

--- a/src/main/scala/temple/generate/server/go/service/main/GoServiceMainHandlersGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/main/GoServiceMainHandlersGenerator.scala
@@ -2,7 +2,7 @@ package temple.generate.server.go.service.main
 
 import temple.ast.AttributeType.{BlobType, DateTimeType, DateType, TimeType}
 import temple.ast.Metadata.Readable
-import temple.ast.{AbstractAttribute, Annotation, AttributeType}
+import temple.ast.{AbstractAttribute, AttributeType}
 import temple.generate.CRUD._
 import temple.generate.server.ServiceRoot
 import temple.generate.server.go.GoHTTPStatus._
@@ -285,21 +285,6 @@ object GoServiceMainHandlersGenerator {
         )
     }
 
-  /** Generate the metric timer declaration, ready to measure the duration of a DAO call */
-  private[main] def generateMetricTimerDecl(op: CRUD): String =
-    genDeclareAndAssign(
-      genMethodCall(
-        "prometheus",
-        "NewTimer",
-        genMethodCall("metric.DatabaseRequestDuration", "WithLabelValues", s"metric.Request$op"),
-      ),
-      "timer",
-    )
-
-  /** Generate the metric timer observation, to log the duration of a DAO call */
-  private[main] def generateMetricTimerObservation(): String =
-    genMethodCall("timer", "ObserveDuration")
-
   /** Generate DAO call block error handling for Read, Update and Delete */
   private[main] def generateDAOCallErrorBlock(root: ServiceRoot): String =
     genIfErr(
@@ -347,10 +332,6 @@ object GoServiceMainHandlersGenerator {
       "Encode",
       genPopulateStruct(s"${typePrefix}Response", responseMap),
     )
-
-  /** Generate the metric call to log a successful request */
-  private[main] def generateMetricSuccess(op: CRUD): String =
-    genMethodCall(genMethodCall("metric.RequestSuccess", "WithLabelValues", s"metric.Request$op"), "Inc")
 
   /** Generate the env handler functions */
   private[service] def generateHandlers(

--- a/src/main/scala/temple/generate/server/go/service/main/GoServiceMainListHandlerGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/main/GoServiceMainListHandlerGenerator.scala
@@ -4,6 +4,7 @@ import temple.generate.CRUD.List
 import temple.generate.server.ServiceRoot
 import temple.generate.server.go.GoHTTPStatus.StatusInternalServerError
 import temple.generate.server.go.common.GoCommonGenerator._
+import temple.generate.server.go.common.GoCommonMainGenerator._
 import temple.generate.server.go.service.main.GoServiceMainHandlersGenerator._
 import temple.generate.utils.CodeTerm.{CodeWrap, mkCode}
 
@@ -89,7 +90,7 @@ object GoServiceMainListHandlerGenerator {
             queryDAOInputBlock,
             generateInvokeBeforeHookBlock(root, ListMap(), List),
             mkCode.lines(
-              when(usesMetrics) { generateMetricTimerDecl(List) },
+              when(usesMetrics) { generateMetricTimerDecl(List.toString) },
               queryDAOBlock,
               when(usesMetrics) { generateMetricTimerObservation() },
               queryDAOErrorBlock,
@@ -98,7 +99,7 @@ object GoServiceMainListHandlerGenerator {
           instantiateResponseBlock,
           mapResponseBlock,
           genMethodCall(genMethodCall("json", "NewEncoder", "w"), "Encode", s"${root.decapitalizedName}ListResp"),
-          when(usesMetrics) { generateMetricSuccess(List) },
+          when(usesMetrics) { generateMetricSuccess(List.toString) },
         ),
       ),
     )

--- a/src/main/scala/temple/generate/server/go/service/main/GoServiceMainReadHandlerGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/main/GoServiceMainReadHandlerGenerator.scala
@@ -3,6 +3,7 @@ package temple.generate.server.go.service.main
 import temple.ast.Metadata.Readable
 import temple.generate.CRUD.Read
 import temple.generate.server.ServiceRoot
+import temple.generate.server.go.common.GoCommonMainGenerator._
 import temple.generate.server.go.service.main.GoServiceMainGenerator.{generateDAOReadCall, generateDAOReadInput}
 import temple.generate.server.go.service.main.GoServiceMainHandlersGenerator._
 import temple.generate.utils.CodeTerm.{CodeWrap, mkCode}
@@ -17,7 +18,7 @@ object GoServiceMainReadHandlerGenerator {
       generateDAOReadInput(root),
       generateInvokeBeforeHookBlock(root, ListMap(), Read),
       mkCode.lines(
-        when(usesMetrics) { generateMetricTimerDecl(Read) },
+        when(usesMetrics) { generateMetricTimerDecl(Read.toString) },
         generateDAOReadCall(root),
         when(usesMetrics) { generateMetricTimerObservation() },
         generateDAOCallErrorBlock(root),
@@ -39,7 +40,7 @@ object GoServiceMainReadHandlerGenerator {
           when(root.readable == Readable.This) { generateCheckAuthorizationBlock(root) },
           generateDAOCallBlock(root, usesMetrics),
           generateJSONResponse(s"read${root.name}", responseMap),
-          when(usesMetrics) { generateMetricSuccess(Read) },
+          when(usesMetrics) { generateMetricSuccess(Read.toString) },
         ),
       ),
     )

--- a/src/main/scala/temple/generate/server/go/service/main/GoServiceMainReadHandlerGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/main/GoServiceMainReadHandlerGenerator.scala
@@ -12,18 +12,24 @@ import scala.collection.immutable.ListMap
 
 object GoServiceMainReadHandlerGenerator {
 
-  private def generateDAOCallBlock(root: ServiceRoot): String =
+  private def generateDAOCallBlock(root: ServiceRoot, usesMetrics: Boolean): String =
     mkCode.doubleLines(
       generateDAOReadInput(root),
       generateInvokeBeforeHookBlock(root, ListMap(), Read),
       mkCode.lines(
+        when(usesMetrics) { generateMetricTimerDecl(Read) },
         generateDAOReadCall(root),
+        when(usesMetrics) { generateMetricTimerObservation() },
         generateDAOCallErrorBlock(root),
       ),
     )
 
   /** Generate the read handler function */
-  private[main] def generateReadHandler(root: ServiceRoot, responseMap: ListMap[String, String]): String =
+  private[main] def generateReadHandler(
+    root: ServiceRoot,
+    responseMap: ListMap[String, String],
+    usesMetrics: Boolean,
+  ): String =
     mkCode(
       generateHandlerDecl(root, Read),
       CodeWrap.curly.tabbed(
@@ -31,8 +37,9 @@ object GoServiceMainReadHandlerGenerator {
           when(root.projectUsesAuth) { generateExtractAuthBlock(root.readable == Readable.This) },
           generateExtractIDBlock(root.decapitalizedName),
           when(root.readable == Readable.This) { generateCheckAuthorizationBlock(root) },
-          generateDAOCallBlock(root),
+          generateDAOCallBlock(root, usesMetrics),
           generateJSONResponse(s"read${root.name}", responseMap),
+          when(usesMetrics) { generateMetricSuccess(Read) },
         ),
       ),
     )

--- a/src/main/scala/temple/generate/server/go/service/main/GoServiceMainUpdateHandlerGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/main/GoServiceMainUpdateHandlerGenerator.scala
@@ -5,6 +5,7 @@ import temple.ast.Metadata.Writable
 import temple.generate.CRUD.Update
 import temple.generate.server.ServiceRoot
 import temple.generate.server.go.common.GoCommonGenerator._
+import temple.generate.server.go.common.GoCommonMainGenerator._
 import temple.generate.server.go.service.main.GoServiceMainHandlersGenerator._
 import temple.generate.utils.CodeTerm.{CodeWrap, mkCode}
 
@@ -23,7 +24,7 @@ object GoServiceMainUpdateHandlerGenerator {
 
   private def generateDAOCallBlock(root: ServiceRoot, usesMetrics: Boolean): String =
     mkCode.lines(
-      when(usesMetrics) { generateMetricTimerDecl(Update) },
+      when(usesMetrics) { generateMetricTimerDecl(Update.toString) },
       genDeclareAndAssign(
         genMethodCall("env.dao", s"Update${root.name}", "input"),
         root.decapitalizedName,
@@ -63,7 +64,7 @@ object GoServiceMainUpdateHandlerGenerator {
           generateInvokeBeforeHookBlock(root, clientAttributes, Update),
           generateDAOCallBlock(root, usesMetrics),
           generateJSONResponse(s"update${root.name}", responseMap),
-          when(usesMetrics) { generateMetricSuccess(Update) },
+          when(usesMetrics) { generateMetricSuccess(Update.toString) },
         ),
       ),
     )

--- a/src/test/resources/project-builder-complex/auth/auth.go
+++ b/src/test/resources/project-builder-complex/auth/auth.go
@@ -12,11 +12,13 @@ import (
 
 	"github.com/squat/and/dab/auth/comm"
 	"github.com/squat/and/dab/auth/dao"
+	"github.com/squat/and/dab/auth/metric"
 	"github.com/squat/and/dab/auth/util"
 	valid "github.com/asaskevich/govalidator"
 	"github.com/dgrijalva/jwt-go"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -155,7 +157,9 @@ func (env *env) registerAuthHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	timer := prometheus.NewTimer(metric.DatabaseRequestDuration.WithLabelValues(metric.RequestRegister))
 	auth, err := env.dao.CreateAuth(input)
+	timer.ObserveDuration()
 	if err != nil {
 		switch err {
 		case dao.ErrDuplicateAuth:
@@ -177,6 +181,8 @@ func (env *env) registerAuthHandler(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(registerAuthResponse{
 		AccessToken: accessToken,
 	})
+
+	metric.RequestSuccess.WithLabelValues(metric.RequestRegister).Inc()
 }
 
 func (env *env) loginAuthHandler(w http.ResponseWriter, r *http.Request) {
@@ -207,7 +213,9 @@ func (env *env) loginAuthHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	timer := prometheus.NewTimer(metric.DatabaseRequestDuration.WithLabelValues(metric.RequestLogin))
 	auth, err := env.dao.ReadAuth(input)
+	timer.ObserveDuration()
 	if err != nil {
 		switch err {
 		case dao.ErrAuthNotFound:
@@ -237,6 +245,8 @@ func (env *env) loginAuthHandler(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(loginAuthResponse{
 		AccessToken: accessToken,
 	})
+
+	metric.RequestSuccess.WithLabelValues(metric.RequestLogin).Inc()
 }
 
 // Create an access token with a 24 hour lifetime

--- a/src/test/scala/temple/generate/server/go/testfiles/auth/auth.go.snippet
+++ b/src/test/scala/temple/generate/server/go/testfiles/auth/auth.go.snippet
@@ -12,11 +12,13 @@ import (
 
 	"github.com/TempleEight/spec-golang/auth/comm"
 	"github.com/TempleEight/spec-golang/auth/dao"
+	"github.com/TempleEight/spec-golang/auth/metric"
 	"github.com/TempleEight/spec-golang/auth/util"
 	valid "github.com/asaskevich/govalidator"
 	"github.com/dgrijalva/jwt-go"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -155,7 +157,9 @@ func (env *env) registerAuthHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	timer := prometheus.NewTimer(metric.DatabaseRequestDuration.WithLabelValues(metric.RequestRegister))
 	auth, err := env.dao.CreateAuth(input)
+	timer.ObserveDuration()
 	if err != nil {
 		switch err {
 		case dao.ErrDuplicateAuth:
@@ -177,6 +181,8 @@ func (env *env) registerAuthHandler(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(registerAuthResponse{
 		AccessToken: accessToken,
 	})
+
+	metric.RequestSuccess.WithLabelValues(metric.RequestRegister).Inc()
 }
 
 func (env *env) loginAuthHandler(w http.ResponseWriter, r *http.Request) {
@@ -207,7 +213,9 @@ func (env *env) loginAuthHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	timer := prometheus.NewTimer(metric.DatabaseRequestDuration.WithLabelValues(metric.RequestLogin))
 	auth, err := env.dao.ReadAuth(input)
+	timer.ObserveDuration()
 	if err != nil {
 		switch err {
 		case dao.ErrAuthNotFound:
@@ -237,6 +245,8 @@ func (env *env) loginAuthHandler(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(loginAuthResponse{
 		AccessToken: accessToken,
 	})
+
+	metric.RequestSuccess.WithLabelValues(metric.RequestLogin).Inc()
 }
 
 // Create an access token with a 24 hour lifetime

--- a/src/test/scala/temple/generate/server/go/testfiles/match/match.go.snippet
+++ b/src/test/scala/temple/generate/server/go/testfiles/match/match.go.snippet
@@ -10,10 +10,12 @@ import (
 
 	"github.com/TempleEight/spec-golang/match/comm"
 	"github.com/TempleEight/spec-golang/match/dao"
+	"github.com/TempleEight/spec-golang/match/metric"
 	"github.com/TempleEight/spec-golang/match/util"
 	valid "github.com/asaskevich/govalidator"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -163,7 +165,9 @@ func (env *env) listMatchHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	timer := prometheus.NewTimer(metric.DatabaseRequestDuration.WithLabelValues(metric.RequestList))
 	matchList, err := env.dao.ListMatch(input)
+	timer.ObserveDuration()
 	if err != nil {
 		errMsg := util.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))
 		http.Error(w, errMsg, http.StatusInternalServerError)
@@ -184,6 +188,8 @@ func (env *env) listMatchHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	json.NewEncoder(w).Encode(matchListResp)
+
+	metric.RequestSuccess.WithLabelValues(metric.RequestList).Inc()
 }
 
 func (env *env) createMatchHandler(w http.ResponseWriter, r *http.Request) {
@@ -261,7 +267,9 @@ func (env *env) createMatchHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	timer := prometheus.NewTimer(metric.DatabaseRequestDuration.WithLabelValues(metric.RequestCreate))
 	match, err := env.dao.CreateMatch(input)
+	timer.ObserveDuration()
 	if err != nil {
 		errMsg := util.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))
 		http.Error(w, errMsg, http.StatusInternalServerError)
@@ -274,6 +282,8 @@ func (env *env) createMatchHandler(w http.ResponseWriter, r *http.Request) {
 		UserTwo:   match.UserTwo,
 		MatchedOn: match.MatchedOn.Format(time.RFC3339),
 	})
+
+	metric.RequestSuccess.WithLabelValues(metric.RequestCreate).Inc()
 }
 
 func (env *env) readMatchHandler(w http.ResponseWriter, r *http.Request) {
@@ -320,7 +330,9 @@ func (env *env) readMatchHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	timer := prometheus.NewTimer(metric.DatabaseRequestDuration.WithLabelValues(metric.RequestRead))
 	match, err := env.dao.ReadMatch(input)
+	timer.ObserveDuration()
 	if err != nil {
 		switch err.(type) {
 		case dao.ErrMatchNotFound:
@@ -338,6 +350,8 @@ func (env *env) readMatchHandler(w http.ResponseWriter, r *http.Request) {
 		UserTwo:   match.UserTwo,
 		MatchedOn: match.MatchedOn.Format(time.RFC3339),
 	})
+
+	metric.RequestSuccess.WithLabelValues(metric.RequestRead).Inc()
 }
 
 func (env *env) updateMatchHandler(w http.ResponseWriter, r *http.Request) {
@@ -431,7 +445,9 @@ func (env *env) updateMatchHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	timer := prometheus.NewTimer(metric.DatabaseRequestDuration.WithLabelValues(metric.RequestUpdate))
 	match, err := env.dao.UpdateMatch(input)
+	timer.ObserveDuration()
 	if err != nil {
 		switch err.(type) {
 		case dao.ErrMatchNotFound:
@@ -449,6 +465,8 @@ func (env *env) updateMatchHandler(w http.ResponseWriter, r *http.Request) {
 		UserTwo:   match.UserTwo,
 		MatchedOn: match.MatchedOn.Format(time.RFC3339),
 	})
+
+	metric.RequestSuccess.WithLabelValues(metric.RequestUpdate).Inc()
 }
 
 func (env *env) deleteMatchHandler(w http.ResponseWriter, r *http.Request) {
@@ -495,7 +513,9 @@ func (env *env) deleteMatchHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	timer := prometheus.NewTimer(metric.DatabaseRequestDuration.WithLabelValues(metric.RequestDelete))
 	err = env.dao.DeleteMatch(input)
+	timer.ObserveDuration()
 	if err != nil {
 		switch err.(type) {
 		case dao.ErrMatchNotFound:
@@ -508,4 +528,6 @@ func (env *env) deleteMatchHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	json.NewEncoder(w).Encode(struct{}{})
+
+	metric.RequestSuccess.WithLabelValues(metric.RequestDelete).Inc()
 }

--- a/src/test/scala/temple/generate/server/go/testfiles/user/user.go.snippet
+++ b/src/test/scala/temple/generate/server/go/testfiles/user/user.go.snippet
@@ -8,10 +8,12 @@ import (
 	"net/http"
 
 	"github.com/TempleEight/spec-golang/user/dao"
+	"github.com/TempleEight/spec-golang/user/metric"
 	"github.com/TempleEight/spec-golang/user/util"
 	valid "github.com/asaskevich/govalidator"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -147,7 +149,9 @@ func (env *env) createUserHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	timer := prometheus.NewTimer(metric.DatabaseRequestDuration.WithLabelValues(metric.RequestCreate))
 	user, err := env.dao.CreateUser(input)
+	timer.ObserveDuration()
 	if err != nil {
 		errMsg := util.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))
 		http.Error(w, errMsg, http.StatusInternalServerError)
@@ -158,6 +162,8 @@ func (env *env) createUserHandler(w http.ResponseWriter, r *http.Request) {
 		ID:   user.ID,
 		Name: user.Name,
 	})
+
+	metric.RequestSuccess.WithLabelValues(metric.RequestCreate).Inc()
 }
 
 func (env *env) readUserHandler(w http.ResponseWriter, r *http.Request) {
@@ -186,7 +192,9 @@ func (env *env) readUserHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	timer := prometheus.NewTimer(metric.DatabaseRequestDuration.WithLabelValues(metric.RequestRead))
 	user, err := env.dao.ReadUser(input)
+	timer.ObserveDuration()
 	if err != nil {
 		switch err.(type) {
 		case dao.ErrUserNotFound:
@@ -202,6 +210,8 @@ func (env *env) readUserHandler(w http.ResponseWriter, r *http.Request) {
 		ID:   user.ID,
 		Name: user.Name,
 	})
+
+	metric.RequestSuccess.WithLabelValues(metric.RequestRead).Inc()
 }
 
 func (env *env) updateUserHandler(w http.ResponseWriter, r *http.Request) {
@@ -258,7 +268,9 @@ func (env *env) updateUserHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	timer := prometheus.NewTimer(metric.DatabaseRequestDuration.WithLabelValues(metric.RequestUpdate))
 	user, err := env.dao.UpdateUser(input)
+	timer.ObserveDuration()
 	if err != nil {
 		switch err.(type) {
 		case dao.ErrUserNotFound:
@@ -274,6 +286,8 @@ func (env *env) updateUserHandler(w http.ResponseWriter, r *http.Request) {
 		ID:   user.ID,
 		Name: user.Name,
 	})
+
+	metric.RequestSuccess.WithLabelValues(metric.RequestUpdate).Inc()
 }
 
 func (env *env) deleteUserHandler(w http.ResponseWriter, r *http.Request) {
@@ -308,7 +322,9 @@ func (env *env) deleteUserHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	timer := prometheus.NewTimer(metric.DatabaseRequestDuration.WithLabelValues(metric.RequestDelete))
 	err = env.dao.DeleteUser(input)
+	timer.ObserveDuration()
 	if err != nil {
 		switch err.(type) {
 		case dao.ErrUserNotFound:
@@ -321,4 +337,6 @@ func (env *env) deleteUserHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	json.NewEncoder(w).Encode(struct{}{})
+
+	metric.RequestSuccess.WithLabelValues(metric.RequestDelete).Inc()
 }


### PR DESCRIPTION
* Adds generation of metrics for timing DAO calls
* Adds generation of metrics for counting the success of a request

This is for both auth and non-auth services. I moved the metric generation functions to `common`, then realised that the handlers are read from file in `auth` atm 🤦 

This was really goddamn tedious, and the refactor with `respondWithError` is going to be even worse.