### PR TITLE
[go-gen] Add identify endpoint

### DIFF
--- a/src/e2e/resources/simple-temple-expected/api/simple-temple-test.openapi.yaml
+++ b/src/e2e/resources/simple-temple-expected/api/simple-temple-test.openapi.yaml
@@ -3,6 +3,52 @@ info:
   title: SimpleTempleTest
   version: 0.0.1
 paths:
+  /simpletempletestuser/all:
+    get:
+      summary: Get a list of every simpletempletestuser
+      tags:
+      - SimpleTempleTestUser
+      responses:
+        '200':
+          description: SimpleTempleTestUser list successfully fetched
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                      format: uuid
+                    simpleTempleTestUser:
+                      type: string
+                    email:
+                      type: string
+                      minLength: 5
+                      maxLength: 40
+                    firstName:
+                      type: string
+                    lastName:
+                      type: string
+                    createdAt:
+                      type: string
+                      format: date-time
+                    numberOfDogs:
+                      type: number
+                      format: int32
+                    currentBankBalance:
+                      type: number
+                      format: float
+                      minimum: 0.0
+                    birthDate:
+                      type: string
+                      format: date
+                    breakfastTime:
+                      type: string
+                      format: time
+        '500':
+          $ref: '#/components/responses/Error500'
   /simpletempletestuser:
     post:
       summary: Register a new simpletempletestuser
@@ -83,6 +129,23 @@ paths:
           $ref: '#/components/responses/Error401'
         '500':
           $ref: '#/components/responses/Error500'
+    get:
+      summary: Look up the single simpletempletestuser associated with the access
+        token
+      tags:
+      - SimpleTempleTestUser
+      responses:
+        '302':
+          description: The single simpletempletestuser is accessible from the provided
+            Location
+          headers:
+            Location:
+              description: The location where the single simpletempletestuser can
+                be found
+              schema:
+                type: string
+        '404':
+          $ref: '#/components/responses/Error404'
   /simpletempletestuser/{id}:
     parameters:
     - in: path
@@ -220,52 +283,6 @@ paths:
           $ref: '#/components/responses/Error401'
         '404':
           $ref: '#/components/responses/Error404'
-        '500':
-          $ref: '#/components/responses/Error500'
-  /simpletempletestuser/all:
-    get:
-      summary: Get a list of every simpletempletestuser
-      tags:
-      - SimpleTempleTestUser
-      responses:
-        '200':
-          description: SimpleTempleTestUser list successfully fetched
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    id:
-                      type: string
-                      format: uuid
-                    simpleTempleTestUser:
-                      type: string
-                    email:
-                      type: string
-                      minLength: 5
-                      maxLength: 40
-                    firstName:
-                      type: string
-                    lastName:
-                      type: string
-                    createdAt:
-                      type: string
-                      format: date-time
-                    numberOfDogs:
-                      type: number
-                      format: int32
-                    currentBankBalance:
-                      type: number
-                      format: float
-                      minimum: 0.0
-                    birthDate:
-                      type: string
-                      format: date
-                    breakfastTime:
-                      type: string
-                      format: time
         '500':
           $ref: '#/components/responses/Error500'
   /booking:

--- a/src/e2e/resources/simple-temple-expected/grafana/provisioning/dashboards/simple-temple-test-user.json
+++ b/src/e2e/resources/simple-temple-expected/grafana/provisioning/dashboards/simple-temple-test-user.json
@@ -27,7 +27,217 @@
         "y" : 0
       },
       "hiddenSeries" : false,
