### PR TITLE
[Validator] Correct casing of createdBy

### DIFF
--- a/src/e2e/scala/temple/DSL/ParserE2ETest.scala
+++ b/src/e2e/scala/temple/DSL/ParserE2ETest.scala
@@ -55,11 +55,11 @@ class ParserE2ETest extends FlatSpec with Matchers with DSLParserMatchers {
           structs = Map(
             "Fred" -> StructBlock(
               Map(
-                "id"         -> IDAttribute,
-                "created_by" -> CreatedByAttribute,
-                "field"      -> Attribute(StringType(), valueAnnotations = Set(Nullable)),
-                "friend"     -> Attribute(ForeignKey("SimpleTempleTestUser")),
-                "image"      -> Attribute(BlobType(size = Some(10_000_000))),
+                "id"        -> IDAttribute,
+                "createdBy" -> CreatedByAttribute,
+                "field"     -> Attribute(StringType(), valueAnnotations = Set(Nullable)),
+                "friend"    -> Attribute(ForeignKey("SimpleTempleTestUser")),
+                "image"     -> Attribute(BlobType(size = Some(10_000_000))),
               ),
               Seq(ServiceEnumerable, Readable.This),
             ),
@@ -67,15 +67,15 @@ class ParserE2ETest extends FlatSpec with Matchers with DSLParserMatchers {
         ),
         "Booking" -> ServiceBlock(
           attributes = ListMap(
-            "id"         -> IDAttribute,
-            "created_by" -> CreatedByAttribute,
+            "id"        -> IDAttribute,
+            "createdBy" -> CreatedByAttribute,
           ),
           metadata = List(Omit(Set(Endpoint.Update))),
         ),
         "SimpleTempleTestGroup" -> ServiceBlock(
           attributes = ListMap(
-            "id"         -> IDAttribute,
-            "created_by" -> CreatedByAttribute,
+            "id"        -> IDAttribute,
+            "createdBy" -> CreatedByAttribute,
           ),
           metadata = List(Omit(Set(Endpoint.Update))),
         ),

--- a/src/main/scala/temple/DSL/semantics/Validator.scala
+++ b/src/main/scala/temple/DSL/semantics/Validator.scala
@@ -36,9 +36,9 @@ private class Validator private (templefile: Templefile) {
 
     val usesCreatedBy: Boolean = templefile.usesAuth && !block.hasMetadata(Metadata.ServiceAuth)
 
-    val implicitAttributes: ListMap[String, AbstractAttribute] = ListMap("id" -> IDAttribute) ++ when(usesCreatedBy) {
-        "created_by" -> CreatedByAttribute
-      }
+    val implicitAttributes: ListMap[String, AbstractAttribute] =
+      (ListMap("id" -> IDAttribute)
+      ++ when(usesCreatedBy) { "createdBy" -> CreatedByAttribute })
 
     // Add implicit attributes
     implicitAttributes ++ block.attributes.map {


### PR DESCRIPTION
Attribute names are given in camelCase, not sure why this one wasn’t