### PR TITLE
[grafana] Fix ordering of grafana

### DIFF
--- a/src/e2e/resources/simple-temple-expected/grafana/provisioning/dashboards/simple-temple-test-user.json
+++ b/src/e2e/resources/simple-temple-expected/grafana/provisioning/dashboards/simple-temple-test-user.json
@@ -27,7 +27,7 @@
         "y" : 0
       },
       "hiddenSeries" : false,
-      "id" : 8,
+      "id" : 0,
       "legend" : {
         "avg" : false,
         "current" : false,
@@ -56,12 +56,12 @@
       "steppedLine" : false,
       "targets" : [
         {
-          "expr" : "rate(simpletempletestuser_request_success_total{request_type=\"identify\"}[5m])",
+          "expr" : "rate(simpletempletestuser_request_success_total{request_type=\"list\"}[5m])",
           "legendFormat" : "Success",
           "refId" : "A"
         },
         {
-          "expr" : "rate(simpletempletestuser_request_failure_total{request_type=\"identify\"}[5m])",
+          "expr" : "rate(simpletempletestuser_request_failure_total{request_type=\"list\"}[5m])",
           "legendFormat" : "{{error_code}}",
           "refId" : "B"
         }
@@ -72,7 +72,7 @@
       "timeRegions" : [
       ],
       "timeShift" : null,
-      "title" : "Identify SimpleTempleTestUser Requests",
+      "title" : "List SimpleTempleTestUser Requests",
       "tooltip" : {
         "shared" : true,
         "sort" : 0,
@@ -127,7 +127,7 @@
         "y" : 0
       },
       "hiddenSeries" : false,
-      "id" : 9,
+      "id" : 1,
       "legend" : {
         "avg" : false,
         "current" : false,
@@ -156,22 +156,22 @@
       "steppedLine" : false,
       "targets" : [
         {
-          "expr" : "simpletempletestuser_database_request_seconds{quantile=\"0.5\",query_type=\"identify\"}",
+          "expr" : "simpletempletestuser_database_request_seconds{quantile=\"0.5\",query_type=\"list\"}",
           "legendFormat" : "50th Percentile",
           "refId" : "A"
         },
         {
-          "expr" : "simpletempletestuser_database_request_seconds{quantile=\"0.9\",query_type=\"identify\"}",
+          "expr" : "simpletempletestuser_database_request_seconds{quantile=\"0.9\",query_type=\"list\"}",
           "legendFormat" : "90th Percentile",
           "refId" : "B"
         },
         {
-          "expr" : "simpletempletestuser_database_request_seconds{quantile=\"0.95\",query_type=\"identify\"}",
+          "expr" : "simpletempletestuser_database_request_seconds{quantile=\"0.95\",query_type=\"list\"}",
           "legendFormat" : "95th Percentile",
           "refId" : "C"
         },
         {
-          "expr" : "simpletempletestuser_database_request_seconds{quantile=\"0.99\",query_type=\"identify\"}",
+          "expr" : "simpletempletestuser_database_request_seconds{quantile=\"0.99\",query_type=\"list\"}",
           "legendFormat" : "99th Percentile",
           "refId" : "D"
         }
@@ -182,7 +182,7 @@
       "timeRegions" : [
       ],
       "timeShift" : null,
-      "title" : "DB Identify Queries",
+      "title" : "DB List Queries",
       "tooltip" : {
         "shared" : true,
         "sort" : 0,
@@ -657,216 +657,6 @@
         "y" : 15
       },
       "hiddenSeries" : false,
-      "id" : 0,
-      "legend" : {
-        "avg" : false,
-        "current" : false,
-        "max" : false,
-        "min" : false,
-        "rightSide" : true,
-        "show" : true,
-        "total" : false,
-        "values" : false
-      },
-      "lines" : true,
-      "linewidth" : 1,
-      "nullPointMode" : "null",
-      "options" : {
-        "dataLinks" : [
-        ]
-      },
-      "percentage" : false,
-      "pointradius" : 2,
-      "points" : false,
-      "renderer" : "flot",
-      "seriesOverrides" : [
-      ],
-      "spaceLength" : 10,
-      "stack" : false,
-      "steppedLine" : false,
-      "targets" : [
-        {
-          "expr" : "rate(simpletempletestuser_request_success_total{request_type=\"list\"}[5m])",
-          "legendFormat" : "Success",
-          "refId" : "A"
-        },
-        {
-          "expr" : "rate(simpletempletestuser_request_failure_total{request_type=\"list\"}[5m])",
-          "legendFormat" : "{{error_code}}",
-          "refId" : "B"
-        }
-      ],
-      "thresholds" : [
-      ],
-      "timeFrom" : null,
-      "timeRegions" : [
-      ],
-      "timeShift" : null,
-      "title" : "List SimpleTempleTestUser Requests",
-      "tooltip" : {
-        "shared" : true,
-        "sort" : 0,
-        "value_type" : "individual"
-      },
-      "type" : "graph",
-      "xaxis" : {
-        "buckets" : null,
-        "mode" : "time",
-        "name" : null,
-        "show" : true,
-        "values" : [
-        ]
-      },
-      "yaxes" : [
-        {
-          "format" : "short",
-          "label" : "QPS",
-          "logBase" : 1,
-          "max" : null,
-          "min" : null,
-          "show" : true
-        },
-        {
-          "format" : "short",
-          "label" : null,
-          "logBase" : 1,
-          "max" : null,
-          "min" : null,
-          "show" : true
-        }
-      ],
-      "yaxis" : {
-        "align" : false,
-        "alignLevel" : null
-      }
-    },
-    {
-      "aliasColors" : {
-        
-      },
-      "bars" : false,
-      "dashLength" : 10,
-      "dashes" : false,
-      "datasource" : "Prometheus",
-      "fill" : 1,
-      "fillGradient" : 0,
-      "gridPos" : {
-        "h" : 5,
-        "w" : 12,
-        "x" : 12,
-        "y" : 15
-      },
-      "hiddenSeries" : false,
-      "id" : 1,
-      "legend" : {
-        "avg" : false,
-        "current" : false,
-        "max" : false,
-        "min" : false,
-        "rightSide" : true,
-        "show" : true,
-        "total" : false,
-        "values" : false
-      },
-      "lines" : true,
-      "linewidth" : 1,
-      "nullPointMode" : "null",
-      "options" : {
-        "dataLinks" : [
-        ]
-      },
-      "percentage" : false,
-      "pointradius" : 2,
-      "points" : false,
-      "renderer" : "flot",
-      "seriesOverrides" : [
-      ],
-      "spaceLength" : 10,
-      "stack" : false,
-      "steppedLine" : false,
-      "targets" : [
-        {
-          "expr" : "simpletempletestuser_database_request_seconds{quantile=\"0.5\",query_type=\"list\"}",
-          "legendFormat" : "50th Percentile",
-          "refId" : "A"
-        },
-        {
-          "expr" : "simpletempletestuser_database_request_seconds{quantile=\"0.9\",query_type=\"list\"}",
-          "legendFormat" : "90th Percentile",
-          "refId" : "B"
-        },
-        {
-          "expr" : "simpletempletestuser_database_request_seconds{quantile=\"0.95\",query_type=\"list\"}",
-          "legendFormat" : "95th Percentile",
-          "refId" : "C"
-        },
-        {
-          "expr" : "simpletempletestuser_database_request_seconds{quantile=\"0.99\",query_type=\"list\"}",
-          "legendFormat" : "99th Percentile",
-          "refId" : "D"
-        }
-      ],
-      "thresholds" : [
-      ],
-      "timeFrom" : null,
-      "timeRegions" : [
-      ],
-      "timeShift" : null,
-      "title" : "DB List Queries",
-      "tooltip" : {
-        "shared" : true,
-        "sort" : 0,
-        "value_type" : "individual"
-      },
-      "type" : "graph",
-      "xaxis" : {
-        "buckets" : null,
-        "mode" : "time",
-        "name" : null,
-        "show" : true,
-        "values" : [
-        ]
-      },
-      "yaxes" : [
-        {
-          "format" : "short",
-          "label" : "Time (seconds)",
-          "logBase" : 1,
-          "max" : null,
-          "min" : null,
-          "show" : true
-        },
-        {
-          "format" : "short",
-          "label" : null,
-          "logBase" : 1,
-          "max" : null,
-          "min" : null,
-          "show" : true
-        }
-      ],
-      "yaxis" : {
-        "align" : false,
-        "alignLevel" : null
-      }
-    },
-    {
-      "aliasColors" : {
-        
-      },
-      "bars" : false,
-      "dashLength" : 10,
-      "dashes" : false,
-      "datasource" : "Prometheus",
-      "fill" : 1,
-      "fillGradient" : 0,
-      "gridPos" : {
-        "h" : 5,
-        "w" : 12,
-        "x" : 0,
-        "y" : 20
-      },
-      "hiddenSeries" : false,
       "id" : 6,
       "legend" : {
         "avg" : false,
@@ -964,7 +754,7 @@
         "h" : 5,
         "w" : 12,
         "x" : 12,
-        "y" : 20
+        "y" : 15
       },
       "hiddenSeries" : false,
       "id" : 7,
@@ -1023,6 +813,216 @@
       ],
       "timeShift" : null,
       "title" : "DB Update Queries",
+      "tooltip" : {
+        "shared" : true,
+        "sort" : 0,
+        "value_type" : "individual"
+      },
+      "type" : "graph",
+      "xaxis" : {
+        "buckets" : null,
+        "mode" : "time",
+        "name" : null,
+        "show" : true,
+        "values" : [
+        ]
+      },
+      "yaxes" : [
+        {
+          "format" : "short",
+          "label" : "Time (seconds)",
+          "logBase" : 1,
+          "max" : null,
+          "min" : null,
+          "show" : true
+        },
+        {
+          "format" : "short",
+          "label" : null,
+          "logBase" : 1,
+          "max" : null,
+          "min" : null,
+          "show" : true
+        }
+      ],
+      "yaxis" : {
+        "align" : false,
+        "alignLevel" : null
+      }
+    },
+    {
+      "aliasColors" : {
+        
+      },
+      "bars" : false,
+      "dashLength" : 10,
+      "dashes" : false,
+      "datasource" : "Prometheus",
+      "fill" : 1,
+      "fillGradient" : 0,
+      "gridPos" : {
+        "h" : 5,
+        "w" : 12,
+        "x" : 0,
+        "y" : 20
+      },
+      "hiddenSeries" : false,
+      "id" : 8,
+      "legend" : {
+        "avg" : false,
+        "current" : false,
+        "max" : false,
+        "min" : false,
+        "rightSide" : true,
+        "show" : true,
+        "total" : false,
+        "values" : false
+      },
+      "lines" : true,
+      "linewidth" : 1,
+      "nullPointMode" : "null",
+      "options" : {
+        "dataLinks" : [
+        ]
+      },
+      "percentage" : false,
+      "pointradius" : 2,
+      "points" : false,
+      "renderer" : "flot",
+      "seriesOverrides" : [
+      ],
+      "spaceLength" : 10,
+      "stack" : false,
+      "steppedLine" : false,
+      "targets" : [
+        {
+          "expr" : "rate(simpletempletestuser_request_success_total{request_type=\"identify\"}[5m])",
+          "legendFormat" : "Success",
+          "refId" : "A"
+        },
+        {
+          "expr" : "rate(simpletempletestuser_request_failure_total{request_type=\"identify\"}[5m])",
+          "legendFormat" : "{{error_code}}",
+          "refId" : "B"
+        }
+      ],
+      "thresholds" : [
+      ],
+      "timeFrom" : null,
+      "timeRegions" : [
+      ],
+      "timeShift" : null,
+      "title" : "Identify SimpleTempleTestUser Requests",
+      "tooltip" : {
+        "shared" : true,
+        "sort" : 0,
+        "value_type" : "individual"
+      },
+      "type" : "graph",
+      "xaxis" : {
+        "buckets" : null,
+        "mode" : "time",
+        "name" : null,
+        "show" : true,
+        "values" : [
+        ]
+      },
+      "yaxes" : [
+        {
+          "format" : "short",
+          "label" : "QPS",
+          "logBase" : 1,
+          "max" : null,
+          "min" : null,
+          "show" : true
+        },
+        {
+          "format" : "short",
+          "label" : null,
+          "logBase" : 1,
+          "max" : null,
+          "min" : null,
+          "show" : true
+        }
+      ],
+      "yaxis" : {
+        "align" : false,
+        "alignLevel" : null
+      }
+    },
+    {
+      "aliasColors" : {
+        
+      },
+      "bars" : false,
+      "dashLength" : 10,
+      "dashes" : false,
+      "datasource" : "Prometheus",
+      "fill" : 1,
+      "fillGradient" : 0,
+      "gridPos" : {
+        "h" : 5,
+        "w" : 12,
+        "x" : 12,
+        "y" : 20
+      },
+      "hiddenSeries" : false,
+      "id" : 9,
+      "legend" : {
+        "avg" : false,
+        "current" : false,
+        "max" : false,
+        "min" : false,
+        "rightSide" : true,
+        "show" : true,
+        "total" : false,
+        "values" : false
+      },
+      "lines" : true,
+      "linewidth" : 1,
+      "nullPointMode" : "null",
+      "options" : {
+        "dataLinks" : [
+        ]
+      },
+      "percentage" : false,
+      "pointradius" : 2,
+      "points" : false,
+      "renderer" : "flot",
+      "seriesOverrides" : [
+      ],
+      "spaceLength" : 10,
+      "stack" : false,
+      "steppedLine" : false,
+      "targets" : [
+        {
+          "expr" : "simpletempletestuser_database_request_seconds{quantile=\"0.5\",query_type=\"identify\"}",
+          "legendFormat" : "50th Percentile",
+          "refId" : "A"
+        },
+        {
+          "expr" : "simpletempletestuser_database_request_seconds{quantile=\"0.9\",query_type=\"identify\"}",
+          "legendFormat" : "90th Percentile",
+          "refId" : "B"
+        },
+        {
+          "expr" : "simpletempletestuser_database_request_seconds{quantile=\"0.95\",query_type=\"identify\"}",
+          "legendFormat" : "95th Percentile",
+          "refId" : "C"
+        },
+        {
+          "expr" : "simpletempletestuser_database_request_seconds{quantile=\"0.99\",query_type=\"identify\"}",
+          "legendFormat" : "99th Percentile",
+          "refId" : "D"
+        }
+      ],
+      "thresholds" : [
+      ],
+      "timeFrom" : null,
+      "timeRegions" : [
+      ],
+      "timeShift" : null,
+      "title" : "DB Identify Queries",
       "tooltip" : {
         "shared" : true,
         "sort" : 0,
@@ -1287,216 +1287,6 @@
         "y" : 30
       },
       "hiddenSeries" : false,
-      "id" : 8,
-      "legend" : {
-        "avg" : false,
-        "current" : false,
-        "max" : false,
-        "min" : false,
-        "rightSide" : true,
-        "show" : true,
-        "total" : false,
-        "values" : false
-      },
-      "lines" : true,
-      "linewidth" : 1,
-      "nullPointMode" : "null",
-      "options" : {
-        "dataLinks" : [
-        ]
-      },
-      "percentage" : false,
-      "pointradius" : 2,
-      "points" : false,
-      "renderer" : "flot",
-      "seriesOverrides" : [
-      ],
-      "spaceLength" : 10,
-      "stack" : false,
-      "steppedLine" : false,
-      "targets" : [
-        {
-          "expr" : "rate(simpletempletestuser_request_success_total{request_type=\"delete_fred\"}[5m])",
-          "legendFormat" : "Success",
-          "refId" : "A"
-        },
-        {
-          "expr" : "rate(simpletempletestuser_request_failure_total{request_type=\"delete_fred\"}[5m])",
-          "legendFormat" : "{{error_code}}",
-          "refId" : "B"
-        }
-      ],
-      "thresholds" : [
-      ],
-      "timeFrom" : null,
-      "timeRegions" : [
-      ],
-      "timeShift" : null,
-      "title" : "Delete Fred Requests",
-      "tooltip" : {
-        "shared" : true,
-        "sort" : 0,
-        "value_type" : "individual"
-      },
-      "type" : "graph",
-      "xaxis" : {
-        "buckets" : null,
-        "mode" : "time",
-        "name" : null,
-        "show" : true,
-        "values" : [
-        ]
-      },
-      "yaxes" : [
-        {
-          "format" : "short",
-          "label" : "QPS",
-          "logBase" : 1,
-          "max" : null,
-          "min" : null,
-          "show" : true
-        },
-        {
-          "format" : "short",
-          "label" : null,
-          "logBase" : 1,
-          "max" : null,
-          "min" : null,
-          "show" : true
-        }
-      ],
-      "yaxis" : {
-        "align" : false,
-        "alignLevel" : null
-      }
-    },
-    {
-      "aliasColors" : {
-        
-      },
-      "bars" : false,
-      "dashLength" : 10,
-      "dashes" : false,
-      "datasource" : "Prometheus",
-      "fill" : 1,
-      "fillGradient" : 0,
-      "gridPos" : {
-        "h" : 5,
-        "w" : 12,
-        "x" : 12,
-        "y" : 30
-      },
-      "hiddenSeries" : false,
-      "id" : 9,
-      "legend" : {
-        "avg" : false,
-        "current" : false,
-        "max" : false,
-        "min" : false,
-        "rightSide" : true,
-        "show" : true,
-        "total" : false,
-        "values" : false
-      },
-      "lines" : true,
-      "linewidth" : 1,
-      "nullPointMode" : "null",
-      "options" : {
-        "dataLinks" : [
-        ]
-      },
-      "percentage" : false,
-      "pointradius" : 2,
-      "points" : false,
-      "renderer" : "flot",
-      "seriesOverrides" : [
-      ],
-      "spaceLength" : 10,
-      "stack" : false,
-      "steppedLine" : false,
-      "targets" : [
-        {
-          "expr" : "simpletempletestuser_database_request_seconds{quantile=\"0.5\",query_type=\"delete_fred\"}",
-          "legendFormat" : "50th Percentile",
-          "refId" : "A"
-        },
-        {
-          "expr" : "simpletempletestuser_database_request_seconds{quantile=\"0.9\",query_type=\"delete_fred\"}",
-          "legendFormat" : "90th Percentile",
-          "refId" : "B"
-        },
-        {
-          "expr" : "simpletempletestuser_database_request_seconds{quantile=\"0.95\",query_type=\"delete_fred\"}",
-          "legendFormat" : "95th Percentile",
-          "refId" : "C"
-        },
-        {
-          "expr" : "simpletempletestuser_database_request_seconds{quantile=\"0.99\",query_type=\"delete_fred\"}",
-          "legendFormat" : "99th Percentile",
-          "refId" : "D"
-        }
-      ],
-      "thresholds" : [
-      ],
-      "timeFrom" : null,
-      "timeRegions" : [
-      ],
-      "timeShift" : null,
-      "title" : "DB Delete Fred Queries",
-      "tooltip" : {
-        "shared" : true,
-        "sort" : 0,
-        "value_type" : "individual"
-      },
-      "type" : "graph",
-      "xaxis" : {
-        "buckets" : null,
-        "mode" : "time",
-        "name" : null,
-        "show" : true,
-        "values" : [
-        ]
-      },
-      "yaxes" : [
-        {
-          "format" : "short",
-          "label" : "Time (seconds)",
-          "logBase" : 1,
-          "max" : null,
-          "min" : null,
-          "show" : true
-        },
-        {
-          "format" : "short",
-          "label" : null,
-          "logBase" : 1,
-          "max" : null,
-          "min" : null,
-          "show" : true
-        }
-      ],
-      "yaxis" : {
-        "align" : false,
-        "alignLevel" : null
-      }
-    },
-    {
-      "aliasColors" : {
-        
-      },
-      "bars" : false,
-      "dashLength" : 10,
-      "dashes" : false,
-      "datasource" : "Prometheus",
-      "fill" : 1,
-      "fillGradient" : 0,
-      "gridPos" : {
-        "h" : 5,
-        "w" : 12,
-        "x" : 0,
-        "y" : 35
-      },
-      "hiddenSeries" : false,
       "id" : 2,
       "legend" : {
         "avg" : false,
@@ -1594,7 +1384,7 @@
         "h" : 5,
         "w" : 12,
         "x" : 12,
-        "y" : 35
+        "y" : 30
       },
       "hiddenSeries" : false,
       "id" : 3,
@@ -1704,7 +1494,7 @@
         "h" : 5,
         "w" : 12,
         "x" : 0,
-        "y" : 40
+        "y" : 35
       },
       "hiddenSeries" : false,
       "id" : 4,
@@ -1804,7 +1594,7 @@
         "h" : 5,
         "w" : 12,
         "x" : 12,
-        "y" : 40
+        "y" : 35
       },
       "hiddenSeries" : false,
       "id" : 5,
@@ -1914,7 +1704,7 @@
         "h" : 5,
         "w" : 12,
         "x" : 0,
-        "y" : 45
+        "y" : 40
       },
       "hiddenSeries" : false,
       "id" : 6,