-      "id" : 0,
+      "id" : 8,
+      "legend" : {
+        "avg" : false,
+        "current" : false,
+        "max" : false,
+        "min" : false,
+        "rightSide" : true,
+        "show" : true,
+        "total" : false,
+        "values" : false
+      },
+      "lines" : true,
+      "linewidth" : 1,
+      "nullPointMode" : "null",
+      "options" : {
+        "dataLinks" : [
+        ]
+      },
+      "percentage" : false,
+      "pointradius" : 2,
+      "points" : false,
+      "renderer" : "flot",
+      "seriesOverrides" : [
+      ],
+      "spaceLength" : 10,
+      "stack" : false,
+      "steppedLine" : false,
+      "targets" : [
+        {
+          "expr" : "rate(simpletempletestuser_request_success_total{request_type=\"identify\"}[5m])",
+          "legendFormat" : "Success",
+          "refId" : "A"
+        },
+        {
+          "expr" : "rate(simpletempletestuser_request_failure_total{request_type=\"identify\"}[5m])",
+          "legendFormat" : "{{error_code}}",
+          "refId" : "B"
+        }
+      ],
+      "thresholds" : [
+      ],
+      "timeFrom" : null,
+      "timeRegions" : [
+      ],
+      "timeShift" : null,
+      "title" : "Identify SimpleTempleTestUser Requests",
+      "tooltip" : {
+        "shared" : true,
+        "sort" : 0,
+        "value_type" : "individual"
+      },
+      "type" : "graph",
+      "xaxis" : {
+        "buckets" : null,
+        "mode" : "time",
+        "name" : null,
+        "show" : true,
+        "values" : [
+        ]
+      },
+      "yaxes" : [
+        {
+          "format" : "short",
+          "label" : "QPS",
+          "logBase" : 1,
+          "max" : null,
+          "min" : null,
+          "show" : true
+        },
+        {
+          "format" : "short",
+          "label" : null,
+          "logBase" : 1,
+          "max" : null,
+          "min" : null,
+          "show" : true
+        }
+      ],
+      "yaxis" : {
+        "align" : false,
+        "alignLevel" : null
+      }
+    },
+    {
+      "aliasColors" : {
+        
+      },
+      "bars" : false,
+      "dashLength" : 10,
+      "dashes" : false,
+      "datasource" : "Prometheus",
+      "fill" : 1,
+      "fillGradient" : 0,
+      "gridPos" : {
+        "h" : 5,
+        "w" : 12,
+        "x" : 12,
+        "y" : 0
+      },
+      "hiddenSeries" : false,
+      "id" : 9,
+      "legend" : {
+        "avg" : false,
+        "current" : false,
+        "max" : false,
+        "min" : false,
+        "rightSide" : true,
+        "show" : true,
+        "total" : false,
+        "values" : false
+      },
+      "lines" : true,
+      "linewidth" : 1,
+      "nullPointMode" : "null",
+      "options" : {
+        "dataLinks" : [
+        ]
+      },
+      "percentage" : false,
+      "pointradius" : 2,
+      "points" : false,
+      "renderer" : "flot",
+      "seriesOverrides" : [
+      ],
+      "spaceLength" : 10,
+      "stack" : false,
+      "steppedLine" : false,
+      "targets" : [
+        {
+          "expr" : "simpletempletestuser_database_request_seconds{quantile=\"0.5\",query_type=\"identify\"}",
+          "legendFormat" : "50th Percentile",
+          "refId" : "A"
+        },
+        {
+          "expr" : "simpletempletestuser_database_request_seconds{quantile=\"0.9\",query_type=\"identify\"}",
+          "legendFormat" : "90th Percentile",
+          "refId" : "B"
+        },
+        {
+          "expr" : "simpletempletestuser_database_request_seconds{quantile=\"0.95\",query_type=\"identify\"}",
+          "legendFormat" : "95th Percentile",
+          "refId" : "C"
+        },
+        {
+          "expr" : "simpletempletestuser_database_request_seconds{quantile=\"0.99\",query_type=\"identify\"}",
+          "legendFormat" : "99th Percentile",
+          "refId" : "D"
+        }
+      ],
+      "thresholds" : [
+      ],
+      "timeFrom" : null,
+      "timeRegions" : [
+      ],
+      "timeShift" : null,
+      "title" : "DB Identify Queries",
+      "tooltip" : {
+        "shared" : true,
+        "sort" : 0,
+        "value_type" : "individual"
+      },
+      "type" : "graph",
+      "xaxis" : {
+        "buckets" : null,
+        "mode" : "time",
+        "name" : null,
+        "show" : true,
+        "values" : [
+        ]
+      },
+      "yaxes" : [
+        {
+          "format" : "short",
+          "label" : "Time (seconds)",
+          "logBase" : 1,
+          "max" : null,
+          "min" : null,
+          "show" : true
+        },
+        {
+          "format" : "short",
+          "label" : null,
+          "logBase" : 1,
+          "max" : null,
+          "min" : null,
+          "show" : true
+        }
+      ],
+      "yaxis" : {
+        "align" : false,
+        "alignLevel" : null
+      }
+    },
+    {
+      "aliasColors" : {
+        
+      },
+      "bars" : false,
+      "dashLength" : 10,
+      "dashes" : false,
+      "datasource" : "Prometheus",
+      "fill" : 1,
+      "fillGradient" : 0,
+      "gridPos" : {
+        "h" : 5,
+        "w" : 12,
+        "x" : 0,
+        "y" : 5
+      },
+      "hiddenSeries" : false,
+      "id" : 2,
       "legend" : {
         "avg" : false,
         "current" : false,
@@ -124,10 +334,10 @@
         "h" : 5,
         "w" : 12,
         "x" : 12,
-        "y" : 0
+        "y" : 5
       },
       "hiddenSeries" : false,
-      "id" : 1,
+      "id" : 3,
       "legend" : {
         "avg" : false,
         "current" : false,
@@ -234,10 +444,10 @@
         "h" : 5,
         "w" : 12,
         "x" : 0,
-        "y" : 5
+        "y" : 10
       },
       "hiddenSeries" : false,
-      "id" : 2,
+      "id" : 4,
       "legend" : {
         "avg" : false,
         "current" : false,
@@ -334,10 +544,10 @@
         "h" : 5,
         "w" : 12,
         "x" : 12,
-        "y" : 5
+        "y" : 10
       },
       "hiddenSeries" : false,
-      "id" : 3,
+      "id" : 5,
       "legend" : {
         "avg" : false,
         "current" : false,
@@ -444,220 +654,10 @@
         "h" : 5,
         "w" : 12,
         "x" : 0,
-        "y" : 10
-      },
-      "hiddenSeries" : false,
-      "id" : 4,
-      "legend" : {
-        "avg" : false,
-        "current" : false,
-        "max" : false,
-        "min" : false,
-        "rightSide" : true,
-        "show" : true,
-        "total" : false,
-        "values" : false
-      },
-      "lines" : true,
-      "linewidth" : 1,
-      "nullPointMode" : "null",
-      "options" : {
-        "dataLinks" : [
-        ]
-      },
-      "percentage" : false,
-      "pointradius" : 2,
-      "points" : false,
-      "renderer" : "flot",
-      "seriesOverrides" : [
-      ],
-      "spaceLength" : 10,
-      "stack" : false,
-      "steppedLine" : false,
-      "targets" : [
-        {
-          "expr" : "rate(simpletempletestuser_request_success_total{request_type=\"update\"}[5m])",
-          "legendFormat" : "Success",
-          "refId" : "A"
-        },
-        {
-          "expr" : "rate(simpletempletestuser_request_failure_total{request_type=\"update\"}[5m])",
-          "legendFormat" : "{{error_code}}",
-          "refId" : "B"
-        }
-      ],
-      "thresholds" : [
-      ],
-      "timeFrom" : null,
-      "timeRegions" : [
-      ],
-      "timeShift" : null,
-      "title" : "Update SimpleTempleTestUser Requests",
-      "tooltip" : {
-        "shared" : true,
-        "sort" : 0,
-        "value_type" : "individual"
-      },
-      "type" : "graph",
-      "xaxis" : {
-        "buckets" : null,
-        "mode" : "time",
-        "name" : null,
-        "show" : true,
-        "values" : [
-        ]
-      },
-      "yaxes" : [
-        {
-          "format" : "short",
-          "label" : "QPS",
-          "logBase" : 1,
-          "max" : null,
-          "min" : null,
-          "show" : true
-        },
-        {
-          "format" : "short",
-          "label" : null,
-          "logBase" : 1,
-          "max" : null,
-          "min" : null,
-          "show" : true
-        }
-      ],
-      "yaxis" : {
-        "align" : false,
-        "alignLevel" : null
-      }
-    },
-    {
-      "aliasColors" : {
-        
-      },
-      "bars" : false,
-      "dashLength" : 10,
-      "dashes" : false,
-      "datasource" : "Prometheus",
-      "fill" : 1,
-      "fillGradient" : 0,
-      "gridPos" : {
-        "h" : 5,
-        "w" : 12,
-        "x" : 12,
-        "y" : 10
-      },
-      "hiddenSeries" : false,
-      "id" : 5,
-      "legend" : {
-        "avg" : false,
-        "current" : false,
-        "max" : false,
-        "min" : false,
-        "rightSide" : true,
-        "show" : true,
-        "total" : false,
-        "values" : false
-      },
-      "lines" : true,
-      "linewidth" : 1,
-      "nullPointMode" : "null",
-      "options" : {
-        "dataLinks" : [
-        ]
-      },
-      "percentage" : false,
-      "pointradius" : 2,
-      "points" : false,
-      "renderer" : "flot",
-      "seriesOverrides" : [
-      ],
-      "spaceLength" : 10,
-      "stack" : false,
-      "steppedLine" : false,
-      "targets" : [
-        {
-          "expr" : "simpletempletestuser_database_request_seconds{quantile=\"0.5\",query_type=\"update\"}",
-          "legendFormat" : "50th Percentile",
-          "refId" : "A"
-        },
-        {
-          "expr" : "simpletempletestuser_database_request_seconds{quantile=\"0.9\",query_type=\"update\"}",
-          "legendFormat" : "90th Percentile",
-          "refId" : "B"
-        },
-        {
-          "expr" : "simpletempletestuser_database_request_seconds{quantile=\"0.95\",query_type=\"update\"}",
-          "legendFormat" : "95th Percentile",
-          "refId" : "C"
-        },
-        {
-          "expr" : "simpletempletestuser_database_request_seconds{quantile=\"0.99\",query_type=\"update\"}",
-          "legendFormat" : "99th Percentile",
-          "refId" : "D"
-        }
-      ],
-      "thresholds" : [
-      ],
-      "timeFrom" : null,
-      "timeRegions" : [
-      ],
-      "timeShift" : null,
-      "title" : "DB Update Queries",
-      "tooltip" : {
-        "shared" : true,
-        "sort" : 0,
-        "value_type" : "individual"
-      },
-      "type" : "graph",
-      "xaxis" : {
-        "buckets" : null,
-        "mode" : "time",
-        "name" : null,
-        "show" : true,
-        "values" : [
-        ]
-      },
-      "yaxes" : [
-        {
-          "format" : "short",
-          "label" : "Time (seconds)",
-          "logBase" : 1,
-          "max" : null,
-          "min" : null,
-          "show" : true
-        },
-        {
-          "format" : "short",
-          "label" : null,
-          "logBase" : 1,
-          "max" : null,
-          "min" : null,
-          "show" : true
-        }
-      ],
-      "yaxis" : {
-        "align" : false,
-        "alignLevel" : null
-      }
-    },
-    {
-      "aliasColors" : {
-        
-      },
-      "bars" : false,
-      "dashLength" : 10,
-      "dashes" : false,
-      "datasource" : "Prometheus",
-      "fill" : 1,
-      "fillGradient" : 0,
-      "gridPos" : {
-        "h" : 5,
-        "w" : 12,
-        "x" : 0,
         "y" : 15
       },
       "hiddenSeries" : false,
-      "id" : 6,
+      "id" : 0,
       "legend" : {
         "avg" : false,
         "current" : false,
@@ -757,7 +757,7 @@
         "y" : 15
       },
       "hiddenSeries" : false,
-      "id" : 7,
+      "id" : 1,
       "legend" : {
         "avg" : false,
         "current" : false,
@@ -867,6 +867,216 @@
         "y" : 20
       },
       "hiddenSeries" : false,
+      "id" : 6,
+      "legend" : {
+        "avg" : false,
+        "current" : false,
+        "max" : false,
+        "min" : false,
+        "rightSide" : true,
+        "show" : true,
+        "total" : false,
+        "values" : false
+      },
+      "lines" : true,
+      "linewidth" : 1,
+      "nullPointMode" : "null",
+      "options" : {
+        "dataLinks" : [
+        ]
+      },
+      "percentage" : false,
+      "pointradius" : 2,
+      "points" : false,
+      "renderer" : "flot",
+      "seriesOverrides" : [
+      ],
+      "spaceLength" : 10,
+      "stack" : false,
+      "steppedLine" : false,
+      "targets" : [
+        {
+          "expr" : "rate(simpletempletestuser_request_success_total{request_type=\"update\"}[5m])",
+          "legendFormat" : "Success",
+          "refId" : "A"
+        },
+        {
+          "expr" : "rate(simpletempletestuser_request_failure_total{request_type=\"update\"}[5m])",
+          "legendFormat" : "{{error_code}}",
+          "refId" : "B"
+        }
+      ],
+      "thresholds" : [
+      ],
+      "timeFrom" : null,
+      "timeRegions" : [
+      ],
+      "timeShift" : null,
+      "title" : "Update SimpleTempleTestUser Requests",
+      "tooltip" : {
+        "shared" : true,
+        "sort" : 0,
+        "value_type" : "individual"
+      },
+      "type" : "graph",
+      "xaxis" : {
+        "buckets" : null,
+        "mode" : "time",
+        "name" : null,
+        "show" : true,
+        "values" : [
+        ]
+      },
+      "yaxes" : [
+        {
+          "format" : "short",
+          "label" : "QPS",
+          "logBase" : 1,
+          "max" : null,
+          "min" : null,
+          "show" : true
+        },
+        {
+          "format" : "short",
+          "label" : null,
+          "logBase" : 1,
+          "max" : null,
+          "min" : null,
+          "show" : true
+        }
+      ],
+      "yaxis" : {
+        "align" : false,
+        "alignLevel" : null
+      }
+    },
+    {
+      "aliasColors" : {
+        
+      },
+      "bars" : false,
+      "dashLength" : 10,
+      "dashes" : false,
+      "datasource" : "Prometheus",
+      "fill" : 1,
+      "fillGradient" : 0,
+      "gridPos" : {
+        "h" : 5,
+        "w" : 12,
+        "x" : 12,
+        "y" : 20
+      },
+      "hiddenSeries" : false,
+      "id" : 7,
+      "legend" : {
+        "avg" : false,
+        "current" : false,
+        "max" : false,
+        "min" : false,
+        "rightSide" : true,
+        "show" : true,
+        "total" : false,
+        "values" : false
+      },
+      "lines" : true,
+      "linewidth" : 1,
+      "nullPointMode" : "null",
+      "options" : {
+        "dataLinks" : [
+        ]
+      },
+      "percentage" : false,
+      "pointradius" : 2,
+      "points" : false,
+      "renderer" : "flot",
+      "seriesOverrides" : [
+      ],
+      "spaceLength" : 10,
+      "stack" : false,
+      "steppedLine" : false,
+      "targets" : [
+        {
+          "expr" : "simpletempletestuser_database_request_seconds{quantile=\"0.5\",query_type=\"update\"}",
+          "legendFormat" : "50th Percentile",
+          "refId" : "A"
+        },
+        {
+          "expr" : "simpletempletestuser_database_request_seconds{quantile=\"0.9\",query_type=\"update\"}",
+          "legendFormat" : "90th Percentile",
+          "refId" : "B"
+        },
+        {
+          "expr" : "simpletempletestuser_database_request_seconds{quantile=\"0.95\",query_type=\"update\"}",
+          "legendFormat" : "95th Percentile",
+          "refId" : "C"
+        },
+        {
+          "expr" : "simpletempletestuser_database_request_seconds{quantile=\"0.99\",query_type=\"update\"}",
+          "legendFormat" : "99th Percentile",
+          "refId" : "D"
+        }
+      ],
+      "thresholds" : [
+      ],
+      "timeFrom" : null,
+      "timeRegions" : [
+      ],
+      "timeShift" : null,
+      "title" : "DB Update Queries",
+      "tooltip" : {
+        "shared" : true,
+        "sort" : 0,
+        "value_type" : "individual"
+      },
+      "type" : "graph",
+      "xaxis" : {
+        "buckets" : null,
+        "mode" : "time",
+        "name" : null,
+        "show" : true,
+        "values" : [
+        ]
+      },
+      "yaxes" : [
+        {
+          "format" : "short",
+          "label" : "Time (seconds)",
+          "logBase" : 1,
+          "max" : null,
+          "min" : null,
+          "show" : true
+        },
+        {
+          "format" : "short",
+          "label" : null,
+          "logBase" : 1,
+          "max" : null,
+          "min" : null,
+          "show" : true
+        }
+      ],
+      "yaxis" : {
+        "align" : false,
+        "alignLevel" : null
+      }
+    },
+    {
+      "aliasColors" : {
+        
+      },
+      "bars" : false,
+      "dashLength" : 10,
+      "dashes" : false,
+      "datasource" : "Prometheus",
+      "fill" : 1,
+      "fillGradient" : 0,
+      "gridPos" : {
+        "h" : 5,
+        "w" : 12,
+        "x" : 0,
+        "y" : 25
+      },
+      "hiddenSeries" : false,
       "id" : 0,
       "legend" : {
         "avg" : false,
@@ -964,7 +1174,7 @@
         "h" : 5,
         "w" : 12,
         "x" : 12,
-        "y" : 20
+        "y" : 25
       },
       "hiddenSeries" : false,
       "id" : 1,
@@ -1074,7 +1284,7 @@
         "h" : 5,
         "w" : 12,
         "x" : 0,
-        "y" : 25
+        "y" : 30
       },
       "hiddenSeries" : false,
       "id" : 8,
@@ -1174,7 +1384,7 @@
         "h" : 5,
         "w" : 12,
         "x" : 12,
-        "y" : 25
+        "y" : 30
       },
       "hiddenSeries" : false,
       "id" : 9,
@@ -1284,7 +1494,7 @@
         "h" : 5,
         "w" : 12,
         "x" : 0,
-        "y" : 30
+        "y" : 35
       },
       "hiddenSeries" : false,
       "id" : 2,
@@ -1384,7 +1594,7 @@
         "h" : 5,
         "w" : 12,
         "x" : 12,
-        "y" : 30
+        "y" : 35
       },
       "hiddenSeries" : false,
       "id" : 3,
@@ -1494,7 +1704,7 @@
         "h" : 5,
         "w" : 12,
         "x" : 0,
-        "y" : 35
+        "y" : 40
       },
       "hiddenSeries" : false,
       "id" : 4,
@@ -1594,7 +1804,7 @@
         "h" : 5,
         "w" : 12,
         "x" : 12,
-        "y" : 35
+        "y" : 40
       },
       "hiddenSeries" : false,
       "id" : 5,
