### PR TITLE
[openapi-gen] Add auth service to OpenAPI gen

### DIFF
--- a/src/e2e/resources/simple-temple-expected/api/simple-temple-test.openapi.yaml
+++ b/src/e2e/resources/simple-temple-expected/api/simple-temple-test.openapi.yaml
@@ -447,6 +447,76 @@ paths:
           $ref: '#/components/responses/Error404'
         '500':
           $ref: '#/components/responses/Error500'
+  /auth/register:
+    post:
+      summary: Register and get an access token
+      tags:
+      - Auth
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                Email:
+                  type: string
+                  format: email
+                Password:
+                  type: string
+                  format: password
+                  minLength: 8
+                  maxLength: 64
+      responses:
+        '200':
+          description: Successful registration
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  AccessToken:
+                    type: string
+        '400':
+          $ref: '#/components/responses/Error400'
+        '403':
+          $ref: '#/components/responses/Error403'
+        '500':
+          $ref: '#/components/responses/Error500'
+  /auth/login:
+    post:
+      summary: Login and get an access token
+      tags:
+      - Auth
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                Email:
+                  type: string
+                  format: email
+                Password:
+                  type: string
+                  format: password
+                  minLength: 8
+                  maxLength: 64
+      responses:
+        '200':
+          description: Successful login
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  AccessToken:
+                    type: string
+        '400':
+          $ref: '#/components/responses/Error400'
+        '401':
+          $ref: '#/components/responses/Error401'
+        '500':
+          $ref: '#/components/responses/Error500'
 components:
   responses:
     Error400:
@@ -469,6 +539,16 @@ components:
               error:
                 type: string
                 example: Not authorised to create this object
+    Error403:
+      description: Valid request but server will not fulfill
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+                example: User with this ID already exists
     Error404:
       description: ID not found
       content:

--- a/src/main/scala/temple/builder/OpenAPIBuilder.scala
+++ b/src/main/scala/temple/builder/OpenAPIBuilder.scala
@@ -1,8 +1,9 @@
 package temple.builder
 
-import temple.ast.Templefile
+import temple.ast.Metadata.AuthMethod
+import temple.ast.{Metadata, Templefile}
 import temple.builder.project.ProjectBuilder.endpoints
