### PR TITLE
[Gen] Fix string decapitalisation with the string "ID"

### DIFF
--- a/src/main/scala/temple/utils/StringUtils.scala
+++ b/src/main/scala/temple/utils/StringUtils.scala
@@ -39,7 +39,7 @@ object StringUtils {
   /** Convert the first character/acronym of a string to lowercase */
   def decapitalize(string: String): String =
     // The first capital of the string, optionally followed by any subsequent capitals except for those starting a word
-    """^[A-Z]([A-Z]+(?=[^a-z]))?""".r.replaceAllIn(string, leadingCapitals => leadingCapitals.group(0).toLowerCase)
+    """^[A-Z]([A-Z]+(?=[^a-z]|$))?""".r.replaceAllIn(string, leadingCapitals => leadingCapitals.group(0).toLowerCase)
 
   type StringWrap = String => String
 

--- a/src/test/scala/temple/utils/StringUtilsTest.scala
+++ b/src/test/scala/temple/utils/StringUtilsTest.scala
@@ -33,6 +33,7 @@ class StringUtilsTest extends FlatSpec with Matchers {
     decapitalize("A_Box") shouldEqual "a_Box"
     decapitalize("AB_Box") shouldEqual "ab_Box"
     decapitalize("ABBox") shouldEqual "abBox"
+    decapitalize("ID") shouldEqual "id"
   }
 
   behavior of "snakeCase"


### PR DESCRIPTION
Due to a regex typo, strings consisting of a single acronym were not decapitalising the final letter. This meant "ID" was being decapitalised to "iD", which looks painful.