### PR TITLE
[project-test] Use identify endpoint to avoid access token logic

### DIFF
--- a/src/main/scala/temple/test/internal/ServiceTestUtils.scala
+++ b/src/main/scala/temple/test/internal/ServiceTestUtils.scala
@@ -164,7 +164,7 @@ object ServiceTestUtils {
     postRequest(test, s"http://$baseURL/api/${StringUtils.kebabCase(serviceName)}", requestBody, accessToken)
   }
 
-  /** Create a new object in a given service, returning the ID field and access token used to make the request */
+  /** Create a new object in a given service, returning the ID field */
   def create(
     test: EndpointTest,
     serviceName: String,


### PR DESCRIPTION
So.. suppose we have a match service like this:
```
Match: service {
  userA: User;
  userB: User;
}
```

If we're trying to mock a request body for this, we previously assumed that we need to create two users. To do this, we would create 2 new access tokens, and make 2 new users (since an access token can only be associated with one user).

However, you can only create a match here because the `User` service was `#readable(by: all)` and therefore it was possible to know about other users.

This doesn't work in the `amazon.temple` example, whereby `Customers` are only accessible by themselves (so `#readable(by: this)`). This means the access token that creates an `Order` (associated with a customer) may only be created by the same token that created the `Customer`.

So, I added a new endpoint that allows you to look up a user ID from an access token - which then allows you to correctly populate request bodies with users associated with tokens.

This removes all the gross logic to do with throwaway access tokens: we now just create 1 token per endpoint, and use that for all requests. 

This does come with the caveat that in the `tinder.temple` example, UserA == UserB, but there's no reason that this shouldn't be allowed. 
