### PR TITLE
[project-test] Refactor to extract common logic

### DIFF
--- a/src/main/scala/temple/test/internal/AuthServiceTest.scala
+++ b/src/main/scala/temple/test/internal/AuthServiceTest.scala
@@ -3,41 +3,37 @@ package temple.test.internal
 import io.circe.syntax._
 import temple.ast.Metadata.AuthMethod
 import temple.utils.StringUtils
+import temple.test.internal.ServiceTestUtils._
 
-object AuthServiceTest extends ServiceTest("Auth") {
+class AuthServiceTest(baseURL: String) extends ServiceTest("Auth", baseURL, false) {
 
-  private def testEmailAuth(baseURL: String): Unit = {
-    val email    = ServiceTestUtils.randomEmail()
-    val password = StringUtils.randomString(10)
+  private def testEmailAuth(): Unit = {
+    val email       = ServiceTestUtils.randomEmail()
+    val password    = StringUtils.randomString(10)
+    val requestBody = Map("email" -> email, "password" -> password).asJson
 
     // Register endpoint
-    testEndpoint("register") { test =>
-      val registerJson = ServiceTestUtils
-        .postRequest(
-          test,
-          s"http://$baseURL/api/auth/register",
-          Map("email" -> email, "password" -> password).asJson,
-        )
+    testEndpoint("register") { (test, _) =>
+      val registerJson = postRequest(test, s"$serviceURL/register", requestBody)
       test.assert(registerJson.contains("AccessToken"), "response didn't contain the key AccessToken")
     }
 
     // Login endpoint
-    testEndpoint("login") { test =>
-      val loginJson = ServiceTestUtils
-        .postRequest(
-          test,
-          s"http://$baseURL/api/auth/login",
-          Map("email" -> email, "password" -> password).asJson,
-        )
+    testEndpoint("login") { (test, _) =>
+      val loginJson = postRequest(test, s"$serviceURL/login", requestBody)
       test.assert(loginJson.contains("AccessToken"), "response didn't contain the key AccessToken")
     }
   }
 
   // Test each type of auth that is present in the project
-  def test(authMethod: AuthMethod, baseURL: String): Boolean = {
+  def test(authMethod: AuthMethod): Boolean = {
     authMethod match {
-      case AuthMethod.Email => testEmailAuth(baseURL)
+      case AuthMethod.Email => testEmailAuth()
     }
     anyTestFailed
   }
+}
+
+object AuthServiceTest {
+  def test(authMethod: AuthMethod, baseURL: String): Boolean = new AuthServiceTest(baseURL).test(authMethod)
 }

--- a/src/main/scala/temple/test/internal/ServiceTest.scala
+++ b/src/main/scala/temple/test/internal/ServiceTest.scala
@@ -1,13 +1,17 @@
 package temple.test.internal
 
-abstract class ServiceTest(service: String) {
+import temple.utils.StringUtils
+
+abstract class ServiceTest(service: String, baseURL: String, usesAuth: Boolean) {
   protected var anyTestFailed = false
+  protected val serviceURL    = s"http://$baseURL/api/${StringUtils.kebabCase(service)}"
   println(s"🧪 Testing $service service")
 
-  def testEndpoint(endpointName: String)(testFn: EndpointTest => Unit): Unit = {
+  def testEndpoint(endpointName: String)(testFn: (EndpointTest, String) => Unit): Unit = {
     val endpointTest = new EndpointTest(service, endpointName)
     try {
-      testFn(endpointTest)
+      val token = if (usesAuth) ServiceTestUtils.getAuthTokenWithEmail(service, baseURL) else ""
+      testFn(endpointTest, token)
       // If we successfully get here then tests have not thrown, so we've passed
       endpointTest.pass()
     } catch {

--- a/src/main/scala/temple/test/internal/ServiceTestUtils.scala
+++ b/src/main/scala/temple/test/internal/ServiceTestUtils.scala
@@ -3,7 +3,7 @@ package temple.test.internal
 import java.net.HttpURLConnection
 import java.sql.Date
 import java.text.SimpleDateFormat
-import java.util.UUID
+import java.util.{Base64, UUID}
 
 import io.circe.parser.parse
 import io.circe.syntax._
@@ -88,13 +88,9 @@ object ServiceTestUtils {
     * @return The access token, as a string
     */
   def getAuthTokenWithEmail(service: String, baseURL: String): String = {
-    val test = new EndpointTest(service, "fetch auth token")
-    val registerJson = ServiceTestUtils
-      .postRequest(
-        test,
-        s"http://$baseURL/api/auth/register",
-        Map("email" -> randomEmail(), "password" -> StringUtils.randomString(10)).asJson,
-      )
+    val test         = new EndpointTest(service, "fetch auth token")
+    val body         = Map("email" -> randomEmail(), "password" -> StringUtils.randomString(10))
+    val registerJson = postRequest(test, s"http://$baseURL/api/auth/register", body.asJson)
     registerJson("AccessToken").flatMap(_.asString).getOrElse(test.fail("access token was not a valid string"))
   }
 
@@ -135,8 +131,7 @@ object ServiceTestUtils {
             case AttributeType.TimeType =>
               new SimpleDateFormat("HH:mm:ss").format(new Date(Random.between(0, 100000000000000L))).asJson
             case AttributeType.BlobType(_) =>
-              // TODO
-              "todo".asJson
+              Base64.getEncoder.encodeToString(Random.nextBytes(Random.between(10, 1000))).asJson
             case AttributeType.StringType(max, min) =>
               val maxValue: Long = max.getOrElse(20)
               val minValue: Int  = min.getOrElse(0)


### PR DESCRIPTION
Small refactor just to pull out some common methods etc. and shrink the size of each test.

Should hopefully make them more readable and make it easier to add tests for structs.

Also fixes `data` request parameters by randomising the contents.