### PR TITLE
[test] Validate kong has been correctly setup when no auth block is present

### DIFF
--- a/src/main/scala/temple/test/ProjectTester.scala
+++ b/src/main/scala/temple/test/ProjectTester.scala
@@ -29,7 +29,7 @@ object ProjectTester {
     generatedPath: String,
   ): Unit = {
     // Get a random service to validate kong is configured correctly
-    val (serviceName, _) = Option(services.head).getOrElse {
+    val (serviceName, _) = services.headOption.getOrElse {
       // If there are no services, there's nothing to setup, so return early...
       return
     }


### PR DESCRIPTION
Turns out, the TODO needed to be TODONE.

Services without auth may also not correctly configure Kong the first time round, so now I pick a random service and test if we can access it. When we can, Kong is correctly setup.