### PR TITLE
[SQL-gen] Add parent attribute to SQL database

### DIFF
--- a/src/e2e/resources/simple-temple-expected/simple-temple-test-user-db/init.sql
+++ b/src/e2e/resources/simple-temple-expected/simple-temple-test-user-db/init.sql
@@ -14,6 +14,7 @@ CREATE TABLE simple_temple_test_user (
 
 CREATE TABLE fred (
   id UUID NOT NULL PRIMARY KEY,
+  parent_id UUID NOT NULL,
   created_by UUID NOT NULL,
   field TEXT NOT NULL,
   friend UUID NOT NULL,

--- a/src/e2e/scala/temple/DSL/ParserE2ETest.scala
+++ b/src/e2e/scala/temple/DSL/ParserE2ETest.scala
@@ -3,7 +3,7 @@ package temple.DSL
 import org.scalatest.{FlatSpec, Matchers}
 import temple.DSL.parser.DSLParserMatchers
 import temple.DSL.semantics.Analyzer.parseAndValidate
-import temple.ast.AbstractAttribute.{Attribute, CreatedByAttribute, IDAttribute}
+import temple.ast.AbstractAttribute.{Attribute, CreatedByAttribute, IDAttribute, ParentAttribute}
 import temple.ast.AbstractServiceBlock.ServiceBlock
 import temple.ast.Annotation.{Server, Unique}
 import temple.ast.AttributeType._
@@ -54,8 +54,9 @@ class ParserE2ETest extends FlatSpec with Matchers with DSLParserMatchers {
           ),
           structs = Map(
             "Fred" -> StructBlock(
-              Map(
+              ListMap(
                 "id"        -> IDAttribute,
+                "parentID"  -> ParentAttribute,
                 "createdBy" -> CreatedByAttribute,
                 "field"     -> Attribute(StringType()),
                 "friend"    -> Attribute(ForeignKey("SimpleTempleTestUser")),

--- a/src/e2e/scala/temple/SimpleE2ETest.scala
+++ b/src/e2e/scala/temple/SimpleE2ETest.scala
@@ -7,8 +7,6 @@ import temple.detail.PoliceSergeantNicholasAngel
 import temple.generate.FileMatchers
 import temple.utils.FileUtils
 
-import scala.reflect.io.Directory
-
 class SimpleE2ETest extends FlatSpec with FileMatchers {
 
   behavior of "Temple"

--- a/src/main/scala/temple/DSL/semantics/NameClashes.scala
+++ b/src/main/scala/temple/DSL/semantics/NameClashes.scala
@@ -10,6 +10,7 @@ object NameClashes {
   val templeAttributeNameValidator: NameValidator = NameValidator.fromBlacklist(
     "id",
     "createdBy",
+    "parentID",
   )
 
   val templeServiceNameValidator: NameValidator = NameValidator.fromBlacklist(

--- a/src/main/scala/temple/DSL/semantics/Validator.scala
+++ b/src/main/scala/temple/DSL/semantics/Validator.scala
@@ -1,7 +1,7 @@
 package temple.DSL.semantics
 
 import temple.DSL.semantics.NameClashes._
-import temple.ast.AbstractAttribute.{Attribute, CreatedByAttribute, IDAttribute}
+import temple.ast.AbstractAttribute.{Attribute, CreatedByAttribute, IDAttribute, ParentAttribute}
 import temple.ast.AbstractServiceBlock._
 import temple.ast.AttributeType._
 import temple.ast.Metadata.ServiceAuth
@@ -38,7 +38,8 @@ private class Validator private (templefile: Templefile) {
 
     val implicitAttributes: ListMap[String, AbstractAttribute] =
       (ListMap("id" -> IDAttribute)
-      ++ when(usesCreatedBy) { "createdBy" -> CreatedByAttribute })
+      ++ when(block.isInstanceOf[StructBlock]) { "parentID" -> ParentAttribute }
+      ++ when(usesCreatedBy) { "createdBy"                  -> CreatedByAttribute })
 
     // Add implicit attributes
     implicitAttributes ++ block.attributes.map {

--- a/src/main/scala/temple/ast/AbstractAttribute.scala
+++ b/src/main/scala/temple/ast/AbstractAttribute.scala
@@ -31,6 +31,12 @@ object AbstractAttribute {
     override def valueAnnotations: Set[ValueAnnotation]     = Set()
   }
 
+  case object ParentAttribute extends AbstractAttribute {
+    override def attributeType: AttributeType               = AttributeType.UUIDType
+    override def accessAnnotation: Option[AccessAnnotation] = Some(Annotation.ServerSet)
+    override def valueAnnotations: Set[ValueAnnotation]     = Set()
+  }
+
   case object CreatedByAttribute extends AbstractAttribute {
     override def attributeType: AttributeType               = AttributeType.UUIDType
     override def accessAnnotation: Option[AccessAnnotation] = Some(Annotation.Server)


### PR DESCRIPTION
On top of #373. Every struct will have an implicit `parentID` stored.