@@ -1704,7 +1914,7 @@
         "h" : 5,
         "w" : 12,
         "x" : 0,
-        "y" : 40
+        "y" : 45
       },
       "hiddenSeries" : false,
       "id" : 6,
@@ -1804,7 +2014,7 @@
         "h" : 5,
         "w" : 12,
         "x" : 12,
-        "y" : 40
+        "y" : 45
       },
       "hiddenSeries" : false,
       "id" : 7,

--- a/src/e2e/resources/simple-temple-expected/simple-temple-test-user/dao/dao.go
+++ b/src/e2e/resources/simple-temple-expected/simple-temple-test-user/dao/dao.go
@@ -76,7 +76,7 @@ type UpdateSimpleTempleTestUserInput struct {
 	BreakfastTime        time.Time
 }
 
-// IdentifySimpleTempleTestUserInput encapsulates the information required to identify the single simpleTempleTestUser in the datastore
+// IdentifySimpleTempleTestUserInput encapsulates the information required to identify the current simpleTempleTestUser in the datastore
 type IdentifySimpleTempleTestUserInput struct {
 	ID uuid.UUID
 }

--- a/src/e2e/resources/simple-temple-expected/simple-temple-test-user/dao/dao.go
+++ b/src/e2e/resources/simple-temple-expected/simple-temple-test-user/dao/dao.go
@@ -18,6 +18,7 @@ type BaseDatastore interface {
 	CreateSimpleTempleTestUser(input CreateSimpleTempleTestUserInput) (*SimpleTempleTestUser, error)
 	ReadSimpleTempleTestUser(input ReadSimpleTempleTestUserInput) (*SimpleTempleTestUser, error)
 	UpdateSimpleTempleTestUser(input UpdateSimpleTempleTestUserInput) (*SimpleTempleTestUser, error)
+	IdentifySimpleTempleTestUser(input IdentifySimpleTempleTestUserInput) (*SimpleTempleTestUser, error)
 }
 
 // DAO encapsulates access to the datastore
@@ -73,6 +74,11 @@ type UpdateSimpleTempleTestUserInput struct {
 	CurrentBankBalance   float32
 	BirthDate            time.Time
 	BreakfastTime        time.Time
+}
+
+// IdentifySimpleTempleTestUserInput encapsulates the information required to identify the single simpleTempleTestUser in the datastore
+type IdentifySimpleTempleTestUserInput struct {
+	ID uuid.UUID
 }
 
 // Init opens the datastore connection, returning a DAO
