### PR TITLE
[Testing] [Go-gen] Fix illegal shadowing of ID in test

### DIFF
--- a/src/test/scala/temple/builder/BuilderTestData.scala
+++ b/src/test/scala/temple/builder/BuilderTestData.scala
@@ -1,6 +1,6 @@
 package temple.builder
 
-import temple.ast.AbstractAttribute.Attribute
+import temple.ast.AbstractAttribute.{Attribute, IDAttribute}
 import temple.ast.AbstractServiceBlock._
 import temple.ast.AttributeType._
 import temple.ast.Metadata.ServiceLanguage
@@ -12,7 +12,7 @@ object BuilderTestData {
 
   val sampleService: ServiceBlock = ServiceBlock(
     ListMap(
-      "id"          -> Attribute(IntType()),
+      "id"          -> IDAttribute,
       "bankBalance" -> Attribute(FloatType()),
       "name"        -> Attribute(StringType()),
       "isStudent"   -> Attribute(BoolType),
@@ -33,7 +33,7 @@ object BuilderTestData {
 
   val sampleComplexService: ServiceBlock = ServiceBlock(
     ListMap(
-      "id"             -> Attribute(IntType(max = Some(100), min = Some(10), precision = 2)),
+      "id"             -> IDAttribute,
       "anotherId"      -> Attribute(IntType(max = Some(100), min = Some(10))),
       "yetAnotherId"   -> Attribute(IntType(max = Some(100), min = Some(10), precision = 8)),
       "bankBalance"    -> Attribute(FloatType(max = Some(300), min = Some(0), precision = 4)),

--- a/src/test/scala/temple/builder/DatabaseBuilderTestData.scala
+++ b/src/test/scala/temple/builder/DatabaseBuilderTestData.scala
@@ -1,7 +1,7 @@
 package temple.builder
 
 import temple.generate.database.ast.ColType._
-import temple.generate.database.ast.ColumnConstraint.{Check, NonNull, Unique}
+import temple.generate.database.ast.ColumnConstraint.{Check, NonNull, PrimaryKey, Unique}
 import temple.generate.database.ast.ComparisonOperator.{GreaterEqual, LessEqual}
 import temple.generate.database.ast.Condition.PreparedComparison
 import temple.generate.database.ast.Statement._
@@ -14,7 +14,7 @@ object DatabaseBuilderTestData {
       Create(
         "temple_user",
         Seq(
-          ColumnDef("id", IntCol(4), Seq(NonNull)),
+          ColumnDef("id", UUIDCol, Seq(NonNull, PrimaryKey)),
           ColumnDef("bank_balance", FloatCol(8), Seq(NonNull)),
           ColumnDef("name", StringCol, Seq(NonNull)),
           ColumnDef("is_student", BoolCol, Seq(NonNull)),
@@ -32,7 +32,7 @@ object DatabaseBuilderTestData {
       Create(
         "temple_user",
         Seq(
-          ColumnDef("id", IntCol(2), Seq(Check("id", LessEqual, "100"), Check("id", GreaterEqual, "10"), NonNull)),
+          ColumnDef("id", UUIDCol, Seq(NonNull, PrimaryKey)),
           ColumnDef(
             "another_id",
             IntCol(4),
@@ -123,7 +123,6 @@ object DatabaseBuilderTestData {
   val sampleUpdateStatement: Statement = Update(
     "test_service",
     Seq(
-      Assignment(Column("id")),
       Assignment(Column("bank_balance")),
       Assignment(Column("name")),
       Assignment(Column("is_student")),

--- a/src/test/scala/temple/builder/ServerBuilderTest.scala
+++ b/src/test/scala/temple/builder/ServerBuilderTest.scala
@@ -4,7 +4,7 @@ import org.scalatest.{FlatSpec, Matchers}
 import temple.ast.AbstractAttribute.Attribute
 import temple.ast.AttributeType
 import temple.ast.AttributeType._
-import temple.ast.Metadata.{AuthMethod, Database, Readable, ServiceAuth, Writable}
+import temple.ast.Metadata.{AuthMethod, Database, Readable, Writable}
 import temple.detail.LanguageDetail.GoLanguageDetail
 import temple.generate.CRUD._
 import temple.generate.server.AttributesRoot.ServiceRoot
@@ -38,13 +38,12 @@ class ServerBuilderTest extends FlatSpec with Matchers {
         List   -> "SELECT id, bank_balance, name, is_student, date_of_birth, time_of_day, expiry, image, fk FROM test_service;",
         Create -> "INSERT INTO test_service (id, bank_balance, name, is_student, date_of_birth, time_of_day, expiry, image, fk) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) RETURNING id, bank_balance, name, is_student, date_of_birth, time_of_day, expiry, image, fk;",
         Read   -> "SELECT id, bank_balance, name, is_student, date_of_birth, time_of_day, expiry, image, fk FROM test_service WHERE id = $1;",
-        Update -> "UPDATE test_service SET id = $1, bank_balance = $2, name = $3, is_student = $4, date_of_birth = $5, time_of_day = $6, expiry = $7, image = $8, fk = $9 WHERE id = $10 RETURNING id, bank_balance, name, is_student, date_of_birth, time_of_day, expiry, image, fk;",
+        Update -> "UPDATE test_service SET bank_balance = $1, name = $2, is_student = $3, date_of_birth = $4, time_of_day = $5, expiry = $6, image = $7, fk = $8 WHERE id = $9 RETURNING id, bank_balance, name, is_student, date_of_birth, time_of_day, expiry, image, fk;",
         Delete -> "DELETE FROM test_service WHERE id = $1;",
       ),
       idAttribute = IDAttribute("id"),
       createdByAttribute = None,
       attributes = ListMap(
-        "id"          -> Attribute(IntType()),
         "bankBalance" -> Attribute(FloatType()),
         "name"        -> Attribute(StringType()),
         "isStudent"   -> Attribute(BoolType),
@@ -85,7 +84,6 @@ class ServerBuilderTest extends FlatSpec with Matchers {
       idAttribute = IDAttribute("id"),
       createdByAttribute = None,
       attributes = ListMap(
-        "id"          -> Attribute(IntType()),
         "bankBalance" -> Attribute(FloatType()),
         "name"        -> Attribute(StringType()),
         "isStudent"   -> Attribute(BoolType),
@@ -126,13 +124,12 @@ class ServerBuilderTest extends FlatSpec with Matchers {
         List   -> "SELECT id, another_id, yet_another_id, bank_balance, big_bank_balance, name, initials, is_student, date_of_birth, time_of_day, expiry, image, sample_fk1, sample_fk2 FROM test_complex_service;",
         Create -> "INSERT INTO test_complex_service (id, another_id, yet_another_id, bank_balance, big_bank_balance, name, initials, is_student, date_of_birth, time_of_day, expiry, image, sample_fk1, sample_fk2) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14) RETURNING id, another_id, yet_another_id, bank_balance, big_bank_balance, name, initials, is_student, date_of_birth, time_of_day, expiry, image, sample_fk1, sample_fk2;",
         Read   -> "SELECT id, another_id, yet_another_id, bank_balance, big_bank_balance, name, initials, is_student, date_of_birth, time_of_day, expiry, image, sample_fk1, sample_fk2 FROM test_complex_service WHERE id = $1;",
-        Update -> "UPDATE test_complex_service SET id = $1, another_id = $2, yet_another_id = $3, bank_balance = $4, big_bank_balance = $5, name = $6, initials = $7, is_student = $8, date_of_birth = $9, time_of_day = $10, expiry = $11, image = $12, sample_fk1 = $13, sample_fk2 = $14 WHERE id = $15 RETURNING id, another_id, yet_another_id, bank_balance, big_bank_balance, name, initials, is_student, date_of_birth, time_of_day, expiry, image, sample_fk1, sample_fk2;",
+        Update -> "UPDATE test_complex_service SET another_id = $1, yet_another_id = $2, bank_balance = $3, big_bank_balance = $4, name = $5, initials = $6, is_student = $7, date_of_birth = $8, time_of_day = $9, expiry = $10, image = $11, sample_fk1 = $12, sample_fk2 = $13 WHERE id = $14 RETURNING id, another_id, yet_another_id, bank_balance, big_bank_balance, name, initials, is_student, date_of_birth, time_of_day, expiry, image, sample_fk1, sample_fk2;",
         Delete -> "DELETE FROM test_complex_service WHERE id = $1;",
       ),
       idAttribute = IDAttribute("id"),
       createdByAttribute = None,
       attributes = ListMap(
-        "id"             -> Attribute(IntType(max = Some(100), min = Some(10), precision = 2)),
         "anotherId"      -> Attribute(IntType(max = Some(100), min = Some(10))),
         "yetAnotherId"   -> Attribute(IntType(max = Some(100), min = Some(10), precision = 8)),
         "bankBalance"    -> Attribute(FloatType(max = Some(300), min = Some(0), precision = 4)),


### PR DESCRIPTION
For some reason `id` was being shadowed as an int, which was leading to some illegal SQL statements being generated.