-import temple.generate.target.openapi.ast.{OpenAPIRoot, Service}
+import temple.generate.target.openapi.ast.{Auth, OpenAPIRoot, Service}
 
 object OpenAPIBuilder {
 
@@ -11,6 +12,7 @@ object OpenAPIBuilder {
       name = templefile.projectName,
       version = version,
       description = description,
+      auth = templefile.lookupMetadata[Metadata.AuthMethod].map { case AuthMethod.Email => Auth.Email },
       services = templefile.providedServices.map {
         case (serviceName, block) =>
           Service(

--- a/src/main/scala/temple/generate/target/openapi/OpenAPIGenerator.scala
+++ b/src/main/scala/temple/generate/target/openapi/OpenAPIGenerator.scala
@@ -22,6 +22,7 @@ private class OpenAPIGenerator private (name: String, version: String, descripti
   private val errorTracker = FlagMapView(
     400 -> generateError("Invalid request", "Invalid request parameters: name"),
     401 -> generateError("Valid request but forbidden by server", "Not authorised to create this object"),
+    403 -> generateError("Valid request but server will not fulfill", "User with this ID already exists"),
     404 -> generateError("ID not found", "Object not found with ID 1"),
     500 -> generateError(
       "The server encountered an error while serving this request",
@@ -189,12 +190,62 @@ private class OpenAPIGenerator private (name: String, version: String, descripti
     this
   }
 
+  def addAuthPaths(auth: Auth): this.type = {
+    val tags = Seq("Auth")
+
+    auth match {
+      case Auth.Email =>
+        val requestBody = Map(
+          "Email" -> OpenAPISimpleType("string", "email"),
+          "Password" -> OpenAPISimpleType(
+            "string",
+            "password",
+            "minLength" -> 8.asJson,
+            "maxLength" -> 64.asJson,
+          ),
+        )
+
+        val responseBody = OpenAPIObject(Map("AccessToken" -> OpenAPISimpleType("string")))
+
+        path(s"/auth/register") += HTTPVerb.Post -> Handler(
+          s"Register and get an access token",
+          tags = tags,
+          requestBody = Some(RequestBodyObject(jsonContent(MediaTypeObject(OpenAPIObject(requestBody))))),
+          responses = Seq(
+            200 -> ResponseObject(
+              s"Successful registration",
+              Some(jsonContent(MediaTypeObject(responseBody))),
+            ),
+            400 -> Response.Ref(useError(400)),
+            403 -> Response.Ref(useError(403)),
+            500 -> Response.Ref(useError(500)),
+          ),
+        )
+        path(s"/auth/login") += HTTPVerb.Post -> Handler(
+          s"Login and get an access token",
+          tags = tags,
+          requestBody = Some(RequestBodyObject(jsonContent(MediaTypeObject(OpenAPIObject(requestBody))))),
+          responses = Seq(
+            200 -> ResponseObject(
+              s"Successful login",
+              Some(jsonContent(MediaTypeObject(responseBody))),
+            ),
+            400 -> Response.Ref(useError(400)),
+            401 -> Response.Ref(useError(401)),
+            500 -> Response.Ref(useError(500)),
+          ),
+        )
+    }
+    this
+  }
+
   def useError(code: Int): String = {
     errorTracker.flag(code)
     s"Error$code"
   }
 
-  def errorBlock: Map[String, Response] = errorTracker.view.map { case i -> response => useError(i) -> response }.toMap
+  def errorBlock: Map[String, Response] =
+    errorTracker.view.map { case i -> response => useError(i) -> response }.toSeq.sortBy(_._1).to(ListMap)
 
   def toOpenAPI: OpenAPIFile = OpenAPIFile(
     info = Info(name, version, description),
@@ -210,6 +261,7 @@ object OpenAPIGenerator {
   private def build(root: OpenAPIRoot): OpenAPIFile = {
     val builder = new OpenAPIGenerator(root.name, root.version, root.description)
     root.services.foreach(builder.addPaths)
+    root.auth.foreach(builder.addAuthPaths)
     builder.toOpenAPI
   }
 

--- a/src/main/scala/temple/generate/target/openapi/ast/OpenAPIRoot.scala
+++ b/src/main/scala/temple/generate/target/openapi/ast/OpenAPIRoot.scala
@@ -1,9 +1,23 @@
 package temple.generate.target.openapi.ast
 
-case class OpenAPIRoot(name: String, version: String, description: String = "", services: Seq[Service])
+case class OpenAPIRoot(
+  name: String,
+  version: String,
+  description: String = "",
+  auth: Option[Auth],
+  services: Seq[Service],
+)
+
+trait Auth
+
+object Auth {
+  case object Email extends Auth
+}
 
 object OpenAPIRoot {
 
-  def build(name: String, version: String, description: String = "")(services: Service*): OpenAPIRoot =
-    new OpenAPIRoot(name, version, description, services)
+  def build(name: String, version: String, description: String = "", auth: Option[Auth] = None)(
+    services: Service*,
+  ): OpenAPIRoot =
+    new OpenAPIRoot(name, version, description, auth, services)
 }

--- a/src/test/resources/project-builder-complex/api/sample-complex-project.openapi.yaml
+++ b/src/test/resources/project-builder-complex/api/sample-complex-project.openapi.yaml
@@ -353,6 +353,76 @@ paths:
           $ref: '#/components/responses/Error404'
         '500':
           $ref: '#/components/responses/Error500'
+  /auth/register:
+    post:
+      summary: Register and get an access token
+      tags:
+      - Auth
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                Email:
+                  type: string
+                  format: email
+                Password:
+                  type: string
+                  format: password
+                  minLength: 8
+                  maxLength: 64
+      responses:
+        '200':
+          description: Successful registration
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  AccessToken:
+                    type: string
+        '400':
+          $ref: '#/components/responses/Error400'
+        '403':
+          $ref: '#/components/responses/Error403'
+        '500':
+          $ref: '#/components/responses/Error500'
+  /auth/login:
+    post:
+      summary: Login and get an access token
+      tags:
+      - Auth
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                Email:
+                  type: string
+                  format: email
+                Password:
+                  type: string
+                  format: password
+                  minLength: 8
+                  maxLength: 64
+      responses:
+        '200':
+          description: Successful login
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  AccessToken:
+                    type: string
+        '400':
+          $ref: '#/components/responses/Error400'
+        '401':
+          $ref: '#/components/responses/Error401'
+        '500':
+          $ref: '#/components/responses/Error500'
 components:
   responses:
     Error400:
@@ -375,6 +445,16 @@ components:
               error:
                 type: string
                 example: Not authorised to create this object
+    Error403:
+      description: Valid request but server will not fulfill
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+                example: User with this ID already exists
     Error404:
       description: ID not found
       content:


### PR DESCRIPTION
Adds the auth service to OpenAPI generator. 

I feel like the `Auth` trait should be moved somewhere else? Thoughts?