### PR TITLE
[test] Allow --testOnly flag to temple test

### DIFF
--- a/src/main/scala/temple/Application.scala
+++ b/src/main/scala/temple/Application.scala
@@ -51,6 +51,10 @@ object Application {
       throw new RuntimeException(error)
     }
     val analyzedTemplefile = Analyzer.parseAndValidate(data)
-    ProjectTester.test(analyzedTemplefile, generatedDirectory)
+    if (config.Test.testOnly()) {
+      ProjectTester.testOnly(analyzedTemplefile, generatedDirectory)
+    } else {
+      ProjectTester.test(analyzedTemplefile, generatedDirectory)
+    }
   }
 }

--- a/src/main/scala/temple/TempleConfig.scala
+++ b/src/main/scala/temple/TempleConfig.scala
@@ -35,6 +35,9 @@ class TempleConfig(arguments: CSeq[String]) extends ScallopConf(arguments) {
   object Test extends Subcommand("test") {
     val filename: ScallopOption[String] = trailArg[String]("filename", "Templefile to test against")
 
+    val testOnly: ScallopOption[Boolean] =
+      opt[Boolean]("testOnly", 't', "Do not spin up or shutdown any infrastructure as part of the testing")
+
     val generatedDirectory: ScallopOption[String] =
       opt[String]("dir", 'd', "Root directory where files have been generated")
   }

--- a/src/main/scala/temple/test/ProjectTester.scala
+++ b/src/main/scala/temple/test/ProjectTester.scala
@@ -1,7 +1,7 @@
 package temple.test
 
 import java.io.IOException
-import java.net.HttpURLConnection
+import java.net.{ConnectException, HttpURLConnection}
 
 import scalaj.http.Http
 import temple.ast.Metadata.{AuthMethod, Provider}
@@ -46,13 +46,29 @@ object ProjectTester {
     }
   }
 
+  private def getConfig(templefile: Templefile): ProjectConfig = {
+    val provider = templefile
+      .lookupMetadata[Metadata.Provider]
+      .getOrElse { throw new RuntimeException("Could not find deployment information") }
+
+    provider match {
+      case Provider.Kubernetes =>
+        // Grab Kong's URL for future requests
+        val Array(baseURL, kongAdmin, _*) = exec("minikube service kong --url").split("\n")
+        val baseIP                        = baseURL.replaceAll("http[s]*://", "")
+        ProjectConfig(baseIP, kongAdmin)
+      case Provider.DockerCompose =>
+        ProjectConfig("localhost:8000", "localhost:8001")
+    }
+  }
+
   /** Configure the infrastructure for testing */
   private def performSetup(templefile: Templefile, generatedPath: String): ProjectConfig = {
     val provider = templefile
       .lookupMetadata[Metadata.Provider]
       .getOrElse { throw new RuntimeException("Could not find deployment information") }
 
-    val config = provider match {
+    provider match {
       case Provider.Kubernetes =>
         println("🍪 Spinning up Kubernetes infrastructure...")
         // Require certain env vars to be set
@@ -61,10 +77,6 @@ object ProjectTester {
         }
         exec(s"sh $generatedPath/deploy.sh")
 
-        // Grab Kong's URL for future requests
-        val Array(baseURL, kongAdmin, _*) = exec("minikube service kong --url").split("\n")
-        val baseIP                        = baseURL.replaceAll("http[s]*://", "")
-        ProjectConfig(baseIP, kongAdmin)
       case Provider.DockerCompose =>
         println("🐳 Spinning up Docker Compose infrastructure...")
         exec(
@@ -87,8 +99,8 @@ object ProjectTester {
           }
           if (!successfullyStarted) exec("sleep 5")
         }
-        ProjectConfig("localhost:8000", "localhost:8001")
     }
+    val config = getConfig(templefile)
     configureKong(templefile.usesAuth, config, generatedPath)
     config
   }
@@ -125,6 +137,25 @@ object ProjectTester {
     // Propagate exception up so that the exit code is relevant
     if (anyFailed) throw new RuntimeException("😢 Looks like a test didn't go as planned")
     else println("🎉 Everything passed")
+  }
+
+  /**
+    * Perform a full endpoint test on a generated project, by querying each endpoint and validating responses
+    * This assumes that the infrastructure is already running
+    * @param templefile The parsed & validated templefile
+    * @param generatedPath The root of the project where the generated code resides
+    */
+  def testOnly(templefile: Templefile, generatedPath: String): Unit = {
+    val config = getConfig(templefile)
+    try {
+      // Check we can actually connect to the URL
+      Http(s"http://${config.baseIP}").asString
+      performTests(templefile, generatedPath, config.baseIP)
+    } catch {
+      case e: ConnectException =>
+        println(s"😢 Could not connect to ${config.baseIP}, is the project running?")
+        throw e
+    }
   }
 
   /**


### PR DESCRIPTION
You can now provide a `--testOnly` flag to `temple test` and it will only query the endpoints, without spinning up any infra. 

This should hopefully be useful when testing metrics / debugging a database.

Also if anyone has a better name please suggest 😄 