### PR TITLE
[Validator] Block self-references (without @nullable) in foreign keys

### DIFF
--- a/src/main/scala/temple/DSL/semantics/Tarjan.scala
+++ b/src/main/scala/temple/DSL/semantics/Tarjan.scala
@@ -17,12 +17,14 @@ class Tarjan[T] private (graph: Map[T, Iterable[T]]) {
     sccBuffer.toSet
   }
 
+  private def neighbours(node: T): Iterable[T] = graph.getOrElse(node, Nil)
+
   private def visit(node: T): Unit = {
     // Set the depth index for v to the smallest unused index
     index(node) = index.size
     lowLink(node) = index(node)
     stack.push(node)
-    for (neighbour <- graph.getOrElse(node, Nil)) {
+    for (neighbour <- neighbours(node)) {
       if (!index.contains(neighbour)) { // neighbour has not yet been visited; recurse on it
         visit(neighbour)
         lowLink(node) = math.min(lowLink(node), lowLink(neighbour))
@@ -34,7 +36,8 @@ class Tarjan[T] private (graph: Map[T, Iterable[T]]) {
     if (lowLink(node) == index(node)) {
       // Pop all elements from the stack until and including this element itself
       val scc = (stack.popWhile(_ != node) :+ stack.pop()).toSet
-      sccBuffer += scc
+      // Only add single elements if they have a self-loop
+      if (scc.sizeIs != 1 || neighbours(node).iterator.contains(node)) sccBuffer += scc
     }
   }
 

--- a/src/main/scala/temple/DSL/semantics/Validator.scala
+++ b/src/main/scala/temple/DSL/semantics/Validator.scala
@@ -215,10 +215,10 @@ private class Validator private (templefile: Templefile) {
   private val referenceCycles: Set[Set[String]] = {
     val graph = templefile.providedBlockNames.map { blockName =>
       blockName -> templefile.getBlock(blockName).attributes.values.collect {
-        case Attribute(ForeignKey(references), _, annotations) => references
+        case Attribute(ForeignKey(references), _, _) => references
       }
     }.toMap
-    Tarjan(graph).filter(_.sizeIs > 1)
+    Tarjan(graph)
   }
 
   def validate(): Seq[String] = {

--- a/src/test/scala/temple/DSL/semantics/ValidatorTest.scala
+++ b/src/test/scala/temple/DSL/semantics/ValidatorTest.scala
@@ -317,6 +317,15 @@ class ValidatorTest extends FlatSpec with Matchers {
       Templefile(
         "MyProject",
         services = Map(
+          "Box" -> ServiceBlock(Map("box" -> Attribute(ForeignKey("Box")))),
+        ),
+      ),
+    ) shouldBe Set("Cycle(s) were detected in foreign keys, between elements: { Box }")
+
+    validationErrors(
+      Templefile(
+        "MyProject",
+        services = Map(
           "User"   -> ServiceBlock(Map("box"    -> Attribute(ForeignKey("Box")))),
           "Box"    -> ServiceBlock(Map("cube"   -> Attribute(ForeignKey("Cube")))),
           "Cube"   -> ServiceBlock(Map("square" -> Attribute(ForeignKey("Square")))),


### PR DESCRIPTION
Blocks the following structures from being initialised: it’s not possible to make a Foo without first having a Foo, and this isn’t Haskell 😛

```scala
Foo: service {
  foo: Foo;
}

Bar: service {
  Foo: struct {
    foo: Foo;
  }
}
```

Note this does not conflict with #333, as `@nullable` entries don’t appear in Tarjan’s graph