### PR TITLE
[Validator] Validate that a struct cannot be more readable than its service

### DIFF
--- a/src/test/scala/temple/DSL/semantics/ValidatorTest.scala
+++ b/src/test/scala/temple/DSL/semantics/ValidatorTest.scala
@@ -46,6 +46,26 @@ class ValidatorTest extends FlatSpec with Matchers {
     ) shouldBe empty
   }
 
+  it should "prevent structs from having greater readability than their parents" in {
+    validationErrors(
+      Templefile(
+        "MyProject",
+        projectBlock = ProjectBlock(Seq(Database.Postgres, AuthMethod.Email)),
+        services = Map(
+          "User" -> ServiceBlock(
+            attributes = Map(),
+            metadata = Seq(Readable.This, ServiceAuth),
+            structs = Map(
+              "Struct" -> StructBlock(Map(), metadata = Seq(Readable.All)),
+            ),
+          ),
+        ),
+      ),
+    ) shouldBe Set(
+      "A struct cannot have wider readability than its parent service in Struct, in User",
+    )
+  }
+
   it should "identify duplicate usage of structs" in {
     validationErrors(
       Templefile(


### PR DESCRIPTION
As discussed on Slack, a struct cannot be readable by everyone if its service can only be read by its creator, logistically because the service entry ID is in the URL, and meaningfully because a struct is effectively an attribute of the service, and so should act as such