### PR TITLE
[validator] Add additional constraints on foreign keys

### DIFF
--- a/src/main/scala/temple/DSL/semantics/Validator.scala
+++ b/src/main/scala/temple/DSL/semantics/Validator.scala
@@ -26,9 +26,10 @@ private class Validator private (templefile: Templefile) {
 
   private def validateAttributes(
     block: AttributeBlock[_],
+    serviceName: String,
     context: SemanticContext,
   ): Map[String, AbstractAttribute] = {
-    block.attributes.foreach { case (name, t) => validateAttribute(t, context :+ name) }
+    block.attributes.foreach { case (name, t) => validateAttribute(t, serviceName, context :+ name) }
 
     // Keep a set of names that have been used already
     val takenNames: mutable.Set[String] = block.attributes.keys.to(mutable.Set)
@@ -89,9 +90,9 @@ private class Validator private (templefile: Templefile) {
     renameBlock(serviceName, service)
 
     val newStructs = service.structs.transform {
-      case (name, struct) => validateStruct(name, struct, context :+ name)
+      case (name, struct) => validateStruct(name, struct, serviceName, context :+ name)
     }
-    val newAttributes = validateAttributes(service, context)
+    val newAttributes = validateAttributes(service, serviceName, context)
     val newMetadata   = validateStructMetadata(service.metadata, newAttributes, context)
 
     ServiceBlock(newAttributes, newMetadata, newStructs)
@@ -100,11 +101,12 @@ private class Validator private (templefile: Templefile) {
   private def validateStruct(
     structName: String,
     struct: StructBlock,
+    serviceName: String,
     context: SemanticContext,
   ): StructBlock = {
     renameBlock(structName, struct)
 
-    val newAttributes = validateAttributes(struct, context)
+    val newAttributes = validateAttributes(struct, serviceName, context)
     val newMetadata   = validateStructMetadata(struct.metadata, newAttributes, context)
 
     StructBlock(newAttributes, newMetadata)
@@ -163,8 +165,8 @@ private class Validator private (templefile: Templefile) {
     }
   }
 
-  private def validateAttribute(attribute: AbstractAttribute, context: SemanticContext): Unit = {
-    validateAttributeType(attribute.attributeType, context)
+  private def validateAttribute(attribute: AbstractAttribute, serviceName: String, context: SemanticContext): Unit = {
+    validateAttributeType(attribute.attributeType, serviceName, context)
     attribute.accessAnnotation match {
       case Some(Annotation.Client)    => // nothing to validate
       case Some(Annotation.Server)    => // nothing to validate
@@ -176,9 +178,11 @@ private class Validator private (templefile: Templefile) {
     }
   }
 
-  private def validateAttributeType(attributeType: AttributeType, context: SemanticContext): Unit =
+  private def validateAttributeType(attributeType: AttributeType, serviceName: String, context: SemanticContext): Unit =
     attributeType match {
-      case ForeignKey(references) if !templefile.providedBlockNames.contains(references) =>
+      case ForeignKey(references)
+          if !templefile.services.contains(references) &&
+          !templefile.services(serviceName).structs.contains(references) =>
         errors += context.errorMessage(s"Invalid foreign key $references")
       case ForeignKey(_) => // all good
 

--- a/src/test/scala/temple/DSL/semantics/ValidatorTest.scala
+++ b/src/test/scala/temple/DSL/semantics/ValidatorTest.scala
@@ -268,6 +268,11 @@ class ValidatorTest extends FlatSpec with Matchers {
             attributes = Map(
               "baz" -> Attribute(ForeignKey("Baz")),
             ),
+            structs = Map(
+              "Quux" -> StructBlock(
+                attributes = Map("baz" -> Attribute(ForeignKey("Baz"))),
+              ),
+            ),
           ),
           "Bar" -> ServiceBlock(
             attributes = Map(),
@@ -281,7 +286,7 @@ class ValidatorTest extends FlatSpec with Matchers {
           ),
         ),
       ),
-    ) shouldBe Set("Invalid foreign key Baz in baz, in Foo")
+    ) shouldBe Set("Invalid foreign key Baz in baz, in Foo", "Invalid foreign key Baz in baz, in Quux, in Foo")
   }
 
   it should "enforce the existence of an auth block when other dependent metadata are used" in {


### PR DESCRIPTION
Add an additional constraint on foreign keys that prevents them from referencing a struct that isn't from their own service. 

The tests allow:
```
Foo: service {
  Bar: struct {
    foo: Foo;
  }
}
```
```
Foo: service {
  Bar: struct {}
  Baz: struct {
    bar: Bar;
  }
}
```


The tests disallow:

```
Foo: service {
  baz: Baz;
}

Bar: service {
  Baz: struct {
    ..
  }
}
```