@@ -153,6 +159,24 @@ func (dao *DAO) ReadSimpleTempleTestUser(input ReadSimpleTempleTestUserInput) (*
 // UpdateSimpleTempleTestUser updates the simpleTempleTestUser in the datastore for a given ID, returning the newly updated simpleTempleTestUser
 func (dao *DAO) UpdateSimpleTempleTestUser(input UpdateSimpleTempleTestUserInput) (*SimpleTempleTestUser, error) {
 	row := executeQueryWithRowResponse(dao.DB, "UPDATE simple_temple_test_user SET simple_temple_test_user = $1, email = $2, first_name = $3, last_name = $4, created_at = $5, number_of_dogs = $6, yeets = $7, current_bank_balance = $8, birth_date = $9, breakfast_time = $10 WHERE id = $11 RETURNING id, simple_temple_test_user, email, first_name, last_name, created_at, number_of_dogs, yeets, current_bank_balance, birth_date, breakfast_time;", input.SimpleTempleTestUser, input.Email, input.FirstName, input.LastName, input.CreatedAt, input.NumberOfDogs, input.Yeets, input.CurrentBankBalance, input.BirthDate, input.BreakfastTime, input.ID)
+
+	var simpleTempleTestUser SimpleTempleTestUser
+	err := row.Scan(&simpleTempleTestUser.ID, &simpleTempleTestUser.SimpleTempleTestUser, &simpleTempleTestUser.Email, &simpleTempleTestUser.FirstName, &simpleTempleTestUser.LastName, &simpleTempleTestUser.CreatedAt, &simpleTempleTestUser.NumberOfDogs, &simpleTempleTestUser.Yeets, &simpleTempleTestUser.CurrentBankBalance, &simpleTempleTestUser.BirthDate, &simpleTempleTestUser.BreakfastTime)
+	if err != nil {
+		switch err {
+		case sql.ErrNoRows:
+			return nil, ErrSimpleTempleTestUserNotFound(input.ID.String())
+		default:
+			return nil, err
+		}
+	}
+
+	return &simpleTempleTestUser, nil
+}
+
+// IdentifySimpleTempleTestUser returns the simpleTempleTestUser in the datastore for a given ID
+func (dao *DAO) IdentifySimpleTempleTestUser(input IdentifySimpleTempleTestUserInput) (*SimpleTempleTestUser, error) {
+	row := executeQueryWithRowResponse(dao.DB, "SELECT id, simple_temple_test_user, email, first_name, last_name, created_at, number_of_dogs, yeets, current_bank_balance, birth_date, breakfast_time FROM simple_temple_test_user WHERE id = $1;", input.ID)
 
 	var simpleTempleTestUser SimpleTempleTestUser
 	err := row.Scan(&simpleTempleTestUser.ID, &simpleTempleTestUser.SimpleTempleTestUser, &simpleTempleTestUser.Email, &simpleTempleTestUser.FirstName, &simpleTempleTestUser.LastName, &simpleTempleTestUser.CreatedAt, &simpleTempleTestUser.NumberOfDogs, &simpleTempleTestUser.Yeets, &simpleTempleTestUser.CurrentBankBalance, &simpleTempleTestUser.BirthDate, &simpleTempleTestUser.BreakfastTime)

--- a/src/e2e/resources/simple-temple-expected/simple-temple-test-user/hook.go
+++ b/src/e2e/resources/simple-temple-expected/simple-temple-test-user/hook.go
@@ -5,14 +5,16 @@ import "github.com/squat/and/dab/simple-temple-test-user/dao"
 // Hook allows additional code to be executed before and after every datastore interaction
 // Hooks are executed in the order they are defined, such that if any hook errors, future hooks are not executed and the request is terminated
 type Hook struct {
-	beforeListHooks   []*func(env *env) *HookError
-	beforeCreateHooks []*func(env *env, req createSimpleTempleTestUserRequest, input *dao.CreateSimpleTempleTestUserInput) *HookError
-	beforeReadHooks   []*func(env *env, input *dao.ReadSimpleTempleTestUserInput) *HookError
-	beforeUpdateHooks []*func(env *env, req updateSimpleTempleTestUserRequest, input *dao.UpdateSimpleTempleTestUserInput) *HookError
-	afterListHooks    []*func(env *env, simpleTempleTestUserList *[]dao.SimpleTempleTestUser) *HookError
-	afterCreateHooks  []*func(env *env, simpleTempleTestUser *dao.SimpleTempleTestUser) *HookError
-	afterReadHooks    []*func(env *env, simpleTempleTestUser *dao.SimpleTempleTestUser) *HookError
-	afterUpdateHooks  []*func(env *env, simpleTempleTestUser *dao.SimpleTempleTestUser) *HookError
+	beforeListHooks     []*func(env *env) *HookError
+	beforeCreateHooks   []*func(env *env, req createSimpleTempleTestUserRequest, input *dao.CreateSimpleTempleTestUserInput) *HookError
+	beforeReadHooks     []*func(env *env, input *dao.ReadSimpleTempleTestUserInput) *HookError
+	beforeUpdateHooks   []*func(env *env, req updateSimpleTempleTestUserRequest, input *dao.UpdateSimpleTempleTestUserInput) *HookError
+	beforeIdentifyHooks []*func(env *env, input *dao.IdentifySimpleTempleTestUserInput) *HookError
+	afterListHooks      []*func(env *env, simpleTempleTestUserList *[]dao.SimpleTempleTestUser) *HookError
+	afterCreateHooks    []*func(env *env, simpleTempleTestUser *dao.SimpleTempleTestUser) *HookError
+	afterReadHooks      []*func(env *env, simpleTempleTestUser *dao.SimpleTempleTestUser) *HookError
+	afterUpdateHooks    []*func(env *env, simpleTempleTestUser *dao.SimpleTempleTestUser) *HookError
+	afterIdentifyHooks  []*func(env *env, simpleTempleTestUser *dao.SimpleTempleTestUser) *HookError
 }
 
 // HookError wraps an existing error with HTTP status code
@@ -45,6 +47,11 @@ func (h *Hook) BeforeUpdate(hook func(env *env, req updateSimpleTempleTestUserRe
 	h.beforeUpdateHooks = append(h.beforeUpdateHooks, &hook)
 }
 
+// BeforeIdentify adds a new hook to be executed before identifying an object in the datastore
+func (h *Hook) BeforeIdentify(hook func(env *env, input *dao.IdentifySimpleTempleTestUserInput) *HookError) {
+	h.beforeIdentifyHooks = append(h.beforeIdentifyHooks, &hook)
+}
+
 // AfterList adds a new hook to be executed after listing the objects in the datastore
 func (h *Hook) AfterList(hook func(env *env, simpleTempleTestUserList *[]dao.SimpleTempleTestUser) *HookError) {
 	h.afterListHooks = append(h.afterListHooks, &hook)
@@ -63,4 +70,9 @@ func (h *Hook) AfterRead(hook func(env *env, simpleTempleTestUser *dao.SimpleTem
 // AfterUpdate adds a new hook to be executed after updating an object in the datastore
 func (h *Hook) AfterUpdate(hook func(env *env, simpleTempleTestUser *dao.SimpleTempleTestUser) *HookError) {
 	h.afterUpdateHooks = append(h.afterUpdateHooks, &hook)
+}
+
+// AfterIdentify adds a new hook to be executed after identifying an object in the datastore
+func (h *Hook) AfterIdentify(hook func(env *env, simpleTempleTestUser *dao.SimpleTempleTestUser) *HookError) {
+	h.afterIdentifyHooks = append(h.afterIdentifyHooks, &hook)
 }

--- a/src/e2e/resources/simple-temple-expected/simple-temple-test-user/metric/metric.go
+++ b/src/e2e/resources/simple-temple-expected/simple-temple-test-user/metric/metric.go
@@ -6,10 +6,11 @@ import (
 )
 
 var (
-	RequestList   = "list"
-	RequestCreate = "create"
-	RequestRead   = "read"
-	RequestUpdate = "update"
+	RequestList     = "list"
+	RequestCreate   = "create"
+	RequestRead     = "read"
+	RequestUpdate   = "update"
+	RequestIdentify = "identify"
 
 	RequestSuccess = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "simpletempletestuser_request_success_total",

--- a/src/e2e/resources/simple-temple-expected/simple-temple-test-user/simple-temple-test-user.go
+++ b/src/e2e/resources/simple-temple-expected/simple-temple-test-user/simple-temple-test-user.go
@@ -120,6 +120,7 @@ func defaultRouter(env *env) *mux.Router {
 	r.HandleFunc("/simple-temple-test-user", env.createSimpleTempleTestUserHandler).Methods(http.MethodPost)
 	r.HandleFunc("/simple-temple-test-user/{id}", env.readSimpleTempleTestUserHandler).Methods(http.MethodGet)
 	r.HandleFunc("/simple-temple-test-user/{id}", env.updateSimpleTempleTestUserHandler).Methods(http.MethodPut)
+	r.HandleFunc("/simple-temple-test-user", env.identifySimpleTempleTestUserHandler).Methods(http.MethodGet)
 	r.Use(jsonMiddleware)
 	return r
 }
@@ -512,4 +513,8 @@ func (env *env) updateSimpleTempleTestUserHandler(w http.ResponseWriter, r *http
 	})
 
 	metric.RequestSuccess.WithLabelValues(metric.RequestUpdate).Inc()
+}
+
+func (env *env) identifySimpleTempleTestUserHandler(w http.ResponseWriter, r *http.Request) {
+
 }

--- a/src/main/scala/temple/builder/DatabaseBuilder.scala
+++ b/src/main/scala/temple/builder/DatabaseBuilder.scala
@@ -3,7 +3,7 @@ package temple.builder
 import temple.ast.AbstractAttribute.{CreatedByAttribute, IDAttribute}
 import temple.ast.Annotation.Nullable
 import temple.ast._
-import temple.generate.CRUD.{CRUD, Create, Delete, List, Read, Update}
+import temple.generate.CRUD._
 import temple.generate.database.ast.ColumnConstraint.Check
 import temple.generate.database.ast.Condition.PreparedComparison
 import temple.generate.database.ast.Expression.PreparedValue
@@ -100,6 +100,12 @@ object DatabaseBuilder {
             condition = when(readable == Metadata.Readable.This) {
               PreparedComparison("created_by", ComparisonOperator.Equal)
             },
+          )
+        case Identify =>
+          Identify -> Statement.Read(
+            tableName,
+            columns = columns,
+            condition = Some(PreparedComparison(selectionAttribute, ComparisonOperator.Equal)),
           )
       }
       .to(SortedMap)

--- a/src/main/scala/temple/builder/MetricsBuilder.scala
+++ b/src/main/scala/temple/builder/MetricsBuilder.scala
@@ -4,6 +4,8 @@ import temple.generate.CRUD.CRUD
 import temple.generate.metrics.grafana.ast.Row.{Metric, Query}
 import temple.generate.metrics.grafana.ast.{Datasource, Row}
 
+import scala.collection.immutable.SortedSet
+
 object MetricsBuilder {
 
   // Generate PromQL queries for determining queries per second to a service
@@ -43,7 +45,7 @@ object MetricsBuilder {
   def createDashboardRows(
     serviceName: String,
     datasource: Datasource,
-    endpoints: Set[CRUD],
+    endpoints: SortedSet[CRUD],
     structName: Option[String] = None,
   ): Seq[Row] =
     endpoints.zipWithIndex.map {

--- a/src/main/scala/temple/builder/ServerBuilder.scala
+++ b/src/main/scala/temple/builder/ServerBuilder.scala
@@ -15,7 +15,7 @@ import temple.generate.server.AttributesRoot.ServiceRoot
 import temple.generate.server._
 import temple.utils.StringUtils
 
-import scala.collection.immutable.{ListMap, SortedMap}
+import scala.collection.immutable.{ListMap, SortedMap, SortedSet}
 
 object ServerBuilder {
 
@@ -23,7 +23,7 @@ object ServerBuilder {
     serviceName: String,
     serviceBlock: AbstractServiceBlock,
     port: Int,
-    endpoints: Set[CRUD],
+    endpoints: SortedSet[CRUD],
     detail: LanguageDetail,
     projectUsesAuth: Boolean,
   ): ServiceRoot = {

--- a/src/main/scala/temple/builder/project/ProjectBuilder.scala
+++ b/src/main/scala/temple/builder/project/ProjectBuilder.scala
@@ -26,15 +26,16 @@ import temple.utils.FileUtils
 import temple.utils.StringUtils._
 
 import Option.when
+import scala.collection.immutable.SortedSet
 
 object ProjectBuilder {
 
-  def endpoints(service: AttributeBlock[_]): Set[CRUD] = {
-    val endpoints: Set[CRUD] = service
+  def endpoints(service: AttributeBlock[_]): SortedSet[CRUD] = {
+    val endpoints: SortedSet[CRUD] = service
       .lookupLocalMetadata[Metadata.Omit]
       .map(_.endpoints)
       .getOrElse(Set.empty)
-      .foldLeft(Set[CRUD](Create, Read, Update, Delete)) {
+      .foldLeft(SortedSet[CRUD](Create, Read, Update, Delete)) {
         case (set, endpoint) =>
           endpoint match {
             case Endpoint.Create => set - CRUD.Create
@@ -43,9 +44,10 @@ object ProjectBuilder {
             case Endpoint.Delete => set - CRUD.Delete
           }
       }
-    // Add read all endpoint if defined
-    if (service hasMetadata Metadata.ServiceEnumerable) endpoints + List
-    else endpoints
+
+    endpoints ++
+    when(service hasMetadata Metadata.ServiceEnumerable) { List } ++
+    when(service hasMetadata Metadata.ServiceAuth) { Identify }
   }
 
   private def buildDatabaseCreationScripts(templefile: Templefile): Files =

--- a/src/main/scala/temple/generate/CRUD.scala
+++ b/src/main/scala/temple/generate/CRUD.scala
@@ -2,7 +2,7 @@ package temple.generate
 
 object CRUD extends Enumeration {
   type CRUD = Value
-  val List, Create, Read, Update, Delete, Identity = Value
+  val List, Create, Read, Update, Delete, Identify = Value
 
   def presentParticiple(crud: CRUD): String = crud match {
     case List     => "listing"
@@ -10,6 +10,6 @@ object CRUD extends Enumeration {
     case Read     => "reading"
     case Update   => "updating"
     case Delete   => "deleting"
-    case Identity => "identifying"
+    case Identify => "identifying"
   }
 }

--- a/src/main/scala/temple/generate/server/go/service/GoServiceHookGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/GoServiceHookGenerator.scala
@@ -18,7 +18,7 @@ object GoServiceHookGenerator {
         case Readable.All =>
           s"func(env *env) *HookError"
       }
-    case op @ (CRUD.Read | CRUD.Delete) =>
+    case op @ (CRUD.Read | CRUD.Delete | CRUD.Identify) =>
       s"func(env *env, input *dao.${op.toString}${root.name}Input) *HookError"
     case op @ (CRUD.Create | CRUD.Update) =>
       if (root.requestAttributes.isEmpty)
@@ -31,7 +31,7 @@ object GoServiceHookGenerator {
   private def generateAfterHookType(root: ServiceRoot, operation: CRUD): String = operation match {
     case CRUD.List =>
       s"func(env *env, ${root.decapitalizedName}List *[]dao.${root.name}) *HookError"
-    case CRUD.Create | CRUD.Read | CRUD.Update =>
+    case CRUD.Create | CRUD.Read | CRUD.Update | CRUD.Identify =>
       s"func(env *env, ${root.decapitalizedName} *dao.${root.name}) *HookError"
     case CRUD.Delete =>
       "func(env *env) *HookError"

--- a/src/main/scala/temple/generate/server/go/service/dao/GoServiceDAOInputStructsGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/dao/GoServiceDAOInputStructsGenerator.scala
@@ -17,7 +17,7 @@ object GoServiceDAOInputStructsGenerator {
     operation match {
       case List                            => s"read a ${root.decapitalizedName} list"
       case Create | Read | Update | Delete => s"${operation.toString.toLowerCase} a single ${root.decapitalizedName}"
-      case Identify                        => s"identify the single ${root.decapitalizedName}"
+      case Identify                        => s"identify the current ${root.decapitalizedName}"
     }
 
   private def generateStruct(root: ServiceRoot, operation: CRUD): String = {
@@ -44,12 +44,10 @@ object GoServiceDAOInputStructsGenerator {
           CodeUtils.pad(
             operation match {
               // Compose struct fields for each operation
-              case List     => createdByMap
-              case Create   => idMap ++ createdByMap ++ attributesMap
-              case Read     => idMap
-              case Update   => idMap ++ attributesMap
-              case Delete   => idMap
-              case Identify => idMap
+              case List                     => createdByMap
+              case Create                   => idMap ++ createdByMap ++ attributesMap
+              case Read | Delete | Identify => idMap
+              case Update                   => idMap ++ attributesMap
             },
           ),
         ),

--- a/src/main/scala/temple/generate/server/go/service/dao/GoServiceDAOInputStructsGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/dao/GoServiceDAOInputStructsGenerator.scala
@@ -2,7 +2,7 @@ package temple.generate.server.go.service.dao
 
 import temple.ast.AttributeType
 import temple.generate.CRUD
-import temple.generate.CRUD.{CRUD, Create, Delete, List, Read, Update}
+import temple.generate.CRUD.{CRUD, Create, Delete, List, Read, Update, Identify}
 import temple.generate.server.AttributesRoot.ServiceRoot
 import temple.generate.server.go.common.GoCommonGenerator.generateGoType
 import temple.generate.server.go.service.dao.GoServiceDAOGenerator.generateDAOFunctionName
@@ -17,6 +17,7 @@ object GoServiceDAOInputStructsGenerator {
     operation match {
       case List                            => s"read a ${root.decapitalizedName} list"
       case Create | Read | Update | Delete => s"${operation.toString.toLowerCase} a single ${root.decapitalizedName}"
+      case Identify                        => s"identify the single ${root.decapitalizedName}"
     }
 
   private def generateStruct(root: ServiceRoot, operation: CRUD): String = {
@@ -43,11 +44,12 @@ object GoServiceDAOInputStructsGenerator {
           CodeUtils.pad(
             operation match {
               // Compose struct fields for each operation
-              case List   => createdByMap
-              case Create => idMap ++ createdByMap ++ attributesMap
-              case Read   => idMap
-              case Update => idMap ++ attributesMap
-              case Delete => idMap
+              case List     => createdByMap
+              case Create   => idMap ++ createdByMap ++ attributesMap
+              case Read     => idMap
+              case Update   => idMap ++ attributesMap
+              case Delete   => idMap
+              case Identify => idMap
             },
           ),
         ),

--- a/src/main/scala/temple/generate/server/go/service/dao/GoServiceDAOInterfaceGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/dao/GoServiceDAOInterfaceGenerator.scala
@@ -1,7 +1,7 @@
 package temple.generate.server.go.service.dao
 
 import temple.generate.CRUD
-import temple.generate.CRUD.{CRUD, Create, Delete, List, Read, Update}
+import temple.generate.CRUD._
 import temple.generate.server.AttributesRoot.ServiceRoot
 import temple.generate.server.go.service.dao.GoServiceDAOGenerator.generateDAOFunctionName
 import temple.generate.utils.CodeTerm.{CodeWrap, mkCode}
@@ -10,9 +10,9 @@ object GoServiceDAOInterfaceGenerator {
 
   private def generateInterfaceFunctionReturnType(root: ServiceRoot, operation: CRUD): String =
     operation match {
-      case List                   => s"(*[]${root.name}, error)"
-      case Create | Read | Update => s"(*${root.name}, error)"
-      case Delete                 => "error"
+      case List                              => s"(*[]${root.name}, error)"
+      case Create | Read | Update | Identify => s"(*${root.name}, error)"
+      case Delete                            => "error"
     }
 
   private[dao] def generateInterfaceFunction(

--- a/src/main/scala/temple/generate/server/go/service/main/GoServiceMainGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/main/GoServiceMainGenerator.scala
@@ -60,6 +60,8 @@ object GoServiceMainGenerator {
             s"r.HandleFunc(${doubleQuote(s"/${root.kebabName}/{id}")}, env.update${root.name}Handler).Methods(http.MethodPut)"
           case Delete =>
             s"r.HandleFunc(${doubleQuote(s"/${root.kebabName}/{id}")}, env.delete${root.name}Handler).Methods(http.MethodDelete)"
+          case Identify =>
+            s"r.HandleFunc(${doubleQuote(s"/${root.kebabName}")}, env.identify${root.name}Handler).Methods(http.MethodGet)"
         }
 
     mkCode.lines(

--- a/src/main/scala/temple/generate/server/go/service/main/GoServiceMainHandlersGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/main/GoServiceMainHandlersGenerator.scala
@@ -12,6 +12,7 @@ import temple.generate.server.go.service.main.GoServiceMainDeleteHandlerGenerato
 import temple.generate.server.go.service.main.GoServiceMainListHandlerGenerator.generateListHandler
 import temple.generate.server.go.service.main.GoServiceMainReadHandlerGenerator.generateReadHandler
 import temple.generate.server.go.service.main.GoServiceMainUpdateHandlerGenerator.generateUpdateHandler
+import temple.generate.server.go.service.main.GoServiceMainIdentityHandlerGenerator.generateIdentityHandler
 import temple.generate.utils.CodeTerm.mkCode
 import temple.utils.StringUtils.{decapitalize, doubleQuote}
 
@@ -380,6 +381,8 @@ object GoServiceMainHandlersGenerator {
           generateUpdateHandler(root, usesComms, responseMap, clientUsesTime, usesMetrics)
         case Delete =>
           generateDeleteHandler(root, usesMetrics)
+        case Identify =>
+          generateIdentityHandler(root, usesMetrics)
       },
     )
   }

--- a/src/main/scala/temple/generate/server/go/service/main/GoServiceMainIdentityHandlerGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/main/GoServiceMainIdentityHandlerGenerator.scala
@@ -1,0 +1,19 @@
+package temple.generate.server.go.service.main
+
+import temple.generate.CRUD.Identify
+import temple.generate.server.AttributesRoot.ServiceRoot
+import temple.generate.server.go.service.main.GoServiceMainHandlersGenerator._
+import temple.generate.utils.CodeTerm.{CodeWrap, mkCode}
+
+object GoServiceMainIdentityHandlerGenerator {
+
+  /** Generate the identity handler function */
+  private[main] def generateIdentityHandler(root: ServiceRoot, usesMetrics: Boolean): String = mkCode(
+    generateHandlerDecl(root, Identify),
+    CodeWrap.curly.tabbed(
+      mkCode.doubleLines(
+        // TODO!
+      ),
+    ),
+  )
+}

--- a/src/main/scala/temple/generate/target/openapi/OpenAPIGenerator.scala
+++ b/src/main/scala/temple/generate/target/openapi/OpenAPIGenerator.scala
@@ -164,7 +164,7 @@ private class OpenAPIGenerator private (name: String, version: String, descripti
               500 -> Response.Ref(useError(500)),
             ),
           )
-      case Identity =>
+      case Identify =>
         path(s"/$lowerName") += HTTPVerb.Get -> Handler(
             s"Look up the single $lowerName associated with the access token",
             tags = tags,

--- a/src/main/scala/temple/test/internal/CRUDServiceTest.scala
+++ b/src/main/scala/temple/test/internal/CRUDServiceTest.scala
@@ -100,11 +100,12 @@ class CRUDServiceTest(
       ServiceTestUtils.getAuthTokenWithEmail(name, baseURL)
     } else ""
     ProjectBuilder.endpoints(service).foreach {
-      case CRUD.List   => testListEndpoint(accessToken)
-      case CRUD.Create => testCreateEndpoint(accessToken)
-      case CRUD.Read   => testReadEndpoint(accessToken)
-      case CRUD.Update => testUpdateEndpoint(accessToken)
-      case CRUD.Delete => testDeleteEndpoint(accessToken)
+      case CRUD.List     => testListEndpoint(accessToken)
+      case CRUD.Create   => testCreateEndpoint(accessToken)
+      case CRUD.Read     => testReadEndpoint(accessToken)
+      case CRUD.Update   => testUpdateEndpoint(accessToken)
+      case CRUD.Delete   => testDeleteEndpoint(accessToken)
+      case CRUD.Identify => // TODO
     }
     anyTestFailed
   }

--- a/src/test/resources/project-builder-complex/api/sample-complex-project.openapi.yaml
+++ b/src/test/resources/project-builder-complex/api/sample-complex-project.openapi.yaml
@@ -121,6 +121,20 @@ paths:
           $ref: '#/components/responses/Error401'
         '500':
           $ref: '#/components/responses/Error500'
+    get:
+      summary: Look up the single complexuser associated with the access token
+      tags:
+      - ComplexUser
+      responses:
+        '302':
+          description: The single complexuser is accessible from the provided Location
+          headers:
+            Location:
+              description: The location where the single complexuser can be found
+              schema:
+                type: string
+        '404':
+          $ref: '#/components/responses/Error404'
   /complexuser/{id}:
     parameters:
     - in: path

--- a/src/test/resources/project-builder-complex/complex-user/complex-user.go
+++ b/src/test/resources/project-builder-complex/complex-user/complex-user.go
@@ -117,6 +117,7 @@ func defaultRouter(env *env) *mux.Router {
 	r.HandleFunc("/complex-user/{id}", env.readComplexUserHandler).Methods(http.MethodGet)
 	r.HandleFunc("/complex-user/{id}", env.updateComplexUserHandler).Methods(http.MethodPut)
 	r.HandleFunc("/complex-user/{id}", env.deleteComplexUserHandler).Methods(http.MethodDelete)
+	r.HandleFunc("/complex-user", env.identifyComplexUserHandler).Methods(http.MethodGet)
 	r.Use(jsonMiddleware)
 	return r
 }
@@ -539,4 +540,8 @@ func (env *env) deleteComplexUserHandler(w http.ResponseWriter, r *http.Request)
 	json.NewEncoder(w).Encode(struct{}{})
 
 	metric.RequestSuccess.WithLabelValues(metric.RequestDelete).Inc()
+}
+
+func (env *env) identifyComplexUserHandler(w http.ResponseWriter, r *http.Request) {
+
 }

--- a/src/test/resources/project-builder-complex/complex-user/dao/dao.go
+++ b/src/test/resources/project-builder-complex/complex-user/dao/dao.go
@@ -18,6 +18,7 @@ type BaseDatastore interface {
 	ReadComplexUser(input ReadComplexUserInput) (*ComplexUser, error)
 	UpdateComplexUser(input UpdateComplexUserInput) (*ComplexUser, error)
 	DeleteComplexUser(input DeleteComplexUserInput) error
+	IdentifyComplexUser(input IdentifyComplexUserInput) (*ComplexUser, error)
 }
 
 // DAO encapsulates access to the datastore
@@ -83,6 +84,11 @@ type UpdateComplexUserInput struct {
 
 // DeleteComplexUserInput encapsulates the information required to delete a single complexUser in the datastore
 type DeleteComplexUserInput struct {
+	ID uuid.UUID
+}
+
+// IdentifyComplexUserInput encapsulates the information required to identify the single complexUser in the datastore
+type IdentifyComplexUserInput struct {
 	ID uuid.UUID
 }
 
@@ -169,4 +175,22 @@ func (dao *DAO) DeleteComplexUser(input DeleteComplexUserInput) error {
 	}
 
 	return nil
+}
+
+// IdentifyComplexUser returns the complexUser in the datastore for a given ID
+func (dao *DAO) IdentifyComplexUser(input IdentifyComplexUserInput) (*ComplexUser, error) {
+	row := executeQueryWithRowResponse(dao.DB, "SELECT id, small_int_field, int_field, big_int_field, float_field, double_field, string_field, bounded_string_field, bool_field, date_field, time_field, date_time_field, blob_field FROM complex_user WHERE id = $1;", input.ID)
+
+	var complexUser ComplexUser
+	err := row.Scan(&complexUser.ID, &complexUser.SmallIntField, &complexUser.IntField, &complexUser.BigIntField, &complexUser.FloatField, &complexUser.DoubleField, &complexUser.StringField, &complexUser.BoundedStringField, &complexUser.BoolField, &complexUser.DateField, &complexUser.TimeField, &complexUser.DateTimeField, &complexUser.BlobField)
+	if err != nil {
+		switch err {
+		case sql.ErrNoRows:
+			return nil, ErrComplexUserNotFound(input.ID.String())
+		default:
+			return nil, err
+		}
+	}
+
+	return &complexUser, nil
 }

--- a/src/test/resources/project-builder-complex/complex-user/dao/dao.go
+++ b/src/test/resources/project-builder-complex/complex-user/dao/dao.go
@@ -87,7 +87,7 @@ type DeleteComplexUserInput struct {
 	ID uuid.UUID
 }
 
-// IdentifyComplexUserInput encapsulates the information required to identify the single complexUser in the datastore
+// IdentifyComplexUserInput encapsulates the information required to identify the current complexUser in the datastore
 type IdentifyComplexUserInput struct {
 	ID uuid.UUID
 }

--- a/src/test/resources/project-builder-complex/complex-user/hook.go
+++ b/src/test/resources/project-builder-complex/complex-user/hook.go
@@ -5,14 +5,16 @@ import "github.com/squat/and/dab/complex-user/dao"
 // Hook allows additional code to be executed before and after every datastore interaction
 // Hooks are executed in the order they are defined, such that if any hook errors, future hooks are not executed and the request is terminated
 type Hook struct {
-	beforeCreateHooks []*func(env *env, req createComplexUserRequest, input *dao.CreateComplexUserInput) *HookError
-	beforeReadHooks   []*func(env *env, input *dao.ReadComplexUserInput) *HookError
-	beforeUpdateHooks []*func(env *env, req updateComplexUserRequest, input *dao.UpdateComplexUserInput) *HookError
-	beforeDeleteHooks []*func(env *env, input *dao.DeleteComplexUserInput) *HookError
-	afterCreateHooks  []*func(env *env, complexUser *dao.ComplexUser) *HookError
-	afterReadHooks    []*func(env *env, complexUser *dao.ComplexUser) *HookError
-	afterUpdateHooks  []*func(env *env, complexUser *dao.ComplexUser) *HookError
-	afterDeleteHooks  []*func(env *env) *HookError
+	beforeCreateHooks   []*func(env *env, req createComplexUserRequest, input *dao.CreateComplexUserInput) *HookError
+	beforeReadHooks     []*func(env *env, input *dao.ReadComplexUserInput) *HookError
+	beforeUpdateHooks   []*func(env *env, req updateComplexUserRequest, input *dao.UpdateComplexUserInput) *HookError
+	beforeDeleteHooks   []*func(env *env, input *dao.DeleteComplexUserInput) *HookError
+	beforeIdentifyHooks []*func(env *env, input *dao.IdentifyComplexUserInput) *HookError
+	afterCreateHooks    []*func(env *env, complexUser *dao.ComplexUser) *HookError
+	afterReadHooks      []*func(env *env, complexUser *dao.ComplexUser) *HookError
+	afterUpdateHooks    []*func(env *env, complexUser *dao.ComplexUser) *HookError
+	afterDeleteHooks    []*func(env *env) *HookError
+	afterIdentifyHooks  []*func(env *env, complexUser *dao.ComplexUser) *HookError
 }
 
 // HookError wraps an existing error with HTTP status code
@@ -45,6 +47,11 @@ func (h *Hook) BeforeDelete(hook func(env *env, input *dao.DeleteComplexUserInpu
 	h.beforeDeleteHooks = append(h.beforeDeleteHooks, &hook)
 }
 
+// BeforeIdentify adds a new hook to be executed before identifying an object in the datastore
+func (h *Hook) BeforeIdentify(hook func(env *env, input *dao.IdentifyComplexUserInput) *HookError) {
+	h.beforeIdentifyHooks = append(h.beforeIdentifyHooks, &hook)
+}
+
 // AfterCreate adds a new hook to be executed after creating an object in the datastore
 func (h *Hook) AfterCreate(hook func(env *env, complexUser *dao.ComplexUser) *HookError) {
 	h.afterCreateHooks = append(h.afterCreateHooks, &hook)
@@ -63,4 +70,9 @@ func (h *Hook) AfterUpdate(hook func(env *env, complexUser *dao.ComplexUser) *Ho
 // AfterDelete adds a new hook to be executed after deleting an object in the datastore
 func (h *Hook) AfterDelete(hook func(env *env) *HookError) {
 	h.afterDeleteHooks = append(h.afterDeleteHooks, &hook)
+}
+
+// AfterIdentify adds a new hook to be executed after identifying an object in the datastore
+func (h *Hook) AfterIdentify(hook func(env *env, complexUser *dao.ComplexUser) *HookError) {
+	h.afterIdentifyHooks = append(h.afterIdentifyHooks, &hook)
 }

--- a/src/test/resources/project-builder-complex/complex-user/metric/metric.go
+++ b/src/test/resources/project-builder-complex/complex-user/metric/metric.go
@@ -6,10 +6,11 @@ import (
 )
 
 var (
-	RequestCreate = "create"
-	RequestRead   = "read"
-	RequestUpdate = "update"
-	RequestDelete = "delete"
+	RequestCreate   = "create"
+	RequestRead     = "read"
+	RequestUpdate   = "update"
+	RequestDelete   = "delete"
+	RequestIdentify = "identify"
 
 	RequestSuccess = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "complexuser_request_success_total",

--- a/src/test/resources/project-builder-complex/grafana/provisioning/dashboards/complex-user.json
+++ b/src/test/resources/project-builder-complex/grafana/provisioning/dashboards/complex-user.json
@@ -237,426 +237,6 @@
         "y" : 5
       },
       "hiddenSeries" : false,
-      "id" : 2,
-      "legend" : {
-        "avg" : false,
-        "current" : false,
-        "max" : false,
-        "min" : false,
-        "rightSide" : true,
-        "show" : true,
-        "total" : false,
-        "values" : false
-      },
-      "lines" : true,
-      "linewidth" : 1,
-      "nullPointMode" : "null",
-      "options" : {
-        "dataLinks" : [
-        ]
-      },
-      "percentage" : false,
-      "pointradius" : 2,
-      "points" : false,
-      "renderer" : "flot",
-      "seriesOverrides" : [
-      ],
-      "spaceLength" : 10,
-      "stack" : false,
-      "steppedLine" : false,
-      "targets" : [
-        {
-          "expr" : "rate(complexuser_request_success_total{request_type=\"read\"}[5m])",
-          "legendFormat" : "Success",
-          "refId" : "A"
-        },
-        {
-          "expr" : "rate(complexuser_request_failure_total{request_type=\"read\"}[5m])",
-          "legendFormat" : "{{error_code}}",
-          "refId" : "B"
-        }
-      ],
-      "thresholds" : [
-      ],
-      "timeFrom" : null,
-      "timeRegions" : [
-      ],
-      "timeShift" : null,
-      "title" : "Read ComplexUser Requests",
-      "tooltip" : {
-        "shared" : true,
-        "sort" : 0,
-        "value_type" : "individual"
-      },
-      "type" : "graph",
-      "xaxis" : {
-        "buckets" : null,
-        "mode" : "time",
-        "name" : null,
-        "show" : true,
-        "values" : [
-        ]
-      },
-      "yaxes" : [
-        {
-          "format" : "short",
-          "label" : "QPS",
-          "logBase" : 1,
-          "max" : null,
-          "min" : null,
-          "show" : true
-        },
-        {
-          "format" : "short",
-          "label" : null,
-          "logBase" : 1,
-          "max" : null,
-          "min" : null,
-          "show" : true
-        }
-      ],
-      "yaxis" : {
-        "align" : false,
-        "alignLevel" : null
-      }
-    },
-    {
-      "aliasColors" : {
-        
-      },
-      "bars" : false,
-      "dashLength" : 10,
-      "dashes" : false,
-      "datasource" : "Prometheus",
-      "fill" : 1,
-      "fillGradient" : 0,
-      "gridPos" : {
-        "h" : 5,
-        "w" : 12,
-        "x" : 12,
-        "y" : 5
-      },
-      "hiddenSeries" : false,
-      "id" : 3,
-      "legend" : {
-        "avg" : false,
-        "current" : false,
-        "max" : false,
-        "min" : false,
-        "rightSide" : true,
-        "show" : true,
-        "total" : false,
-        "values" : false
-      },
-      "lines" : true,
-      "linewidth" : 1,
-      "nullPointMode" : "null",
-      "options" : {
-        "dataLinks" : [
-        ]
-      },
-      "percentage" : false,
-      "pointradius" : 2,
-      "points" : false,
-      "renderer" : "flot",
-      "seriesOverrides" : [
-      ],
-      "spaceLength" : 10,
-      "stack" : false,
-      "steppedLine" : false,
-      "targets" : [
-        {
-          "expr" : "complexuser_database_request_seconds{quantile=\"0.5\",query_type=\"read\"}",
-          "legendFormat" : "50th Percentile",
-          "refId" : "A"
-        },
-        {
-          "expr" : "complexuser_database_request_seconds{quantile=\"0.9\",query_type=\"read\"}",
-          "legendFormat" : "90th Percentile",
-          "refId" : "B"
-        },
-        {
-          "expr" : "complexuser_database_request_seconds{quantile=\"0.95\",query_type=\"read\"}",
-          "legendFormat" : "95th Percentile",
-          "refId" : "C"
-        },
-        {
-          "expr" : "complexuser_database_request_seconds{quantile=\"0.99\",query_type=\"read\"}",
-          "legendFormat" : "99th Percentile",
-          "refId" : "D"
-        }
-      ],
-      "thresholds" : [
-      ],
-      "timeFrom" : null,
-      "timeRegions" : [
-      ],
-      "timeShift" : null,
-      "title" : "DB Read Queries",
-      "tooltip" : {
-        "shared" : true,
-        "sort" : 0,
-        "value_type" : "individual"
-      },
-      "type" : "graph",
-      "xaxis" : {
-        "buckets" : null,
-        "mode" : "time",
-        "name" : null,
-        "show" : true,
-        "values" : [
-        ]
-      },
-      "yaxes" : [
-        {
-          "format" : "short",
-          "label" : "Time (seconds)",
-          "logBase" : 1,
-          "max" : null,
-          "min" : null,
-          "show" : true
-        },
-        {
-          "format" : "short",
-          "label" : null,
-          "logBase" : 1,
-          "max" : null,
-          "min" : null,
-          "show" : true
-        }
-      ],
-      "yaxis" : {
-        "align" : false,
-        "alignLevel" : null
-      }
-    },
-    {
-      "aliasColors" : {
-        
-      },
-      "bars" : false,
-      "dashLength" : 10,
-      "dashes" : false,
-      "datasource" : "Prometheus",
-      "fill" : 1,
-      "fillGradient" : 0,
-      "gridPos" : {
-        "h" : 5,
-        "w" : 12,
-        "x" : 0,
-        "y" : 10
-      },
-      "hiddenSeries" : false,
-      "id" : 4,
-      "legend" : {
-        "avg" : false,
-        "current" : false,
-        "max" : false,
-        "min" : false,
-        "rightSide" : true,
-        "show" : true,
-        "total" : false,
-        "values" : false
-      },
-      "lines" : true,
-      "linewidth" : 1,
-      "nullPointMode" : "null",
-      "options" : {
-        "dataLinks" : [
-        ]
-      },
-      "percentage" : false,
-      "pointradius" : 2,
-      "points" : false,
-      "renderer" : "flot",
-      "seriesOverrides" : [
-      ],
-      "spaceLength" : 10,
-      "stack" : false,
-      "steppedLine" : false,
-      "targets" : [
-        {
-          "expr" : "rate(complexuser_request_success_total{request_type=\"update\"}[5m])",
-          "legendFormat" : "Success",
-          "refId" : "A"
-        },
-        {
-          "expr" : "rate(complexuser_request_failure_total{request_type=\"update\"}[5m])",
-          "legendFormat" : "{{error_code}}",
-          "refId" : "B"
-        }
-      ],
-      "thresholds" : [
-      ],
-      "timeFrom" : null,
-      "timeRegions" : [
-      ],
-      "timeShift" : null,
-      "title" : "Update ComplexUser Requests",
-      "tooltip" : {
-        "shared" : true,
-        "sort" : 0,
-        "value_type" : "individual"
-      },
-      "type" : "graph",
-      "xaxis" : {
-        "buckets" : null,
-        "mode" : "time",
-        "name" : null,
-        "show" : true,
-        "values" : [
-        ]
-      },
-      "yaxes" : [
-        {
-          "format" : "short",
-          "label" : "QPS",
-          "logBase" : 1,
-          "max" : null,
-          "min" : null,
-          "show" : true
-        },
-        {
-          "format" : "short",
-          "label" : null,
-          "logBase" : 1,
-          "max" : null,
-          "min" : null,
-          "show" : true
-        }
-      ],
-      "yaxis" : {
-        "align" : false,
-        "alignLevel" : null
-      }
-    },
-    {
-      "aliasColors" : {
-        
-      },
-      "bars" : false,
-      "dashLength" : 10,
-      "dashes" : false,
-      "datasource" : "Prometheus",
-      "fill" : 1,
-      "fillGradient" : 0,
-      "gridPos" : {
-        "h" : 5,
-        "w" : 12,
-        "x" : 12,
-        "y" : 10
-      },
-      "hiddenSeries" : false,
-      "id" : 5,
-      "legend" : {
-        "avg" : false,
-        "current" : false,
-        "max" : false,
-        "min" : false,
-        "rightSide" : true,
-        "show" : true,
-        "total" : false,
-        "values" : false
-      },
-      "lines" : true,
-      "linewidth" : 1,
-      "nullPointMode" : "null",
-      "options" : {
-        "dataLinks" : [
-        ]
-      },
-      "percentage" : false,
-      "pointradius" : 2,
-      "points" : false,
-      "renderer" : "flot",
-      "seriesOverrides" : [
-      ],
-      "spaceLength" : 10,
-      "stack" : false,
-      "steppedLine" : false,
-      "targets" : [
-        {
-          "expr" : "complexuser_database_request_seconds{quantile=\"0.5\",query_type=\"update\"}",
-          "legendFormat" : "50th Percentile",
-          "refId" : "A"
-        },
-        {
-          "expr" : "complexuser_database_request_seconds{quantile=\"0.9\",query_type=\"update\"}",
-          "legendFormat" : "90th Percentile",
-          "refId" : "B"
-        },
-        {
-          "expr" : "complexuser_database_request_seconds{quantile=\"0.95\",query_type=\"update\"}",
-          "legendFormat" : "95th Percentile",
-          "refId" : "C"
-        },
-        {
-          "expr" : "complexuser_database_request_seconds{quantile=\"0.99\",query_type=\"update\"}",
-          "legendFormat" : "99th Percentile",
-          "refId" : "D"
-        }
-      ],
-      "thresholds" : [
-      ],
-      "timeFrom" : null,
-      "timeRegions" : [
-      ],
-      "timeShift" : null,
-      "title" : "DB Update Queries",
-      "tooltip" : {
-        "shared" : true,
-        "sort" : 0,
-        "value_type" : "individual"
-      },
-      "type" : "graph",
-      "xaxis" : {
-        "buckets" : null,
-        "mode" : "time",
-        "name" : null,
-        "show" : true,
-        "values" : [
-        ]
-      },
-      "yaxes" : [
-        {
-          "format" : "short",
-          "label" : "Time (seconds)",
-          "logBase" : 1,
-          "max" : null,
-          "min" : null,
-          "show" : true
-        },
-        {
-          "format" : "short",
-          "label" : null,
-          "logBase" : 1,
-          "max" : null,
-          "min" : null,
-          "show" : true
-        }
-      ],
-      "yaxis" : {
-        "align" : false,
-        "alignLevel" : null
-      }
-    },
-    {
-      "aliasColors" : {
-        
-      },
-      "bars" : false,
-      "dashLength" : 10,
-      "dashes" : false,
-      "datasource" : "Prometheus",
-      "fill" : 1,
-      "fillGradient" : 0,
-      "gridPos" : {
-        "h" : 5,
-        "w" : 12,
-        "x" : 0,
-        "y" : 15
-      },
-      "hiddenSeries" : false,
       "id" : 6,
       "legend" : {
         "avg" : false,
@@ -754,7 +334,7 @@
         "h" : 5,
         "w" : 12,
         "x" : 12,
-        "y" : 15
+        "y" : 5
       },
       "hiddenSeries" : false,
       "id" : 7,
@@ -864,7 +444,637 @@
         "h" : 5,
         "w" : 12,
         "x" : 0,
+        "y" : 10
+      },
+      "hiddenSeries" : false,
+      "id" : 2,
+      "legend" : {
+        "avg" : false,
+        "current" : false,
+        "max" : false,
+        "min" : false,
+        "rightSide" : true,
+        "show" : true,
+        "total" : false,
+        "values" : false
+      },
+      "lines" : true,
+      "linewidth" : 1,
+      "nullPointMode" : "null",
+      "options" : {
+        "dataLinks" : [
+        ]
+      },
+      "percentage" : false,
+      "pointradius" : 2,
+      "points" : false,
+      "renderer" : "flot",
+      "seriesOverrides" : [
+      ],
+      "spaceLength" : 10,
+      "stack" : false,
+      "steppedLine" : false,
+      "targets" : [
+        {
+          "expr" : "rate(complexuser_request_success_total{request_type=\"read\"}[5m])",
+          "legendFormat" : "Success",
+          "refId" : "A"
+        },
+        {
+          "expr" : "rate(complexuser_request_failure_total{request_type=\"read\"}[5m])",
+          "legendFormat" : "{{error_code}}",
+          "refId" : "B"
+        }
+      ],
+      "thresholds" : [
+      ],
+      "timeFrom" : null,
+      "timeRegions" : [
+      ],
+      "timeShift" : null,
+      "title" : "Read ComplexUser Requests",
+      "tooltip" : {
+        "shared" : true,
+        "sort" : 0,
+        "value_type" : "individual"
+      },
+      "type" : "graph",
+      "xaxis" : {
+        "buckets" : null,
+        "mode" : "time",
+        "name" : null,
+        "show" : true,
+        "values" : [
+        ]
+      },
+      "yaxes" : [
+        {
+          "format" : "short",
+          "label" : "QPS",
+          "logBase" : 1,
+          "max" : null,
+          "min" : null,
+          "show" : true
+        },
+        {
+          "format" : "short",
+          "label" : null,
+          "logBase" : 1,
+          "max" : null,
+          "min" : null,
+          "show" : true
+        }
+      ],
+      "yaxis" : {
+        "align" : false,
+        "alignLevel" : null
+      }
+    },
+    {
+      "aliasColors" : {
+        
+      },
+      "bars" : false,
+      "dashLength" : 10,
+      "dashes" : false,
+      "datasource" : "Prometheus",
+      "fill" : 1,
+      "fillGradient" : 0,
+      "gridPos" : {
+        "h" : 5,
+        "w" : 12,
+        "x" : 12,
+        "y" : 10
+      },
+      "hiddenSeries" : false,
+      "id" : 3,
+      "legend" : {
+        "avg" : false,
+        "current" : false,
+        "max" : false,
+        "min" : false,
+        "rightSide" : true,
+        "show" : true,
+        "total" : false,
+        "values" : false
+      },
+      "lines" : true,
+      "linewidth" : 1,
+      "nullPointMode" : "null",
+      "options" : {
+        "dataLinks" : [
+        ]
+      },
+      "percentage" : false,
+      "pointradius" : 2,
+      "points" : false,
+      "renderer" : "flot",
+      "seriesOverrides" : [
+      ],
+      "spaceLength" : 10,
+      "stack" : false,
+      "steppedLine" : false,
+      "targets" : [
+        {
+          "expr" : "complexuser_database_request_seconds{quantile=\"0.5\",query_type=\"read\"}",
+          "legendFormat" : "50th Percentile",
+          "refId" : "A"
+        },
+        {
+          "expr" : "complexuser_database_request_seconds{quantile=\"0.9\",query_type=\"read\"}",
+          "legendFormat" : "90th Percentile",
+          "refId" : "B"
+        },
+        {
+          "expr" : "complexuser_database_request_seconds{quantile=\"0.95\",query_type=\"read\"}",
+          "legendFormat" : "95th Percentile",
+          "refId" : "C"
+        },
+        {
+          "expr" : "complexuser_database_request_seconds{quantile=\"0.99\",query_type=\"read\"}",
+          "legendFormat" : "99th Percentile",
+          "refId" : "D"
+        }
+      ],
+      "thresholds" : [
+      ],
+      "timeFrom" : null,
+      "timeRegions" : [
+      ],
+      "timeShift" : null,
+      "title" : "DB Read Queries",
+      "tooltip" : {
+        "shared" : true,
+        "sort" : 0,
+        "value_type" : "individual"
+      },
+      "type" : "graph",
+      "xaxis" : {
+        "buckets" : null,
+        "mode" : "time",
+        "name" : null,
+        "show" : true,
+        "values" : [
+        ]
+      },
+      "yaxes" : [
+        {
+          "format" : "short",
+          "label" : "Time (seconds)",
+          "logBase" : 1,
+          "max" : null,
+          "min" : null,
+          "show" : true
+        },
+        {
+          "format" : "short",
+          "label" : null,
+          "logBase" : 1,
+          "max" : null,
+          "min" : null,
+          "show" : true
+        }
+      ],
+      "yaxis" : {
+        "align" : false,
+        "alignLevel" : null
+      }
+    },
+    {
+      "aliasColors" : {
+        
+      },
+      "bars" : false,
+      "dashLength" : 10,
+      "dashes" : false,
+      "datasource" : "Prometheus",
+      "fill" : 1,
+      "fillGradient" : 0,
+      "gridPos" : {
+        "h" : 5,
+        "w" : 12,
+        "x" : 0,
+        "y" : 15
+      },
+      "hiddenSeries" : false,
+      "id" : 8,
+      "legend" : {
+        "avg" : false,
+        "current" : false,
+        "max" : false,
+        "min" : false,
+        "rightSide" : true,
+        "show" : true,
+        "total" : false,
+        "values" : false
+      },
+      "lines" : true,
+      "linewidth" : 1,
+      "nullPointMode" : "null",
+      "options" : {
+        "dataLinks" : [
+        ]
+      },
+      "percentage" : false,
+      "pointradius" : 2,
+      "points" : false,
+      "renderer" : "flot",
+      "seriesOverrides" : [
+      ],
+      "spaceLength" : 10,
+      "stack" : false,
+      "steppedLine" : false,
+      "targets" : [
+        {
+          "expr" : "rate(complexuser_request_success_total{request_type=\"identify\"}[5m])",
+          "legendFormat" : "Success",
+          "refId" : "A"
+        },
+        {
+          "expr" : "rate(complexuser_request_failure_total{request_type=\"identify\"}[5m])",
+          "legendFormat" : "{{error_code}}",
+          "refId" : "B"
+        }
+      ],
+      "thresholds" : [
+      ],
+      "timeFrom" : null,
+      "timeRegions" : [
+      ],
+      "timeShift" : null,
+      "title" : "Identify ComplexUser Requests",
+      "tooltip" : {
+        "shared" : true,
+        "sort" : 0,
+        "value_type" : "individual"
+      },
+      "type" : "graph",
+      "xaxis" : {
+        "buckets" : null,
+        "mode" : "time",
+        "name" : null,
+        "show" : true,
+        "values" : [
+        ]
+      },
+      "yaxes" : [
+        {
+          "format" : "short",
+          "label" : "QPS",
+          "logBase" : 1,
+          "max" : null,
+          "min" : null,
+          "show" : true
+        },
+        {
+          "format" : "short",
+          "label" : null,
+          "logBase" : 1,
+          "max" : null,
+          "min" : null,
+          "show" : true
+        }
+      ],
+      "yaxis" : {
+        "align" : false,
+        "alignLevel" : null
+      }
+    },
+    {
+      "aliasColors" : {
+        
+      },
+      "bars" : false,
+      "dashLength" : 10,
+      "dashes" : false,
+      "datasource" : "Prometheus",
+      "fill" : 1,
+      "fillGradient" : 0,
+      "gridPos" : {
+        "h" : 5,
+        "w" : 12,
+        "x" : 12,
+        "y" : 15
+      },
+      "hiddenSeries" : false,
+      "id" : 9,
+      "legend" : {
+        "avg" : false,
+        "current" : false,
+        "max" : false,
+        "min" : false,
+        "rightSide" : true,
+        "show" : true,
+        "total" : false,
+        "values" : false
+      },
+      "lines" : true,
+      "linewidth" : 1,
+      "nullPointMode" : "null",
+      "options" : {
+        "dataLinks" : [
+        ]
+      },
+      "percentage" : false,
+      "pointradius" : 2,
+      "points" : false,
+      "renderer" : "flot",
+      "seriesOverrides" : [
+      ],
+      "spaceLength" : 10,
+      "stack" : false,
+      "steppedLine" : false,
+      "targets" : [
+        {
+          "expr" : "complexuser_database_request_seconds{quantile=\"0.5\",query_type=\"identify\"}",
+          "legendFormat" : "50th Percentile",
+          "refId" : "A"
+        },
+        {
+          "expr" : "complexuser_database_request_seconds{quantile=\"0.9\",query_type=\"identify\"}",
+          "legendFormat" : "90th Percentile",
+          "refId" : "B"
+        },
+        {
+          "expr" : "complexuser_database_request_seconds{quantile=\"0.95\",query_type=\"identify\"}",
+          "legendFormat" : "95th Percentile",
+          "refId" : "C"
+        },
+        {
+          "expr" : "complexuser_database_request_seconds{quantile=\"0.99\",query_type=\"identify\"}",
+          "legendFormat" : "99th Percentile",
+          "refId" : "D"
+        }
+      ],
+      "thresholds" : [
+      ],
+      "timeFrom" : null,
+      "timeRegions" : [
+      ],
+      "timeShift" : null,
+      "title" : "DB Identify Queries",
+      "tooltip" : {
+        "shared" : true,
+        "sort" : 0,
+        "value_type" : "individual"
+      },
+      "type" : "graph",
+      "xaxis" : {
+        "buckets" : null,
+        "mode" : "time",
+        "name" : null,
+        "show" : true,
+        "values" : [
+        ]
+      },
+      "yaxes" : [
+        {
+          "format" : "short",
+          "label" : "Time (seconds)",
+          "logBase" : 1,
+          "max" : null,
+          "min" : null,
+          "show" : true
+        },
+        {
+          "format" : "short",
+          "label" : null,
+          "logBase" : 1,
+          "max" : null,
+          "min" : null,
+          "show" : true
+        }
+      ],
+      "yaxis" : {
+        "align" : false,
+        "alignLevel" : null
+      }
+    },
+    {
+      "aliasColors" : {
+        
+      },
+      "bars" : false,
+      "dashLength" : 10,
+      "dashes" : false,
+      "datasource" : "Prometheus",
+      "fill" : 1,
+      "fillGradient" : 0,
+      "gridPos" : {
+        "h" : 5,
+        "w" : 12,
+        "x" : 0,
         "y" : 20
+      },
+      "hiddenSeries" : false,
+      "id" : 4,
+      "legend" : {
+        "avg" : false,
+        "current" : false,
+        "max" : false,
+        "min" : false,
+        "rightSide" : true,
+        "show" : true,
+        "total" : false,
+        "values" : false
+      },
+      "lines" : true,
+      "linewidth" : 1,
+      "nullPointMode" : "null",
+      "options" : {
+        "dataLinks" : [
+        ]
+      },
+      "percentage" : false,
+      "pointradius" : 2,
+      "points" : false,
+      "renderer" : "flot",
+      "seriesOverrides" : [
+      ],
+      "spaceLength" : 10,
+      "stack" : false,
+      "steppedLine" : false,
+      "targets" : [
+        {
+          "expr" : "rate(complexuser_request_success_total{request_type=\"update\"}[5m])",
+          "legendFormat" : "Success",
+          "refId" : "A"
+        },
+        {
+          "expr" : "rate(complexuser_request_failure_total{request_type=\"update\"}[5m])",
+          "legendFormat" : "{{error_code}}",
+          "refId" : "B"
+        }
+      ],
+      "thresholds" : [
+      ],
+      "timeFrom" : null,
+      "timeRegions" : [
+      ],
+      "timeShift" : null,
+      "title" : "Update ComplexUser Requests",
+      "tooltip" : {
+        "shared" : true,
+        "sort" : 0,
+        "value_type" : "individual"
+      },
+      "type" : "graph",
+      "xaxis" : {
+        "buckets" : null,
+        "mode" : "time",
+        "name" : null,
+        "show" : true,
+        "values" : [
+        ]
+      },
+      "yaxes" : [
+        {
+          "format" : "short",
+          "label" : "QPS",
+          "logBase" : 1,
+          "max" : null,
+          "min" : null,
+          "show" : true
+        },
+        {
+          "format" : "short",
+          "label" : null,
+          "logBase" : 1,
+          "max" : null,
+          "min" : null,
+          "show" : true
+        }
+      ],
+      "yaxis" : {
+        "align" : false,
+        "alignLevel" : null
+      }
+    },
+    {
+      "aliasColors" : {
+        
+      },
+      "bars" : false,
+      "dashLength" : 10,
+      "dashes" : false,
+      "datasource" : "Prometheus",
+      "fill" : 1,
+      "fillGradient" : 0,
+      "gridPos" : {
+        "h" : 5,
+        "w" : 12,
+        "x" : 12,
+        "y" : 20
+      },
+      "hiddenSeries" : false,
+      "id" : 5,
+      "legend" : {
+        "avg" : false,
+        "current" : false,
+        "max" : false,
+        "min" : false,
+        "rightSide" : true,
+        "show" : true,
+        "total" : false,
+        "values" : false
+      },
+      "lines" : true,
+      "linewidth" : 1,
+      "nullPointMode" : "null",
+      "options" : {
+        "dataLinks" : [
+        ]
+      },
+      "percentage" : false,
+      "pointradius" : 2,
+      "points" : false,
+      "renderer" : "flot",
+      "seriesOverrides" : [
+      ],
+      "spaceLength" : 10,
+      "stack" : false,
+      "steppedLine" : false,
+      "targets" : [
+        {
+          "expr" : "complexuser_database_request_seconds{quantile=\"0.5\",query_type=\"update\"}",
+          "legendFormat" : "50th Percentile",
+          "refId" : "A"
+        },
+        {
+          "expr" : "complexuser_database_request_seconds{quantile=\"0.9\",query_type=\"update\"}",
+          "legendFormat" : "90th Percentile",
+          "refId" : "B"
+        },
+        {
+          "expr" : "complexuser_database_request_seconds{quantile=\"0.95\",query_type=\"update\"}",
+          "legendFormat" : "95th Percentile",
+          "refId" : "C"
+        },
+        {
+          "expr" : "complexuser_database_request_seconds{quantile=\"0.99\",query_type=\"update\"}",
+          "legendFormat" : "99th Percentile",
+          "refId" : "D"
+        }
+      ],
+      "thresholds" : [
+      ],
+      "timeFrom" : null,
+      "timeRegions" : [
+      ],
+      "timeShift" : null,
+      "title" : "DB Update Queries",
+      "tooltip" : {
+        "shared" : true,
+        "sort" : 0,
+        "value_type" : "individual"
+      },
+      "type" : "graph",
+      "xaxis" : {
+        "buckets" : null,
+        "mode" : "time",
+        "name" : null,
+        "show" : true,
+        "values" : [
+        ]
+      },
+      "yaxes" : [
+        {
+          "format" : "short",
+          "label" : "Time (seconds)",
+          "logBase" : 1,
+          "max" : null,
+          "min" : null,
+          "show" : true
+        },
+        {
+          "format" : "short",
+          "label" : null,
+          "logBase" : 1,
+          "max" : null,
+          "min" : null,
+          "show" : true
+        }
+      ],
+      "yaxis" : {
+        "align" : false,
+        "alignLevel" : null
+      }
+    },
+    {
+      "aliasColors" : {
+        
+      },
+      "bars" : false,
+      "dashLength" : 10,
+      "dashes" : false,
+      "datasource" : "Prometheus",
+      "fill" : 1,
+      "fillGradient" : 0,
+      "gridPos" : {
+        "h" : 5,
+        "w" : 12,
+        "x" : 0,
+        "y" : 25
       },
       "hiddenSeries" : false,
       "id" : 0,
@@ -964,7 +1174,7 @@
         "h" : 5,
         "w" : 12,
         "x" : 12,
-        "y" : 20
+        "y" : 25
       },
       "hiddenSeries" : false,
       "id" : 1,
@@ -1074,7 +1284,7 @@
         "h" : 5,
         "w" : 12,
         "x" : 0,
-        "y" : 25
+        "y" : 30
       },
       "hiddenSeries" : false,
       "id" : 2,
@@ -1174,7 +1384,7 @@
         "h" : 5,
         "w" : 12,
         "x" : 12,
-        "y" : 25
+        "y" : 30
       },
       "hiddenSeries" : false,
       "id" : 3,
@@ -1284,7 +1494,7 @@
         "h" : 5,
         "w" : 12,
         "x" : 0,
-        "y" : 30
+        "y" : 35
       },
       "hiddenSeries" : false,
       "id" : 4,
@@ -1384,7 +1594,7 @@
         "h" : 5,
         "w" : 12,
         "x" : 12,
-        "y" : 30
+        "y" : 35
       },
       "hiddenSeries" : false,
       "id" : 5,
@@ -1494,7 +1704,7 @@
         "h" : 5,
         "w" : 12,
         "x" : 0,
-        "y" : 35
+        "y" : 40
       },
       "hiddenSeries" : false,
       "id" : 6,
@@ -1594,7 +1804,7 @@
         "h" : 5,
         "w" : 12,
         "x" : 12,
-        "y" : 35
+        "y" : 40
       },
       "hiddenSeries" : false,
       "id" : 7,

--- a/src/test/scala/temple/DSL/semantics/NameClashesTest.scala
+++ b/src/test/scala/temple/DSL/semantics/NameClashesTest.scala
@@ -58,12 +58,12 @@ class NameClashesTest extends FlatSpec with Matchers {
       NameClashes.constructUniqueName("Func", "CreateMachine", takenNames = Set("unimportant"))(
         NameClashes.goServiceValidator,
       )
-    } should have message """Cannot generate good name for "func", names of projects and blocks cannot start with [create, delete, identity, list, read, update] or end with [create, delete, identity, list, read, update]"""
+    } should have message """Cannot generate good name for "func", names of projects and blocks cannot start with [create, delete, identify, list, read, update] or end with [create, delete, identify, list, read, update]"""
 
     the[SemanticParsingException] thrownBy {
       NameClashes.constructUniqueName("List", "Tinder", takenNames = Set("unimportant"))(
         NameClashes.goServiceValidator,
       )
-    } should have message """Cannot generate good name for "list", names of projects and blocks cannot start with [create, delete, identity, list, read, update] or end with [create, delete, identity, list, read, update]"""
+    } should have message """Cannot generate good name for "list", names of projects and blocks cannot start with [create, delete, identify, list, read, update] or end with [create, delete, identify, list, read, update]"""
   }
 }

--- a/src/test/scala/temple/builder/ServerBuilderTest.scala
+++ b/src/test/scala/temple/builder/ServerBuilderTest.scala
@@ -10,7 +10,7 @@ import temple.generate.CRUD._
 import temple.generate.server.AttributesRoot.ServiceRoot
 import temple.generate.server._
 
-import scala.collection.immutable.{ListMap, SortedMap}
+import scala.collection.immutable.{ListMap, SortedMap, SortedSet}
 
 class ServerBuilderTest extends FlatSpec with Matchers {
 
@@ -23,7 +23,7 @@ class ServerBuilderTest extends FlatSpec with Matchers {
           .buildServiceRoot(
             name,
             service,
-            endpoints = Set(Create, Read, Update, Delete, List),
+            endpoints = SortedSet(Create, Read, Update, Delete, List),
             port = port.service,
             detail = GoLanguageDetail("github.com/squat/and/dab"),
             projectUsesAuth = false,
@@ -70,7 +70,7 @@ class ServerBuilderTest extends FlatSpec with Matchers {
           .buildServiceRoot(
             name,
             service,
-            endpoints = Set(),
+            endpoints = SortedSet(),
             port = port.service,
             detail = GoLanguageDetail("github.com/squat/and/dab"),
             projectUsesAuth = false,
@@ -111,7 +111,7 @@ class ServerBuilderTest extends FlatSpec with Matchers {
           .buildServiceRoot(
             name,
             service,
-            endpoints = Set(Create, Read, Update, Delete, List),
+            endpoints = SortedSet(Create, Read, Update, Delete, List),
             port = port.service,
             detail = GoLanguageDetail("github.com/squat/and/dab"),
             projectUsesAuth = false,


### PR DESCRIPTION
Sorry for the size 😨 

- Rename `identity` to `identify` since it should be a verb
- Adds empty identify handler
- Adds identify hooks
- Adds identify DAO method (although I think we can just return the ID?)

 I think there's an issue with the Grafana gen in that it doesn't order the items properly in the JSON file. I'll investigate that after this is done.