@@ -2014,7 +1804,7 @@
         "h" : 5,
         "w" : 12,
         "x" : 12,
-        "y" : 45
+        "y" : 40
       },
       "hiddenSeries" : false,
       "id" : 7,
@@ -2073,6 +1863,216 @@
       ],
       "timeShift" : null,
       "title" : "DB Update Fred Queries",
+      "tooltip" : {
+        "shared" : true,
+        "sort" : 0,
+        "value_type" : "individual"
+      },
+      "type" : "graph",
+      "xaxis" : {
+        "buckets" : null,
+        "mode" : "time",
+        "name" : null,
+        "show" : true,
+        "values" : [
+        ]
+      },
+      "yaxes" : [
+        {
+          "format" : "short",
+          "label" : "Time (seconds)",
+          "logBase" : 1,
+          "max" : null,
+          "min" : null,
+          "show" : true
+        },
+        {
+          "format" : "short",
+          "label" : null,
+          "logBase" : 1,
+          "max" : null,
+          "min" : null,
+          "show" : true
+        }
+      ],
+      "yaxis" : {
+        "align" : false,
+        "alignLevel" : null
+      }
+    },
+    {
+      "aliasColors" : {
+        
+      },
+      "bars" : false,
+      "dashLength" : 10,
+      "dashes" : false,
+      "datasource" : "Prometheus",
+      "fill" : 1,
+      "fillGradient" : 0,
+      "gridPos" : {
+        "h" : 5,
+        "w" : 12,
+        "x" : 0,
+        "y" : 45
+      },
+      "hiddenSeries" : false,
+      "id" : 8,
+      "legend" : {
+        "avg" : false,
+        "current" : false,
+        "max" : false,
+        "min" : false,
+        "rightSide" : true,
+        "show" : true,
+        "total" : false,
+        "values" : false
+      },
+      "lines" : true,
+      "linewidth" : 1,
+      "nullPointMode" : "null",
+      "options" : {
+        "dataLinks" : [
+        ]
+      },
+      "percentage" : false,
+      "pointradius" : 2,
+      "points" : false,
+      "renderer" : "flot",
+      "seriesOverrides" : [
+      ],
+      "spaceLength" : 10,
+      "stack" : false,
+      "steppedLine" : false,
+      "targets" : [
+        {
+          "expr" : "rate(simpletempletestuser_request_success_total{request_type=\"delete_fred\"}[5m])",
+          "legendFormat" : "Success",
+          "refId" : "A"
+        },
+        {
+          "expr" : "rate(simpletempletestuser_request_failure_total{request_type=\"delete_fred\"}[5m])",
+          "legendFormat" : "{{error_code}}",
+          "refId" : "B"
+        }
+      ],
+      "thresholds" : [
+      ],
+      "timeFrom" : null,
+      "timeRegions" : [
+      ],
+      "timeShift" : null,
+      "title" : "Delete Fred Requests",
+      "tooltip" : {
+        "shared" : true,
+        "sort" : 0,
+        "value_type" : "individual"
+      },
+      "type" : "graph",
+      "xaxis" : {
+        "buckets" : null,
+        "mode" : "time",
+        "name" : null,
+        "show" : true,
+        "values" : [
+        ]
+      },
+      "yaxes" : [
+        {
+          "format" : "short",
+          "label" : "QPS",
+          "logBase" : 1,
+          "max" : null,
+          "min" : null,
+          "show" : true
+        },
+        {
+          "format" : "short",
+          "label" : null,
+          "logBase" : 1,
+          "max" : null,
+          "min" : null,
+          "show" : true
+        }
+      ],
+      "yaxis" : {
+        "align" : false,
+        "alignLevel" : null
+      }
+    },
+    {
+      "aliasColors" : {
+        
+      },
+      "bars" : false,
+      "dashLength" : 10,
+      "dashes" : false,
+      "datasource" : "Prometheus",
+      "fill" : 1,
+      "fillGradient" : 0,
+      "gridPos" : {
+        "h" : 5,
+        "w" : 12,
+        "x" : 12,
+        "y" : 45
+      },
+      "hiddenSeries" : false,
+      "id" : 9,
+      "legend" : {
+        "avg" : false,
+        "current" : false,
+        "max" : false,
+        "min" : false,
+        "rightSide" : true,
+        "show" : true,
+        "total" : false,
+        "values" : false
+      },
+      "lines" : true,
+      "linewidth" : 1,
+      "nullPointMode" : "null",
+      "options" : {
+        "dataLinks" : [
+        ]
+      },
+      "percentage" : false,
+      "pointradius" : 2,
+      "points" : false,
+      "renderer" : "flot",
+      "seriesOverrides" : [
+      ],
+      "spaceLength" : 10,
+      "stack" : false,
+      "steppedLine" : false,
+      "targets" : [
+        {
+          "expr" : "simpletempletestuser_database_request_seconds{quantile=\"0.5\",query_type=\"delete_fred\"}",
+          "legendFormat" : "50th Percentile",
+          "refId" : "A"
+        },
+        {
+          "expr" : "simpletempletestuser_database_request_seconds{quantile=\"0.9\",query_type=\"delete_fred\"}",
+          "legendFormat" : "90th Percentile",
+          "refId" : "B"
+        },
+        {
+          "expr" : "simpletempletestuser_database_request_seconds{quantile=\"0.95\",query_type=\"delete_fred\"}",
+          "legendFormat" : "95th Percentile",
+          "refId" : "C"
+        },
+        {
+          "expr" : "simpletempletestuser_database_request_seconds{quantile=\"0.99\",query_type=\"delete_fred\"}",
+          "legendFormat" : "99th Percentile",
+          "refId" : "D"
+        }
+      ],
+      "thresholds" : [
+      ],
+      "timeFrom" : null,
+      "timeRegions" : [
+      ],
+      "timeShift" : null,
+      "title" : "DB Delete Fred Queries",
       "tooltip" : {
         "shared" : true,
         "sort" : 0,

--- a/src/main/scala/temple/builder/MetricsBuilder.scala
+++ b/src/main/scala/temple/builder/MetricsBuilder.scala
@@ -48,7 +48,7 @@ object MetricsBuilder {
     endpoints: SortedSet[CRUD],
     structName: Option[String] = None,
   ): Seq[Row] =
-    endpoints.zipWithIndex.map {
+    endpoints.toSeq.zipWithIndex.map {
       case (endpoint, index) =>
         Row(
           Metric(
@@ -72,5 +72,5 @@ object MetricsBuilder {
             ),
           ),
         )
-    }.toSeq
+    }
 }

--- a/src/test/resources/project-builder-complex/grafana/provisioning/dashboards/complex-user.json
+++ b/src/test/resources/project-builder-complex/grafana/provisioning/dashboards/complex-user.json
@@ -237,216 +237,6 @@
         "y" : 5
       },
       "hiddenSeries" : false,
