### PR TITLE
[DSL] Remove access controls from structs

### DIFF
--- a/src/e2e/scala/temple/DSL/ParserE2ETest.scala
+++ b/src/e2e/scala/temple/DSL/ParserE2ETest.scala
@@ -61,7 +61,7 @@ class ParserE2ETest extends FlatSpec with Matchers with DSLParserMatchers {
                 "friend"    -> Attribute(ForeignKey("SimpleTempleTestUser")),
                 "image"     -> Attribute(BlobType(size = Some(10_000_000))),
               ),
-              Seq(ServiceEnumerable, Readable.This),
+              Seq(ServiceEnumerable),
             ),
           ),
         ),

--- a/src/main/scala/temple/DSL/semantics/Analyzer.scala
+++ b/src/main/scala/temple/DSL/semantics/Analyzer.scala
@@ -167,8 +167,6 @@ object Analyzer {
   /** A parser of Metadata items that can occur in struct blocks */
   private val parseStructMetadata = new MetadataParser[StructMetadata] {
     registerEmptyKeyword("enumerable")(ServiceEnumerable)
-    registerKeywordWithContext("readable", "by", TokenArgType)(Readable)
-    registerKeywordWithContext("writable", "by", TokenArgType)(Writable)
     registerKeywordWithContext("omit", "endpoints", ListArgType(TokenArgType))(Omit)
   }
 

--- a/src/main/scala/temple/DSL/semantics/Validator.scala
+++ b/src/main/scala/temple/DSL/semantics/Validator.scala
@@ -4,7 +4,7 @@ import temple.DSL.semantics.NameClashes._
 import temple.ast.AbstractAttribute.{Attribute, CreatedByAttribute, IDAttribute}
 import temple.ast.AbstractServiceBlock._
 import temple.ast.AttributeType._
-import temple.ast.Metadata.{Readable, ServiceAuth}
+import temple.ast.Metadata.ServiceAuth
 import temple.ast._
 import temple.builder.project.ProjectConfig
 import temple.utils.MonadUtils.FromEither
@@ -88,17 +88,8 @@ private class Validator private (templefile: Templefile) {
   private def validateService(serviceName: String, service: ServiceBlock, context: SemanticContext): ServiceBlock = {
     renameBlock(serviceName, service)
 
-    val defaultReadable                       = ProjectConfig.getDefaultReadable(templefile.usesAuth)
-    def readability(block: AttributeBlock[_]) = block.lookupLocalMetadata[Metadata.Readable] getOrElse defaultReadable
-    lazy val serviceReadability               = readability(service)
     val newStructs = service.structs.transform {
-      case (name, struct) =>
-        val structContext = context :+ name
-
-        if (readability(struct) == Metadata.Readable.All && serviceReadability == Readable.This)
-          errors += structContext.errorMessage("A struct cannot have wider readability than its parent service")
-
-        validateStruct(name, struct, structContext)
+      case (name, struct) => validateStruct(name, struct, context :+ name)
     }
     val newAttributes = validateAttributes(service, context)
     val newMetadata   = validateStructMetadata(service.metadata, newAttributes, context)

--- a/src/main/scala/temple/ast/Metadata.scala
+++ b/src/main/scala/temple/ast/Metadata.scala
@@ -57,7 +57,6 @@ object Metadata {
   sealed abstract class Readable private (name: String)
       extends EnumEntry(name)
       with ServiceMetadata
-      with StructMetadata
       with ProjectMetadata
 
   object Readable extends Enum[Readable] {
@@ -66,7 +65,10 @@ object Metadata {
     case object This extends Readable("this")
   }
 
-  sealed abstract class Writable private (name: String) extends EnumEntry(name) with StructMetadata with ProjectMetadata
+  sealed abstract class Writable private (name: String)
+      extends EnumEntry(name)
+      with ServiceMetadata
+      with ProjectMetadata
 
   object Writable extends Enum[Writable] {
     override def values: IndexedSeq[Writable] = findValues

--- a/src/test/scala/temple/DSL/parser/DSLParserTest.scala
+++ b/src/test/scala/temple/DSL/parser/DSLParserTest.scala
@@ -87,7 +87,6 @@ class DSLParserTest extends FlatSpec with DSLParserMatchers {
               Attribute("friend", AttributeType.Foreign("User")),
               Attribute("image", AttributeType.Primitive("data", Args(Seq(Arg.IntArg(10_000_000))))),
               Metadata("enumerable"),
-              Metadata("readable", Args(kwargs = Seq("by" -> Arg.TokenArg("this")))),
             ),
           ),
           Metadata("enumerable"),

--- a/src/test/scala/temple/DSL/semantics/ValidatorTest.scala
+++ b/src/test/scala/temple/DSL/semantics/ValidatorTest.scala
@@ -46,26 +46,6 @@ class ValidatorTest extends FlatSpec with Matchers {
     ) shouldBe empty
   }
 
-  it should "prevent structs from having greater readability than their parents" in {
-    validationErrors(
-      Templefile(
-        "MyProject",
-        projectBlock = ProjectBlock(Seq(Database.Postgres, AuthMethod.Email)),
-        services = Map(
-          "User" -> ServiceBlock(
-            attributes = Map(),
-            metadata = Seq(Readable.This, ServiceAuth),
-            structs = Map(
-              "Struct" -> StructBlock(Map(), metadata = Seq(Readable.All)),
-            ),
-          ),
-        ),
-      ),
-    ) shouldBe Set(
-      "A struct cannot have wider readability than its parent service in Struct, in User",
-    )
-  }
-
   it should "identify duplicate usage of structs" in {
     validationErrors(
       Templefile(

--- a/src/test/scala/temple/testfiles/simple-dc.temple
+++ b/src/test/scala/temple/testfiles/simple-dc.temple
@@ -21,7 +21,6 @@ User: service {
     friend: User;
     image: data(10M);
     #enumerable;
-    #readable(by: this);
   };
 
   #enumerable;

--- a/src/test/scala/temple/testfiles/simple.temple
+++ b/src/test/scala/temple/testfiles/simple.temple
@@ -21,7 +21,6 @@ User: service {
     friend: User;
     image: data(10M);
     #enumerable;
-    #readable(by: this);
   };
 
   #enumerable;


### PR DESCRIPTION
As agreed on slack, this can now be inherited in its entirety from the parent service. Surprised at how easy this was to remove…

Edit: reverts #344, d’oh