-      "id" : 6,
-      "legend" : {
-        "avg" : false,
-        "current" : false,
-        "max" : false,
-        "min" : false,
-        "rightSide" : true,
-        "show" : true,
-        "total" : false,
-        "values" : false
-      },
-      "lines" : true,
-      "linewidth" : 1,
-      "nullPointMode" : "null",
-      "options" : {
-        "dataLinks" : [
-        ]
-      },
-      "percentage" : false,
-      "pointradius" : 2,
-      "points" : false,
-      "renderer" : "flot",
-      "seriesOverrides" : [
-      ],
-      "spaceLength" : 10,
-      "stack" : false,
-      "steppedLine" : false,
-      "targets" : [
-        {
-          "expr" : "rate(complexuser_request_success_total{request_type=\"delete\"}[5m])",
-          "legendFormat" : "Success",
-          "refId" : "A"
-        },
-        {
-          "expr" : "rate(complexuser_request_failure_total{request_type=\"delete\"}[5m])",
-          "legendFormat" : "{{error_code}}",
-          "refId" : "B"
-        }
-      ],
-      "thresholds" : [
-      ],
-      "timeFrom" : null,
-      "timeRegions" : [
-      ],
-      "timeShift" : null,
-      "title" : "Delete ComplexUser Requests",
-      "tooltip" : {
-        "shared" : true,
-        "sort" : 0,
-        "value_type" : "individual"
-      },
-      "type" : "graph",
-      "xaxis" : {
-        "buckets" : null,
-        "mode" : "time",
-        "name" : null,
-        "show" : true,
-        "values" : [
-        ]
-      },
-      "yaxes" : [
-        {
-          "format" : "short",
-          "label" : "QPS",
-          "logBase" : 1,
-          "max" : null,
-          "min" : null,
-          "show" : true
-        },
-        {
-          "format" : "short",
-          "label" : null,
-          "logBase" : 1,
-          "max" : null,
-          "min" : null,
-          "show" : true
-        }
-      ],
-      "yaxis" : {
-        "align" : false,
-        "alignLevel" : null
-      }
-    },
-    {
-      "aliasColors" : {
-        
-      },
-      "bars" : false,
-      "dashLength" : 10,
-      "dashes" : false,
-      "datasource" : "Prometheus",
-      "fill" : 1,
-      "fillGradient" : 0,
-      "gridPos" : {
-        "h" : 5,
-        "w" : 12,
-        "x" : 12,
-        "y" : 5
-      },
-      "hiddenSeries" : false,
-      "id" : 7,
-      "legend" : {
-        "avg" : false,
-        "current" : false,
-        "max" : false,
-        "min" : false,
-        "rightSide" : true,
-        "show" : true,
-        "total" : false,
-        "values" : false
-      },
-      "lines" : true,
-      "linewidth" : 1,
-      "nullPointMode" : "null",
-      "options" : {
-        "dataLinks" : [
-        ]
-      },
-      "percentage" : false,
-      "pointradius" : 2,
-      "points" : false,
-      "renderer" : "flot",
-      "seriesOverrides" : [
-      ],
-      "spaceLength" : 10,
-      "stack" : false,
-      "steppedLine" : false,
-      "targets" : [
-        {
-          "expr" : "complexuser_database_request_seconds{quantile=\"0.5\",query_type=\"delete\"}",
-          "legendFormat" : "50th Percentile",
-          "refId" : "A"
-        },
-        {
-          "expr" : "complexuser_database_request_seconds{quantile=\"0.9\",query_type=\"delete\"}",
-          "legendFormat" : "90th Percentile",
-          "refId" : "B"
-        },
-        {
-          "expr" : "complexuser_database_request_seconds{quantile=\"0.95\",query_type=\"delete\"}",
-          "legendFormat" : "95th Percentile",
-          "refId" : "C"
-        },
-        {
-          "expr" : "complexuser_database_request_seconds{quantile=\"0.99\",query_type=\"delete\"}",
-          "legendFormat" : "99th Percentile",
-          "refId" : "D"
-        }
-      ],
-      "thresholds" : [
-      ],
-      "timeFrom" : null,
-      "timeRegions" : [
-      ],
-      "timeShift" : null,
-      "title" : "DB Delete Queries",
-      "tooltip" : {
-        "shared" : true,
-        "sort" : 0,
-        "value_type" : "individual"
-      },
-      "type" : "graph",
-      "xaxis" : {
-        "buckets" : null,
-        "mode" : "time",
-        "name" : null,
-        "show" : true,
-        "values" : [
-        ]
-      },
-      "yaxes" : [
-        {
-          "format" : "short",
-          "label" : "Time (seconds)",
-          "logBase" : 1,
-          "max" : null,
-          "min" : null,
-          "show" : true
-        },
-        {
-          "format" : "short",
-          "label" : null,
-          "logBase" : 1,
-          "max" : null,
-          "min" : null,
-          "show" : true
-        }
-      ],
-      "yaxis" : {
-        "align" : false,
-        "alignLevel" : null
-      }
-    },
-    {
-      "aliasColors" : {
-        
-      },
-      "bars" : false,
-      "dashLength" : 10,
-      "dashes" : false,
-      "datasource" : "Prometheus",
-      "fill" : 1,
-      "fillGradient" : 0,
-      "gridPos" : {
-        "h" : 5,
-        "w" : 12,
-        "x" : 0,
-        "y" : 10
-      },
-      "hiddenSeries" : false,
       "id" : 2,
       "legend" : {
         "avg" : false,
@@ -544,7 +334,7 @@
         "h" : 5,
         "w" : 12,
         "x" : 12,
-        "y" : 10
+        "y" : 5
       },
       "hiddenSeries" : false,
       "id" : 3,
@@ -654,217 +444,7 @@
         "h" : 5,
         "w" : 12,
         "x" : 0,
-        "y" : 15
-      },
-      "hiddenSeries" : false,
-      "id" : 8,
-      "legend" : {
-        "avg" : false,
-        "current" : false,
-        "max" : false,
-        "min" : false,
-        "rightSide" : true,
-        "show" : true,
-        "total" : false,
-        "values" : false
-      },
-      "lines" : true,
-      "linewidth" : 1,
-      "nullPointMode" : "null",
-      "options" : {
-        "dataLinks" : [
-        ]
-      },
-      "percentage" : false,
-      "pointradius" : 2,
-      "points" : false,
-      "renderer" : "flot",
-      "seriesOverrides" : [
-      ],
-      "spaceLength" : 10,
-      "stack" : false,
-      "steppedLine" : false,
-      "targets" : [
-        {
-          "expr" : "rate(complexuser_request_success_total{request_type=\"identify\"}[5m])",
-          "legendFormat" : "Success",
-          "refId" : "A"
-        },
-        {
-          "expr" : "rate(complexuser_request_failure_total{request_type=\"identify\"}[5m])",
-          "legendFormat" : "{{error_code}}",
-          "refId" : "B"
-        }
-      ],
-      "thresholds" : [
-      ],
-      "timeFrom" : null,
-      "timeRegions" : [
-      ],
-      "timeShift" : null,
-      "title" : "Identify ComplexUser Requests",
-      "tooltip" : {
-        "shared" : true,
-        "sort" : 0,
-        "value_type" : "individual"
-      },
-      "type" : "graph",
-      "xaxis" : {
-        "buckets" : null,
-        "mode" : "time",
-        "name" : null,
-        "show" : true,
-        "values" : [
-        ]
-      },
-      "yaxes" : [
-        {
-          "format" : "short",
-          "label" : "QPS",
-          "logBase" : 1,
-          "max" : null,
-          "min" : null,
-          "show" : true
-        },
-        {
-          "format" : "short",
-          "label" : null,
-          "logBase" : 1,
-          "max" : null,
-          "min" : null,
-          "show" : true
-        }
-      ],
-      "yaxis" : {
-        "align" : false,
-        "alignLevel" : null
-      }
-    },
-    {
-      "aliasColors" : {
-        
-      },
-      "bars" : false,
-      "dashLength" : 10,
-      "dashes" : false,
-      "datasource" : "Prometheus",
-      "fill" : 1,
-      "fillGradient" : 0,
-      "gridPos" : {
-        "h" : 5,
-        "w" : 12,
-        "x" : 12,
-        "y" : 15
-      },
-      "hiddenSeries" : false,
-      "id" : 9,
-      "legend" : {
-        "avg" : false,
-        "current" : false,
-        "max" : false,
-        "min" : false,
-        "rightSide" : true,
-        "show" : true,
-        "total" : false,
-        "values" : false
-      },
-      "lines" : true,
-      "linewidth" : 1,
-      "nullPointMode" : "null",
-      "options" : {
-        "dataLinks" : [
-        ]
-      },
-      "percentage" : false,
-      "pointradius" : 2,
-      "points" : false,
-      "renderer" : "flot",
-      "seriesOverrides" : [
-      ],
-      "spaceLength" : 10,
-      "stack" : false,
-      "steppedLine" : false,
-      "targets" : [
-        {
-          "expr" : "complexuser_database_request_seconds{quantile=\"0.5\",query_type=\"identify\"}",
-          "legendFormat" : "50th Percentile",
-          "refId" : "A"
-        },
-        {
-          "expr" : "complexuser_database_request_seconds{quantile=\"0.9\",query_type=\"identify\"}",
-          "legendFormat" : "90th Percentile",
-          "refId" : "B"
-        },
-        {
-          "expr" : "complexuser_database_request_seconds{quantile=\"0.95\",query_type=\"identify\"}",
-          "legendFormat" : "95th Percentile",
-          "refId" : "C"
-        },
-        {
-          "expr" : "complexuser_database_request_seconds{quantile=\"0.99\",query_type=\"identify\"}",
-          "legendFormat" : "99th Percentile",
-          "refId" : "D"
-        }
-      ],
-      "thresholds" : [
-      ],
-      "timeFrom" : null,
-      "timeRegions" : [
-      ],
-      "timeShift" : null,
-      "title" : "DB Identify Queries",
-      "tooltip" : {
-        "shared" : true,
-        "sort" : 0,
-        "value_type" : "individual"
-      },
-      "type" : "graph",
-      "xaxis" : {
-        "buckets" : null,
-        "mode" : "time",
-        "name" : null,
-        "show" : true,
-        "values" : [
-        ]
-      },
-      "yaxes" : [
-        {
-          "format" : "short",
-          "label" : "Time (seconds)",
-          "logBase" : 1,
-          "max" : null,
-          "min" : null,
-          "show" : true
-        },
-        {
-          "format" : "short",
-          "label" : null,
-          "logBase" : 1,
-          "max" : null,
-          "min" : null,
-          "show" : true
-        }
-      ],
-      "yaxis" : {
-        "align" : false,
-        "alignLevel" : null
-      }
-    },
-    {
-      "aliasColors" : {
-        
-      },
-      "bars" : false,
-      "dashLength" : 10,
-      "dashes" : false,
-      "datasource" : "Prometheus",
-      "fill" : 1,
-      "fillGradient" : 0,
-      "gridPos" : {
-        "h" : 5,
-        "w" : 12,
-        "x" : 0,
-        "y" : 20
+        "y" : 10
       },
       "hiddenSeries" : false,
       "id" : 4,
@@ -964,7 +544,7 @@
         "h" : 5,
         "w" : 12,
         "x" : 12,
-        "y" : 20
+        "y" : 10
       },
       "hiddenSeries" : false,
       "id" : 5,
@@ -1023,6 +603,426 @@
       ],
       "timeShift" : null,
       "title" : "DB Update Queries",
+      "tooltip" : {
+        "shared" : true,
+        "sort" : 0,
+        "value_type" : "individual"
+      },
+      "type" : "graph",
+      "xaxis" : {
+        "buckets" : null,
+        "mode" : "time",
+        "name" : null,
+        "show" : true,
+        "values" : [
+        ]
+      },
+      "yaxes" : [
+        {
+          "format" : "short",
+          "label" : "Time (seconds)",
+          "logBase" : 1,
+          "max" : null,
+          "min" : null,
+          "show" : true
+        },
+        {
+          "format" : "short",
+          "label" : null,
+          "logBase" : 1,
+          "max" : null,
+          "min" : null,
+          "show" : true
+        }
+      ],
+      "yaxis" : {
+        "align" : false,
+        "alignLevel" : null
+      }
+    },
+    {
+      "aliasColors" : {
+        
+      },
+      "bars" : false,
+      "dashLength" : 10,
+      "dashes" : false,
+      "datasource" : "Prometheus",
+      "fill" : 1,
+      "fillGradient" : 0,
+      "gridPos" : {
+        "h" : 5,
+        "w" : 12,
+        "x" : 0,
+        "y" : 15
+      },
+      "hiddenSeries" : false,
+      "id" : 6,
+      "legend" : {
+        "avg" : false,
+        "current" : false,
+        "max" : false,
+        "min" : false,
+        "rightSide" : true,
+        "show" : true,
+        "total" : false,
+        "values" : false
+      },
+      "lines" : true,
+      "linewidth" : 1,
+      "nullPointMode" : "null",
+      "options" : {
+        "dataLinks" : [
+        ]
+      },
+      "percentage" : false,
+      "pointradius" : 2,
+      "points" : false,
+      "renderer" : "flot",
+      "seriesOverrides" : [
+      ],
+      "spaceLength" : 10,
+      "stack" : false,
+      "steppedLine" : false,
+      "targets" : [
+        {
+          "expr" : "rate(complexuser_request_success_total{request_type=\"delete\"}[5m])",
+          "legendFormat" : "Success",
+          "refId" : "A"
+        },
+        {
+          "expr" : "rate(complexuser_request_failure_total{request_type=\"delete\"}[5m])",
+          "legendFormat" : "{{error_code}}",
+          "refId" : "B"
+        }
+      ],
+      "thresholds" : [
+      ],
+      "timeFrom" : null,
+      "timeRegions" : [
+      ],
+      "timeShift" : null,
+      "title" : "Delete ComplexUser Requests",
+      "tooltip" : {
+        "shared" : true,
+        "sort" : 0,
+        "value_type" : "individual"
+      },
+      "type" : "graph",
+      "xaxis" : {
+        "buckets" : null,
+        "mode" : "time",
+        "name" : null,
+        "show" : true,
+        "values" : [
+        ]
+      },
+      "yaxes" : [
+        {
+          "format" : "short",
+          "label" : "QPS",
+          "logBase" : 1,
+          "max" : null,
+          "min" : null,
+          "show" : true
+        },
+        {
+          "format" : "short",
+          "label" : null,
+          "logBase" : 1,
+          "max" : null,
+          "min" : null,
+          "show" : true
+        }
+      ],
+      "yaxis" : {
+        "align" : false,
+        "alignLevel" : null
+      }
+    },
+    {
+      "aliasColors" : {
+        
+      },
+      "bars" : false,
+      "dashLength" : 10,
+      "dashes" : false,
+      "datasource" : "Prometheus",
+      "fill" : 1,
+      "fillGradient" : 0,
+      "gridPos" : {
+        "h" : 5,
+        "w" : 12,
+        "x" : 12,
+        "y" : 15
+      },
+      "hiddenSeries" : false,
+      "id" : 7,
+      "legend" : {
+        "avg" : false,
+        "current" : false,
+        "max" : false,
+        "min" : false,
+        "rightSide" : true,
+        "show" : true,
+        "total" : false,
+        "values" : false
+      },
+      "lines" : true,
+      "linewidth" : 1,
+      "nullPointMode" : "null",
+      "options" : {
+        "dataLinks" : [
+        ]
+      },
+      "percentage" : false,
+      "pointradius" : 2,
+      "points" : false,
+      "renderer" : "flot",
+      "seriesOverrides" : [
+      ],
+      "spaceLength" : 10,
+      "stack" : false,
+      "steppedLine" : false,
+      "targets" : [
+        {
+          "expr" : "complexuser_database_request_seconds{quantile=\"0.5\",query_type=\"delete\"}",
+          "legendFormat" : "50th Percentile",
+          "refId" : "A"
+        },
+        {
+          "expr" : "complexuser_database_request_seconds{quantile=\"0.9\",query_type=\"delete\"}",
+          "legendFormat" : "90th Percentile",
+          "refId" : "B"
+        },
+        {
+          "expr" : "complexuser_database_request_seconds{quantile=\"0.95\",query_type=\"delete\"}",
+          "legendFormat" : "95th Percentile",
+          "refId" : "C"
+        },
+        {
+          "expr" : "complexuser_database_request_seconds{quantile=\"0.99\",query_type=\"delete\"}",
+          "legendFormat" : "99th Percentile",
+          "refId" : "D"
+        }
+      ],
+      "thresholds" : [
+      ],
+      "timeFrom" : null,
+      "timeRegions" : [
+      ],
+      "timeShift" : null,
+      "title" : "DB Delete Queries",
+      "tooltip" : {
+        "shared" : true,
+        "sort" : 0,
+        "value_type" : "individual"
+      },
+      "type" : "graph",
+      "xaxis" : {
+        "buckets" : null,
+        "mode" : "time",
+        "name" : null,
+        "show" : true,
+        "values" : [
+        ]
+      },
+      "yaxes" : [
+        {
+          "format" : "short",
+          "label" : "Time (seconds)",
+          "logBase" : 1,
+          "max" : null,
+          "min" : null,
+          "show" : true
+        },
+        {
+          "format" : "short",
+          "label" : null,
+          "logBase" : 1,
+          "max" : null,
+          "min" : null,
+          "show" : true
+        }
+      ],
+      "yaxis" : {
+        "align" : false,
+        "alignLevel" : null
+      }
+    },
+    {
+      "aliasColors" : {
+        
+      },
+      "bars" : false,
+      "dashLength" : 10,
+      "dashes" : false,
+      "datasource" : "Prometheus",
+      "fill" : 1,
+      "fillGradient" : 0,
+      "gridPos" : {
+        "h" : 5,
+        "w" : 12,
+        "x" : 0,
+        "y" : 20
+      },
+      "hiddenSeries" : false,
+      "id" : 8,
+      "legend" : {
+        "avg" : false,
+        "current" : false,
+        "max" : false,
+        "min" : false,
+        "rightSide" : true,
+        "show" : true,
+        "total" : false,
+        "values" : false
+      },
+      "lines" : true,
+      "linewidth" : 1,
+      "nullPointMode" : "null",
+      "options" : {
+        "dataLinks" : [
+        ]
+      },
+      "percentage" : false,
+      "pointradius" : 2,
+      "points" : false,
+      "renderer" : "flot",
+      "seriesOverrides" : [
+      ],
+      "spaceLength" : 10,
+      "stack" : false,
+      "steppedLine" : false,
+      "targets" : [
+        {
+          "expr" : "rate(complexuser_request_success_total{request_type=\"identify\"}[5m])",
+          "legendFormat" : "Success",
+          "refId" : "A"
+        },
+        {
+          "expr" : "rate(complexuser_request_failure_total{request_type=\"identify\"}[5m])",
+          "legendFormat" : "{{error_code}}",
+          "refId" : "B"
+        }
+      ],
+      "thresholds" : [
+      ],
+      "timeFrom" : null,
+      "timeRegions" : [
+      ],
+      "timeShift" : null,
+      "title" : "Identify ComplexUser Requests",
+      "tooltip" : {
+        "shared" : true,
+        "sort" : 0,
+        "value_type" : "individual"
+      },
+      "type" : "graph",
+      "xaxis" : {
+        "buckets" : null,
+        "mode" : "time",
+        "name" : null,
+        "show" : true,
+        "values" : [
+        ]
+      },
+      "yaxes" : [
+        {
+          "format" : "short",
+          "label" : "QPS",
+          "logBase" : 1,
+          "max" : null,
+          "min" : null,
+          "show" : true
+        },
+        {
+          "format" : "short",
+          "label" : null,
+          "logBase" : 1,
+          "max" : null,
+          "min" : null,
+          "show" : true
+        }
+      ],
+      "yaxis" : {
+        "align" : false,
+        "alignLevel" : null
+      }
+    },
+    {
+      "aliasColors" : {
+        
+      },
+      "bars" : false,
+      "dashLength" : 10,
+      "dashes" : false,
+      "datasource" : "Prometheus",
+      "fill" : 1,
+      "fillGradient" : 0,
+      "gridPos" : {
+        "h" : 5,
+        "w" : 12,
+        "x" : 12,
+        "y" : 20
+      },
+      "hiddenSeries" : false,
+      "id" : 9,
+      "legend" : {
+        "avg" : false,
+        "current" : false,
+        "max" : false,
+        "min" : false,
+        "rightSide" : true,
+        "show" : true,
+        "total" : false,
+        "values" : false
+      },
+      "lines" : true,
+      "linewidth" : 1,
+      "nullPointMode" : "null",
+      "options" : {
+        "dataLinks" : [
+        ]
+      },
+      "percentage" : false,
+      "pointradius" : 2,
+      "points" : false,
+      "renderer" : "flot",
+      "seriesOverrides" : [
+      ],
+      "spaceLength" : 10,
+      "stack" : false,
+      "steppedLine" : false,
+      "targets" : [
+        {
+          "expr" : "complexuser_database_request_seconds{quantile=\"0.5\",query_type=\"identify\"}",
+          "legendFormat" : "50th Percentile",
+          "refId" : "A"
+        },
+        {
+          "expr" : "complexuser_database_request_seconds{quantile=\"0.9\",query_type=\"identify\"}",
+          "legendFormat" : "90th Percentile",
+          "refId" : "B"
+        },
+        {
+          "expr" : "complexuser_database_request_seconds{quantile=\"0.95\",query_type=\"identify\"}",
+          "legendFormat" : "95th Percentile",
+          "refId" : "C"
+        },
+        {
+          "expr" : "complexuser_database_request_seconds{quantile=\"0.99\",query_type=\"identify\"}",
+          "legendFormat" : "99th Percentile",
+          "refId" : "D"
+        }
+      ],
+      "thresholds" : [
+      ],
+      "timeFrom" : null,
+      "timeRegions" : [
+      ],
+      "timeShift" : null,
+      "title" : "DB Identify Queries",
       "tooltip" : {
         "shared" : true,
         "sort" : 0,


### PR DESCRIPTION
The order of the dashboards in Grafana didn't match our LCRUDI (what an acronym), because of a sorting issue.

Moving the `.toSeq` seems to have fixed.