### PR TITLE
[go-gen] Name hooks after their service

### DIFF
--- a/src/e2e/resources/attributes-temple-expected/example/example.go
+++ b/src/e2e/resources/attributes-temple-expected/example/example.go
@@ -127,7 +127,7 @@ func (env *env) createExampleHandler(w http.ResponseWriter, r *http.Request) {
 		ID: uuid,
 	}
 
-	for _, hook := range env.hook.beforeCreateHooks {
+	for _, hook := range env.hook.beforeCreateExampleHooks {
 		err := (*hook)(env, req, &input)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode)
@@ -141,7 +141,7 @@ func (env *env) createExampleHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	for _, hook := range env.hook.afterCreateHooks {
+	for _, hook := range env.hook.afterCreateExampleHooks {
 		err := (*hook)(env, example)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode)
@@ -166,7 +166,7 @@ func (env *env) readExampleHandler(w http.ResponseWriter, r *http.Request) {
 		ID: exampleID,
 	}
 
-	for _, hook := range env.hook.beforeReadHooks {
+	for _, hook := range env.hook.beforeReadExampleHooks {
 		err := (*hook)(env, &input)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode)
@@ -185,7 +185,7 @@ func (env *env) readExampleHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	for _, hook := range env.hook.afterReadHooks {
+	for _, hook := range env.hook.afterReadExampleHooks {
 		err := (*hook)(env, example)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode)
@@ -228,7 +228,7 @@ func (env *env) updateExampleHandler(w http.ResponseWriter, r *http.Request) {
 		ID: exampleID,
 	}
 
-	for _, hook := range env.hook.beforeUpdateHooks {
+	for _, hook := range env.hook.beforeUpdateExampleHooks {
 		err := (*hook)(env, req, &input)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode)
@@ -247,7 +247,7 @@ func (env *env) updateExampleHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	for _, hook := range env.hook.afterUpdateHooks {
+	for _, hook := range env.hook.afterUpdateExampleHooks {
 		err := (*hook)(env, example)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode)
@@ -272,7 +272,7 @@ func (env *env) deleteExampleHandler(w http.ResponseWriter, r *http.Request) {
 		ID: exampleID,
 	}
 
-	for _, hook := range env.hook.beforeDeleteHooks {
+	for _, hook := range env.hook.beforeDeleteExampleHooks {
 		err := (*hook)(env, &input)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode)
@@ -291,7 +291,7 @@ func (env *env) deleteExampleHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	for _, hook := range env.hook.afterDeleteHooks {
+	for _, hook := range env.hook.afterDeleteExampleHooks {
 		err := (*hook)(env)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode)

--- a/src/e2e/resources/attributes-temple-expected/example/hook.go
+++ b/src/e2e/resources/attributes-temple-expected/example/hook.go
@@ -5,15 +5,15 @@ import "github.com/squat/and/dab/example/dao"
 // Hook allows additional code to be executed before and after every datastore interaction
 // Hooks are executed in the order they are defined, such that if any hook errors, future hooks are not executed and the request is terminated
 type Hook struct {
-	beforeCreateHooks []*func(env *env, req createExampleRequest, input *dao.CreateExampleInput) *HookError
-	beforeReadHooks   []*func(env *env, input *dao.ReadExampleInput) *HookError
-	beforeUpdateHooks []*func(env *env, req updateExampleRequest, input *dao.UpdateExampleInput) *HookError
-	beforeDeleteHooks []*func(env *env, input *dao.DeleteExampleInput) *HookError
+	beforeCreateExampleHooks []*func(env *env, req createExampleRequest, input *dao.CreateExampleInput) *HookError
+	beforeReadExampleHooks   []*func(env *env, input *dao.ReadExampleInput) *HookError
+	beforeUpdateExampleHooks []*func(env *env, req updateExampleRequest, input *dao.UpdateExampleInput) *HookError
+	beforeDeleteExampleHooks []*func(env *env, input *dao.DeleteExampleInput) *HookError
 
-	afterCreateHooks []*func(env *env, example *dao.Example) *HookError
-	afterReadHooks   []*func(env *env, example *dao.Example) *HookError
-	afterUpdateHooks []*func(env *env, example *dao.Example) *HookError
-	afterDeleteHooks []*func(env *env) *HookError
+	afterCreateExampleHooks []*func(env *env, example *dao.Example) *HookError
+	afterReadExampleHooks   []*func(env *env, example *dao.Example) *HookError
+	afterUpdateExampleHooks []*func(env *env, example *dao.Example) *HookError
+	afterDeleteExampleHooks []*func(env *env) *HookError
 }
 
 // HookError wraps an existing error with HTTP status code
@@ -26,42 +26,42 @@ func (e *HookError) Error() string {
 	return e.error.Error()
 }
 
-// BeforeCreate adds a new hook to be executed before creating an object in the datastore
-func (h *Hook) BeforeCreate(hook func(env *env, req createExampleRequest, input *dao.CreateExampleInput) *HookError) {
-	h.beforeCreateHooks = append(h.beforeCreateHooks, &hook)
+// BeforeCreateExample adds a new hook to be executed before creating an object in the datastore
+func (h *Hook) BeforeCreateExample(hook func(env *env, req createExampleRequest, input *dao.CreateExampleInput) *HookError) {
+	h.beforeCreateExampleHooks = append(h.beforeCreateExampleHooks, &hook)
 }
 
-// BeforeRead adds a new hook to be executed before reading an object in the datastore
-func (h *Hook) BeforeRead(hook func(env *env, input *dao.ReadExampleInput) *HookError) {
-	h.beforeReadHooks = append(h.beforeReadHooks, &hook)
+// BeforeReadExample adds a new hook to be executed before reading an object in the datastore
+func (h *Hook) BeforeReadExample(hook func(env *env, input *dao.ReadExampleInput) *HookError) {
+	h.beforeReadExampleHooks = append(h.beforeReadExampleHooks, &hook)
 }
 
-// BeforeUpdate adds a new hook to be executed before updating an object in the datastore
-func (h *Hook) BeforeUpdate(hook func(env *env, req updateExampleRequest, input *dao.UpdateExampleInput) *HookError) {
-	h.beforeUpdateHooks = append(h.beforeUpdateHooks, &hook)
+// BeforeUpdateExample adds a new hook to be executed before updating an object in the datastore
+func (h *Hook) BeforeUpdateExample(hook func(env *env, req updateExampleRequest, input *dao.UpdateExampleInput) *HookError) {
+	h.beforeUpdateExampleHooks = append(h.beforeUpdateExampleHooks, &hook)
 }
 
-// BeforeDelete adds a new hook to be executed before deleting an object in the datastore
-func (h *Hook) BeforeDelete(hook func(env *env, input *dao.DeleteExampleInput) *HookError) {
-	h.beforeDeleteHooks = append(h.beforeDeleteHooks, &hook)
+// BeforeDeleteExample adds a new hook to be executed before deleting an object in the datastore
+func (h *Hook) BeforeDeleteExample(hook func(env *env, input *dao.DeleteExampleInput) *HookError) {
+	h.beforeDeleteExampleHooks = append(h.beforeDeleteExampleHooks, &hook)
 }
 
-// AfterCreate adds a new hook to be executed after creating an object in the datastore
-func (h *Hook) AfterCreate(hook func(env *env, example *dao.Example) *HookError) {
-	h.afterCreateHooks = append(h.afterCreateHooks, &hook)
+// AfterCreateExample adds a new hook to be executed after creating an object in the datastore
+func (h *Hook) AfterCreateExample(hook func(env *env, example *dao.Example) *HookError) {
+	h.afterCreateExampleHooks = append(h.afterCreateExampleHooks, &hook)
 }
 
-// AfterRead adds a new hook to be executed after reading an object in the datastore
-func (h *Hook) AfterRead(hook func(env *env, example *dao.Example) *HookError) {
-	h.afterReadHooks = append(h.afterReadHooks, &hook)
+// AfterReadExample adds a new hook to be executed after reading an object in the datastore
+func (h *Hook) AfterReadExample(hook func(env *env, example *dao.Example) *HookError) {
+	h.afterReadExampleHooks = append(h.afterReadExampleHooks, &hook)
 }
 
-// AfterUpdate adds a new hook to be executed after updating an object in the datastore
-func (h *Hook) AfterUpdate(hook func(env *env, example *dao.Example) *HookError) {
-	h.afterUpdateHooks = append(h.afterUpdateHooks, &hook)
+// AfterUpdateExample adds a new hook to be executed after updating an object in the datastore
+func (h *Hook) AfterUpdateExample(hook func(env *env, example *dao.Example) *HookError) {
+	h.afterUpdateExampleHooks = append(h.afterUpdateExampleHooks, &hook)
 }
 
-// AfterDelete adds a new hook to be executed after deleting an object in the datastore
-func (h *Hook) AfterDelete(hook func(env *env) *HookError) {
-	h.afterDeleteHooks = append(h.afterDeleteHooks, &hook)
+// AfterDeleteExample adds a new hook to be executed after deleting an object in the datastore
+func (h *Hook) AfterDeleteExample(hook func(env *env) *HookError) {
+	h.afterDeleteExampleHooks = append(h.afterDeleteExampleHooks, &hook)
 }

--- a/src/e2e/resources/simple-temple-expected/booking/booking.go
+++ b/src/e2e/resources/simple-temple-expected/booking/booking.go
@@ -123,7 +123,7 @@ func (env *env) createBookingHandler(w http.ResponseWriter, r *http.Request) {
 		AuthID: auth.ID,
 	}
 
-	for _, hook := range env.hook.beforeCreateHooks {
+	for _, hook := range env.hook.beforeCreateBookingHooks {
 		err := (*hook)(env, &input, auth)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestCreate)
@@ -139,7 +139,7 @@ func (env *env) createBookingHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	for _, hook := range env.hook.afterCreateHooks {
+	for _, hook := range env.hook.afterCreateBookingHooks {
 		err := (*hook)(env, booking, auth)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestCreate)
@@ -186,7 +186,7 @@ func (env *env) readBookingHandler(w http.ResponseWriter, r *http.Request) {
 		ID: bookingID,
 	}
 
-	for _, hook := range env.hook.beforeReadHooks {
+	for _, hook := range env.hook.beforeReadBookingHooks {
 		err := (*hook)(env, &input, auth)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestRead)
@@ -207,7 +207,7 @@ func (env *env) readBookingHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	for _, hook := range env.hook.afterReadHooks {
+	for _, hook := range env.hook.afterReadBookingHooks {
 		err := (*hook)(env, booking, auth)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestRead)
@@ -254,7 +254,7 @@ func (env *env) deleteBookingHandler(w http.ResponseWriter, r *http.Request) {
 		ID: bookingID,
 	}
 
-	for _, hook := range env.hook.beforeDeleteHooks {
+	for _, hook := range env.hook.beforeDeleteBookingHooks {
 		err := (*hook)(env, &input, auth)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestDelete)
@@ -275,7 +275,7 @@ func (env *env) deleteBookingHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	for _, hook := range env.hook.afterDeleteHooks {
+	for _, hook := range env.hook.afterDeleteBookingHooks {
 		err := (*hook)(env, auth)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestDelete)

--- a/src/e2e/resources/simple-temple-expected/booking/hook.go
+++ b/src/e2e/resources/simple-temple-expected/booking/hook.go
@@ -8,13 +8,13 @@ import (
 // Hook allows additional code to be executed before and after every datastore interaction
 // Hooks are executed in the order they are defined, such that if any hook errors, future hooks are not executed and the request is terminated
 type Hook struct {
-	beforeCreateHooks []*func(env *env, input *dao.CreateBookingInput, auth *util.Auth) *HookError
-	beforeReadHooks   []*func(env *env, input *dao.ReadBookingInput, auth *util.Auth) *HookError
-	beforeDeleteHooks []*func(env *env, input *dao.DeleteBookingInput, auth *util.Auth) *HookError
+	beforeCreateBookingHooks []*func(env *env, input *dao.CreateBookingInput, auth *util.Auth) *HookError
+	beforeReadBookingHooks   []*func(env *env, input *dao.ReadBookingInput, auth *util.Auth) *HookError
+	beforeDeleteBookingHooks []*func(env *env, input *dao.DeleteBookingInput, auth *util.Auth) *HookError
 
-	afterCreateHooks []*func(env *env, booking *dao.Booking, auth *util.Auth) *HookError
-	afterReadHooks   []*func(env *env, booking *dao.Booking, auth *util.Auth) *HookError
-	afterDeleteHooks []*func(env *env, auth *util.Auth) *HookError
+	afterCreateBookingHooks []*func(env *env, booking *dao.Booking, auth *util.Auth) *HookError
+	afterReadBookingHooks   []*func(env *env, booking *dao.Booking, auth *util.Auth) *HookError
+	afterDeleteBookingHooks []*func(env *env, auth *util.Auth) *HookError
 }
 
 // HookError wraps an existing error with HTTP status code
@@ -27,32 +27,32 @@ func (e *HookError) Error() string {
 	return e.error.Error()
 }
 
-// BeforeCreate adds a new hook to be executed before creating an object in the datastore
-func (h *Hook) BeforeCreate(hook func(env *env, input *dao.CreateBookingInput, auth *util.Auth) *HookError) {
-	h.beforeCreateHooks = append(h.beforeCreateHooks, &hook)
+// BeforeCreateBooking adds a new hook to be executed before creating an object in the datastore
+func (h *Hook) BeforeCreateBooking(hook func(env *env, input *dao.CreateBookingInput, auth *util.Auth) *HookError) {
+	h.beforeCreateBookingHooks = append(h.beforeCreateBookingHooks, &hook)
 }
 
-// BeforeRead adds a new hook to be executed before reading an object in the datastore
-func (h *Hook) BeforeRead(hook func(env *env, input *dao.ReadBookingInput, auth *util.Auth) *HookError) {
-	h.beforeReadHooks = append(h.beforeReadHooks, &hook)
+// BeforeReadBooking adds a new hook to be executed before reading an object in the datastore
+func (h *Hook) BeforeReadBooking(hook func(env *env, input *dao.ReadBookingInput, auth *util.Auth) *HookError) {
+	h.beforeReadBookingHooks = append(h.beforeReadBookingHooks, &hook)
 }
 
-// BeforeDelete adds a new hook to be executed before deleting an object in the datastore
-func (h *Hook) BeforeDelete(hook func(env *env, input *dao.DeleteBookingInput, auth *util.Auth) *HookError) {
-	h.beforeDeleteHooks = append(h.beforeDeleteHooks, &hook)
+// BeforeDeleteBooking adds a new hook to be executed before deleting an object in the datastore
+func (h *Hook) BeforeDeleteBooking(hook func(env *env, input *dao.DeleteBookingInput, auth *util.Auth) *HookError) {
+	h.beforeDeleteBookingHooks = append(h.beforeDeleteBookingHooks, &hook)
 }
 
-// AfterCreate adds a new hook to be executed after creating an object in the datastore
-func (h *Hook) AfterCreate(hook func(env *env, booking *dao.Booking, auth *util.Auth) *HookError) {
-	h.afterCreateHooks = append(h.afterCreateHooks, &hook)
+// AfterCreateBooking adds a new hook to be executed after creating an object in the datastore
+func (h *Hook) AfterCreateBooking(hook func(env *env, booking *dao.Booking, auth *util.Auth) *HookError) {
+	h.afterCreateBookingHooks = append(h.afterCreateBookingHooks, &hook)
 }
 
-// AfterRead adds a new hook to be executed after reading an object in the datastore
-func (h *Hook) AfterRead(hook func(env *env, booking *dao.Booking, auth *util.Auth) *HookError) {
-	h.afterReadHooks = append(h.afterReadHooks, &hook)
+// AfterReadBooking adds a new hook to be executed after reading an object in the datastore
+func (h *Hook) AfterReadBooking(hook func(env *env, booking *dao.Booking, auth *util.Auth) *HookError) {
+	h.afterReadBookingHooks = append(h.afterReadBookingHooks, &hook)
 }
 
-// AfterDelete adds a new hook to be executed after deleting an object in the datastore
-func (h *Hook) AfterDelete(hook func(env *env, auth *util.Auth) *HookError) {
-	h.afterDeleteHooks = append(h.afterDeleteHooks, &hook)
+// AfterDeleteBooking adds a new hook to be executed after deleting an object in the datastore
+func (h *Hook) AfterDeleteBooking(hook func(env *env, auth *util.Auth) *HookError) {
+	h.afterDeleteBookingHooks = append(h.afterDeleteBookingHooks, &hook)
 }

--- a/src/e2e/resources/simple-temple-expected/simple-temple-test-group/hook.go
+++ b/src/e2e/resources/simple-temple-expected/simple-temple-test-group/hook.go
@@ -8,13 +8,13 @@ import (
 // Hook allows additional code to be executed before and after every datastore interaction
 // Hooks are executed in the order they are defined, such that if any hook errors, future hooks are not executed and the request is terminated
 type Hook struct {
-	beforeCreateHooks []*func(env *env, input *dao.CreateSimpleTempleTestGroupInput, auth *util.Auth) *HookError
-	beforeReadHooks   []*func(env *env, input *dao.ReadSimpleTempleTestGroupInput, auth *util.Auth) *HookError
-	beforeDeleteHooks []*func(env *env, input *dao.DeleteSimpleTempleTestGroupInput, auth *util.Auth) *HookError
+	beforeCreateSimpleTempleTestGroupHooks []*func(env *env, input *dao.CreateSimpleTempleTestGroupInput, auth *util.Auth) *HookError
+	beforeReadSimpleTempleTestGroupHooks   []*func(env *env, input *dao.ReadSimpleTempleTestGroupInput, auth *util.Auth) *HookError
+	beforeDeleteSimpleTempleTestGroupHooks []*func(env *env, input *dao.DeleteSimpleTempleTestGroupInput, auth *util.Auth) *HookError
 
-	afterCreateHooks []*func(env *env, simpleTempleTestGroup *dao.SimpleTempleTestGroup, auth *util.Auth) *HookError
-	afterReadHooks   []*func(env *env, simpleTempleTestGroup *dao.SimpleTempleTestGroup, auth *util.Auth) *HookError
-	afterDeleteHooks []*func(env *env, auth *util.Auth) *HookError
+	afterCreateSimpleTempleTestGroupHooks []*func(env *env, simpleTempleTestGroup *dao.SimpleTempleTestGroup, auth *util.Auth) *HookError
+	afterReadSimpleTempleTestGroupHooks   []*func(env *env, simpleTempleTestGroup *dao.SimpleTempleTestGroup, auth *util.Auth) *HookError
+	afterDeleteSimpleTempleTestGroupHooks []*func(env *env, auth *util.Auth) *HookError
 }
 
 // HookError wraps an existing error with HTTP status code
@@ -27,32 +27,32 @@ func (e *HookError) Error() string {
 	return e.error.Error()
 }
 
-// BeforeCreate adds a new hook to be executed before creating an object in the datastore
-func (h *Hook) BeforeCreate(hook func(env *env, input *dao.CreateSimpleTempleTestGroupInput, auth *util.Auth) *HookError) {
-	h.beforeCreateHooks = append(h.beforeCreateHooks, &hook)
+// BeforeCreateSimpleTempleTestGroup adds a new hook to be executed before creating an object in the datastore
+func (h *Hook) BeforeCreateSimpleTempleTestGroup(hook func(env *env, input *dao.CreateSimpleTempleTestGroupInput, auth *util.Auth) *HookError) {
+	h.beforeCreateSimpleTempleTestGroupHooks = append(h.beforeCreateSimpleTempleTestGroupHooks, &hook)
 }
 
-// BeforeRead adds a new hook to be executed before reading an object in the datastore
-func (h *Hook) BeforeRead(hook func(env *env, input *dao.ReadSimpleTempleTestGroupInput, auth *util.Auth) *HookError) {
-	h.beforeReadHooks = append(h.beforeReadHooks, &hook)
+// BeforeReadSimpleTempleTestGroup adds a new hook to be executed before reading an object in the datastore
+func (h *Hook) BeforeReadSimpleTempleTestGroup(hook func(env *env, input *dao.ReadSimpleTempleTestGroupInput, auth *util.Auth) *HookError) {
+	h.beforeReadSimpleTempleTestGroupHooks = append(h.beforeReadSimpleTempleTestGroupHooks, &hook)
 }
 
-// BeforeDelete adds a new hook to be executed before deleting an object in the datastore
-func (h *Hook) BeforeDelete(hook func(env *env, input *dao.DeleteSimpleTempleTestGroupInput, auth *util.Auth) *HookError) {
-	h.beforeDeleteHooks = append(h.beforeDeleteHooks, &hook)
+// BeforeDeleteSimpleTempleTestGroup adds a new hook to be executed before deleting an object in the datastore
+func (h *Hook) BeforeDeleteSimpleTempleTestGroup(hook func(env *env, input *dao.DeleteSimpleTempleTestGroupInput, auth *util.Auth) *HookError) {
+	h.beforeDeleteSimpleTempleTestGroupHooks = append(h.beforeDeleteSimpleTempleTestGroupHooks, &hook)
 }
 
-// AfterCreate adds a new hook to be executed after creating an object in the datastore
-func (h *Hook) AfterCreate(hook func(env *env, simpleTempleTestGroup *dao.SimpleTempleTestGroup, auth *util.Auth) *HookError) {
-	h.afterCreateHooks = append(h.afterCreateHooks, &hook)
+// AfterCreateSimpleTempleTestGroup adds a new hook to be executed after creating an object in the datastore
+func (h *Hook) AfterCreateSimpleTempleTestGroup(hook func(env *env, simpleTempleTestGroup *dao.SimpleTempleTestGroup, auth *util.Auth) *HookError) {
+	h.afterCreateSimpleTempleTestGroupHooks = append(h.afterCreateSimpleTempleTestGroupHooks, &hook)
 }
 
-// AfterRead adds a new hook to be executed after reading an object in the datastore
-func (h *Hook) AfterRead(hook func(env *env, simpleTempleTestGroup *dao.SimpleTempleTestGroup, auth *util.Auth) *HookError) {
-	h.afterReadHooks = append(h.afterReadHooks, &hook)
+// AfterReadSimpleTempleTestGroup adds a new hook to be executed after reading an object in the datastore
+func (h *Hook) AfterReadSimpleTempleTestGroup(hook func(env *env, simpleTempleTestGroup *dao.SimpleTempleTestGroup, auth *util.Auth) *HookError) {
+	h.afterReadSimpleTempleTestGroupHooks = append(h.afterReadSimpleTempleTestGroupHooks, &hook)
 }
 
-// AfterDelete adds a new hook to be executed after deleting an object in the datastore
-func (h *Hook) AfterDelete(hook func(env *env, auth *util.Auth) *HookError) {
-	h.afterDeleteHooks = append(h.afterDeleteHooks, &hook)
+// AfterDeleteSimpleTempleTestGroup adds a new hook to be executed after deleting an object in the datastore
+func (h *Hook) AfterDeleteSimpleTempleTestGroup(hook func(env *env, auth *util.Auth) *HookError) {
+	h.afterDeleteSimpleTempleTestGroupHooks = append(h.afterDeleteSimpleTempleTestGroupHooks, &hook)
 }

--- a/src/e2e/resources/simple-temple-expected/simple-temple-test-group/simple-temple-test-group.go
+++ b/src/e2e/resources/simple-temple-expected/simple-temple-test-group/simple-temple-test-group.go
@@ -123,7 +123,7 @@ func (env *env) createSimpleTempleTestGroupHandler(w http.ResponseWriter, r *htt
 		AuthID: auth.ID,
 	}
 
-	for _, hook := range env.hook.beforeCreateHooks {
+	for _, hook := range env.hook.beforeCreateSimpleTempleTestGroupHooks {
 		err := (*hook)(env, &input, auth)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestCreate)
@@ -139,7 +139,7 @@ func (env *env) createSimpleTempleTestGroupHandler(w http.ResponseWriter, r *htt
 		return
 	}
 
-	for _, hook := range env.hook.afterCreateHooks {
+	for _, hook := range env.hook.afterCreateSimpleTempleTestGroupHooks {
 		err := (*hook)(env, simpleTempleTestGroup, auth)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestCreate)
@@ -186,7 +186,7 @@ func (env *env) readSimpleTempleTestGroupHandler(w http.ResponseWriter, r *http.
 		ID: simpleTempleTestGroupID,
 	}
 
-	for _, hook := range env.hook.beforeReadHooks {
+	for _, hook := range env.hook.beforeReadSimpleTempleTestGroupHooks {
 		err := (*hook)(env, &input, auth)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestRead)
@@ -207,7 +207,7 @@ func (env *env) readSimpleTempleTestGroupHandler(w http.ResponseWriter, r *http.
 		return
 	}
 
-	for _, hook := range env.hook.afterReadHooks {
+	for _, hook := range env.hook.afterReadSimpleTempleTestGroupHooks {
 		err := (*hook)(env, simpleTempleTestGroup, auth)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestRead)
@@ -254,7 +254,7 @@ func (env *env) deleteSimpleTempleTestGroupHandler(w http.ResponseWriter, r *htt
 		ID: simpleTempleTestGroupID,
 	}
 
-	for _, hook := range env.hook.beforeDeleteHooks {
+	for _, hook := range env.hook.beforeDeleteSimpleTempleTestGroupHooks {
 		err := (*hook)(env, &input, auth)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestDelete)
@@ -275,7 +275,7 @@ func (env *env) deleteSimpleTempleTestGroupHandler(w http.ResponseWriter, r *htt
 		return
 	}
 
-	for _, hook := range env.hook.afterDeleteHooks {
+	for _, hook := range env.hook.afterDeleteSimpleTempleTestGroupHooks {
 		err := (*hook)(env, auth)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestDelete)

--- a/src/e2e/resources/simple-temple-expected/simple-temple-test-user/hook.go
+++ b/src/e2e/resources/simple-temple-expected/simple-temple-test-user/hook.go
@@ -8,17 +8,17 @@ import (
 // Hook allows additional code to be executed before and after every datastore interaction
 // Hooks are executed in the order they are defined, such that if any hook errors, future hooks are not executed and the request is terminated
 type Hook struct {
-	beforeListHooks     []*func(env *env, auth *util.Auth) *HookError
-	beforeCreateHooks   []*func(env *env, req createSimpleTempleTestUserRequest, input *dao.CreateSimpleTempleTestUserInput, auth *util.Auth) *HookError
-	beforeReadHooks     []*func(env *env, input *dao.ReadSimpleTempleTestUserInput, auth *util.Auth) *HookError
-	beforeUpdateHooks   []*func(env *env, req updateSimpleTempleTestUserRequest, input *dao.UpdateSimpleTempleTestUserInput, auth *util.Auth) *HookError
-	beforeIdentifyHooks []*func(env *env, input *dao.IdentifySimpleTempleTestUserInput, auth *util.Auth) *HookError
+	beforeListSimpleTempleTestUserHooks     []*func(env *env, auth *util.Auth) *HookError
+	beforeCreateSimpleTempleTestUserHooks   []*func(env *env, req createSimpleTempleTestUserRequest, input *dao.CreateSimpleTempleTestUserInput, auth *util.Auth) *HookError
+	beforeReadSimpleTempleTestUserHooks     []*func(env *env, input *dao.ReadSimpleTempleTestUserInput, auth *util.Auth) *HookError
+	beforeUpdateSimpleTempleTestUserHooks   []*func(env *env, req updateSimpleTempleTestUserRequest, input *dao.UpdateSimpleTempleTestUserInput, auth *util.Auth) *HookError
+	beforeIdentifySimpleTempleTestUserHooks []*func(env *env, input *dao.IdentifySimpleTempleTestUserInput, auth *util.Auth) *HookError
 
-	afterListHooks     []*func(env *env, simpleTempleTestUserList *[]dao.SimpleTempleTestUser, auth *util.Auth) *HookError
-	afterCreateHooks   []*func(env *env, simpleTempleTestUser *dao.SimpleTempleTestUser, auth *util.Auth) *HookError
-	afterReadHooks     []*func(env *env, simpleTempleTestUser *dao.SimpleTempleTestUser, auth *util.Auth) *HookError
-	afterUpdateHooks   []*func(env *env, simpleTempleTestUser *dao.SimpleTempleTestUser, auth *util.Auth) *HookError
-	afterIdentifyHooks []*func(env *env, simpleTempleTestUser *dao.SimpleTempleTestUser, auth *util.Auth) *HookError
+	afterListSimpleTempleTestUserHooks     []*func(env *env, simpleTempleTestUserList *[]dao.SimpleTempleTestUser, auth *util.Auth) *HookError
+	afterCreateSimpleTempleTestUserHooks   []*func(env *env, simpleTempleTestUser *dao.SimpleTempleTestUser, auth *util.Auth) *HookError
+	afterReadSimpleTempleTestUserHooks     []*func(env *env, simpleTempleTestUser *dao.SimpleTempleTestUser, auth *util.Auth) *HookError
+	afterUpdateSimpleTempleTestUserHooks   []*func(env *env, simpleTempleTestUser *dao.SimpleTempleTestUser, auth *util.Auth) *HookError
+	afterIdentifySimpleTempleTestUserHooks []*func(env *env, simpleTempleTestUser *dao.SimpleTempleTestUser, auth *util.Auth) *HookError
 }
 
 // HookError wraps an existing error with HTTP status code
@@ -31,52 +31,52 @@ func (e *HookError) Error() string {
 	return e.error.Error()
 }
 
-// BeforeList adds a new hook to be executed before listing the objects in the datastore
-func (h *Hook) BeforeList(hook func(env *env, auth *util.Auth) *HookError) {
-	h.beforeListHooks = append(h.beforeListHooks, &hook)
+// BeforeListSimpleTempleTestUser adds a new hook to be executed before listing the objects in the datastore
+func (h *Hook) BeforeListSimpleTempleTestUser(hook func(env *env, auth *util.Auth) *HookError) {
+	h.beforeListSimpleTempleTestUserHooks = append(h.beforeListSimpleTempleTestUserHooks, &hook)
 }
 
-// BeforeCreate adds a new hook to be executed before creating an object in the datastore
-func (h *Hook) BeforeCreate(hook func(env *env, req createSimpleTempleTestUserRequest, input *dao.CreateSimpleTempleTestUserInput, auth *util.Auth) *HookError) {
-	h.beforeCreateHooks = append(h.beforeCreateHooks, &hook)
+// BeforeCreateSimpleTempleTestUser adds a new hook to be executed before creating an object in the datastore
+func (h *Hook) BeforeCreateSimpleTempleTestUser(hook func(env *env, req createSimpleTempleTestUserRequest, input *dao.CreateSimpleTempleTestUserInput, auth *util.Auth) *HookError) {
+	h.beforeCreateSimpleTempleTestUserHooks = append(h.beforeCreateSimpleTempleTestUserHooks, &hook)
 }
 
-// BeforeRead adds a new hook to be executed before reading an object in the datastore
-func (h *Hook) BeforeRead(hook func(env *env, input *dao.ReadSimpleTempleTestUserInput, auth *util.Auth) *HookError) {
-	h.beforeReadHooks = append(h.beforeReadHooks, &hook)
+// BeforeReadSimpleTempleTestUser adds a new hook to be executed before reading an object in the datastore
+func (h *Hook) BeforeReadSimpleTempleTestUser(hook func(env *env, input *dao.ReadSimpleTempleTestUserInput, auth *util.Auth) *HookError) {
+	h.beforeReadSimpleTempleTestUserHooks = append(h.beforeReadSimpleTempleTestUserHooks, &hook)
 }
 
-// BeforeUpdate adds a new hook to be executed before updating an object in the datastore
-func (h *Hook) BeforeUpdate(hook func(env *env, req updateSimpleTempleTestUserRequest, input *dao.UpdateSimpleTempleTestUserInput, auth *util.Auth) *HookError) {
-	h.beforeUpdateHooks = append(h.beforeUpdateHooks, &hook)
+// BeforeUpdateSimpleTempleTestUser adds a new hook to be executed before updating an object in the datastore
+func (h *Hook) BeforeUpdateSimpleTempleTestUser(hook func(env *env, req updateSimpleTempleTestUserRequest, input *dao.UpdateSimpleTempleTestUserInput, auth *util.Auth) *HookError) {
+	h.beforeUpdateSimpleTempleTestUserHooks = append(h.beforeUpdateSimpleTempleTestUserHooks, &hook)
 }
 
-// BeforeIdentify adds a new hook to be executed before identifying an object in the datastore
-func (h *Hook) BeforeIdentify(hook func(env *env, input *dao.IdentifySimpleTempleTestUserInput, auth *util.Auth) *HookError) {
-	h.beforeIdentifyHooks = append(h.beforeIdentifyHooks, &hook)
+// BeforeIdentifySimpleTempleTestUser adds a new hook to be executed before identifying an object in the datastore
+func (h *Hook) BeforeIdentifySimpleTempleTestUser(hook func(env *env, input *dao.IdentifySimpleTempleTestUserInput, auth *util.Auth) *HookError) {
+	h.beforeIdentifySimpleTempleTestUserHooks = append(h.beforeIdentifySimpleTempleTestUserHooks, &hook)
 }
 
-// AfterList adds a new hook to be executed after listing the objects in the datastore
-func (h *Hook) AfterList(hook func(env *env, simpleTempleTestUserList *[]dao.SimpleTempleTestUser, auth *util.Auth) *HookError) {
-	h.afterListHooks = append(h.afterListHooks, &hook)
+// AfterListSimpleTempleTestUser adds a new hook to be executed after listing the objects in the datastore
+func (h *Hook) AfterListSimpleTempleTestUser(hook func(env *env, simpleTempleTestUserList *[]dao.SimpleTempleTestUser, auth *util.Auth) *HookError) {
+	h.afterListSimpleTempleTestUserHooks = append(h.afterListSimpleTempleTestUserHooks, &hook)
 }
 
-// AfterCreate adds a new hook to be executed after creating an object in the datastore
-func (h *Hook) AfterCreate(hook func(env *env, simpleTempleTestUser *dao.SimpleTempleTestUser, auth *util.Auth) *HookError) {
-	h.afterCreateHooks = append(h.afterCreateHooks, &hook)
+// AfterCreateSimpleTempleTestUser adds a new hook to be executed after creating an object in the datastore
+func (h *Hook) AfterCreateSimpleTempleTestUser(hook func(env *env, simpleTempleTestUser *dao.SimpleTempleTestUser, auth *util.Auth) *HookError) {
+	h.afterCreateSimpleTempleTestUserHooks = append(h.afterCreateSimpleTempleTestUserHooks, &hook)
 }
 
-// AfterRead adds a new hook to be executed after reading an object in the datastore
-func (h *Hook) AfterRead(hook func(env *env, simpleTempleTestUser *dao.SimpleTempleTestUser, auth *util.Auth) *HookError) {
-	h.afterReadHooks = append(h.afterReadHooks, &hook)
+// AfterReadSimpleTempleTestUser adds a new hook to be executed after reading an object in the datastore
+func (h *Hook) AfterReadSimpleTempleTestUser(hook func(env *env, simpleTempleTestUser *dao.SimpleTempleTestUser, auth *util.Auth) *HookError) {
+	h.afterReadSimpleTempleTestUserHooks = append(h.afterReadSimpleTempleTestUserHooks, &hook)
 }
 
-// AfterUpdate adds a new hook to be executed after updating an object in the datastore
-func (h *Hook) AfterUpdate(hook func(env *env, simpleTempleTestUser *dao.SimpleTempleTestUser, auth *util.Auth) *HookError) {
-	h.afterUpdateHooks = append(h.afterUpdateHooks, &hook)
+// AfterUpdateSimpleTempleTestUser adds a new hook to be executed after updating an object in the datastore
+func (h *Hook) AfterUpdateSimpleTempleTestUser(hook func(env *env, simpleTempleTestUser *dao.SimpleTempleTestUser, auth *util.Auth) *HookError) {
+	h.afterUpdateSimpleTempleTestUserHooks = append(h.afterUpdateSimpleTempleTestUserHooks, &hook)
 }
 
-// AfterIdentify adds a new hook to be executed after identifying an object in the datastore
-func (h *Hook) AfterIdentify(hook func(env *env, simpleTempleTestUser *dao.SimpleTempleTestUser, auth *util.Auth) *HookError) {
-	h.afterIdentifyHooks = append(h.afterIdentifyHooks, &hook)
+// AfterIdentifySimpleTempleTestUser adds a new hook to be executed after identifying an object in the datastore
+func (h *Hook) AfterIdentifySimpleTempleTestUser(hook func(env *env, simpleTempleTestUser *dao.SimpleTempleTestUser, auth *util.Auth) *HookError) {
+	h.afterIdentifySimpleTempleTestUserHooks = append(h.afterIdentifySimpleTempleTestUserHooks, &hook)
 }

--- a/src/e2e/resources/simple-temple-expected/simple-temple-test-user/simple-temple-test-user.go
+++ b/src/e2e/resources/simple-temple-expected/simple-temple-test-user/simple-temple-test-user.go
@@ -181,7 +181,7 @@ func (env *env) listSimpleTempleTestUserHandler(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	for _, hook := range env.hook.beforeListHooks {
+	for _, hook := range env.hook.beforeListSimpleTempleTestUserHooks {
 		err := (*hook)(env, auth)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestList)
@@ -197,7 +197,7 @@ func (env *env) listSimpleTempleTestUserHandler(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	for _, hook := range env.hook.afterListHooks {
+	for _, hook := range env.hook.afterListSimpleTempleTestUserHooks {
 		err := (*hook)(env, simpleTempleTestUserList, auth)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestList)
@@ -285,7 +285,7 @@ func (env *env) createSimpleTempleTestUserHandler(w http.ResponseWriter, r *http
 		BreakfastTime:        breakfastTime,
 	}
 
-	for _, hook := range env.hook.beforeCreateHooks {
+	for _, hook := range env.hook.beforeCreateSimpleTempleTestUserHooks {
 		err := (*hook)(env, req, &input, auth)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestCreate)
@@ -301,7 +301,7 @@ func (env *env) createSimpleTempleTestUserHandler(w http.ResponseWriter, r *http
 		return
 	}
 
-	for _, hook := range env.hook.afterCreateHooks {
+	for _, hook := range env.hook.afterCreateSimpleTempleTestUserHooks {
 		err := (*hook)(env, simpleTempleTestUser, auth)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestCreate)
@@ -342,7 +342,7 @@ func (env *env) readSimpleTempleTestUserHandler(w http.ResponseWriter, r *http.R
 		ID: simpleTempleTestUserID,
 	}
 
-	for _, hook := range env.hook.beforeReadHooks {
+	for _, hook := range env.hook.beforeReadSimpleTempleTestUserHooks {
 		err := (*hook)(env, &input, auth)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestRead)
@@ -363,7 +363,7 @@ func (env *env) readSimpleTempleTestUserHandler(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	for _, hook := range env.hook.afterReadHooks {
+	for _, hook := range env.hook.afterReadSimpleTempleTestUserHooks {
 		err := (*hook)(env, simpleTempleTestUser, auth)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestRead)
@@ -454,7 +454,7 @@ func (env *env) updateSimpleTempleTestUserHandler(w http.ResponseWriter, r *http
 		BreakfastTime:        breakfastTime,
 	}
 
-	for _, hook := range env.hook.beforeUpdateHooks {
+	for _, hook := range env.hook.beforeUpdateSimpleTempleTestUserHooks {
 		err := (*hook)(env, req, &input, auth)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestUpdate)
@@ -475,7 +475,7 @@ func (env *env) updateSimpleTempleTestUserHandler(w http.ResponseWriter, r *http
 		return
 	}
 
-	for _, hook := range env.hook.afterUpdateHooks {
+	for _, hook := range env.hook.afterUpdateSimpleTempleTestUserHooks {
 		err := (*hook)(env, simpleTempleTestUser, auth)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestUpdate)
@@ -510,7 +510,7 @@ func (env *env) identifySimpleTempleTestUserHandler(w http.ResponseWriter, r *ht
 		ID: auth.ID,
 	}
 
-	for _, hook := range env.hook.beforeIdentifyHooks {
+	for _, hook := range env.hook.beforeIdentifySimpleTempleTestUserHooks {
 		err := (*hook)(env, &input, auth)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestIdentify)
@@ -531,7 +531,7 @@ func (env *env) identifySimpleTempleTestUserHandler(w http.ResponseWriter, r *ht
 		return
 	}
 
-	for _, hook := range env.hook.afterIdentifyHooks {
+	for _, hook := range env.hook.afterIdentifySimpleTempleTestUserHooks {
 		err := (*hook)(env, simpleTempleTestUser, auth)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestIdentify)

--- a/src/main/scala/temple/generate/server/go/service/GoServiceHookGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/GoServiceHookGenerator.scala
@@ -1,8 +1,8 @@
 package temple.generate.server.go.service
 
 import temple.ast.Metadata.Readable
-import temple.generate.CRUD
-import temple.generate.CRUD.{CRUD, presentParticiple}
+import temple.generate.CRUD._
+import temple.generate.server.AttributesRoot
 import temple.generate.server.AttributesRoot.ServiceRoot
 import temple.generate.server.go.common.GoCommonGenerator._
 import temple.generate.server.go.common.GoCommonHookGenerator
@@ -20,52 +20,50 @@ object GoServiceHookGenerator {
     else mkCode("import", daoImport)
   }
 
-  private def generateHookType(root: ServiceRoot, args: String*): String =
+  private def generateHookType(block: AttributesRoot, args: String*): String =
     mkCode(
-      CodeWrap.parens
-        .prefix("func")
-        .list("env *env", args, when(root.projectUsesAuth) { "auth *util.Auth" }),
+      CodeWrap.parens.prefix("func").list("env *env", args, when(block.projectUsesAuth) { "auth *util.Auth" }),
       "*HookError",
     )
 
-  private def generateBeforeHookType(root: ServiceRoot, operation: CRUD): String =
+  private def generateBeforeHookType(block: AttributesRoot, operation: CRUD): String =
     operation match {
-      case CRUD.List =>
-        root.readable match {
-          case Readable.This => generateHookType(root, s"input *dao.List${root.name}Input")
-          case Readable.All  => generateHookType(root)
+      case List =>
+        block.readable match {
+          case Readable.This => generateHookType(block, s"input *dao.List${block.name}Input")
+          case Readable.All  => generateHookType(block)
         }
-      case op @ (CRUD.Read | CRUD.Delete | CRUD.Identify) =>
-        generateHookType(root, s"input *dao.${op.toString}${root.name}Input")
-      case op @ (CRUD.Create | CRUD.Update) =>
-        if (root.requestAttributes.isEmpty)
-          generateHookType(root, s"input *dao.${op.toString}${root.name}Input")
+      case op @ (Read | Delete | Identify) =>
+        generateHookType(block, s"input *dao.${op.toString}${block.name}Input")
+      case op @ (Create | Update) =>
+        if (block.requestAttributes.isEmpty)
+          generateHookType(block, s"input *dao.${op.toString}${block.name}Input")
         else
           generateHookType(
-            root,
-            s"req ${op.toString.toLowerCase}${root.name}Request",
-            s"input *dao.${op.toString}${root.name}Input",
+            block,
+            s"req ${op.toString.toLowerCase}${block.name}Request",
+            s"input *dao.${op.toString}${block.name}Input",
           )
 
     }
 
-  private def generateAfterHookType(root: ServiceRoot, operation: CRUD): String =
-    operation match {
-      case CRUD.List =>
-        generateHookType(root, s"${root.decapitalizedName}List *[]dao.${root.name}")
-      case CRUD.Create | CRUD.Read | CRUD.Update | CRUD.Identify =>
-        generateHookType(root, s"${root.decapitalizedName} *dao.${root.name}")
-      case CRUD.Delete =>
-        generateHookType(root)
-    }
+  private def generateAfterHookType(block: AttributesRoot, operation: CRUD): String = operation match {
+    case List =>
+      generateHookType(block, s"${block.decapitalizedName}List *[]dao.${block.name}")
+    case Create | Read | Update | Identify =>
+      generateHookType(block, s"${block.decapitalizedName} *dao.${block.name}")
+    case Delete =>
+      generateHookType(block)
+  }
 
   private[service] def generateHookStruct(root: ServiceRoot): String = {
     val beforeCreate = root.operations.toSeq.map { op =>
-      s"before${op.toString}Hooks" -> s"[]*${generateBeforeHookType(root, op)}"
+      s"before${op.toString}${root.name}Hooks" -> s"[]*${generateBeforeHookType(root, op)}"
     }
 
-    val afterCreate = root.operations.toSeq.map { op =>
-      s"after${op.toString}Hooks" -> s"[]*${generateAfterHookType(root, op)}"
+    val afterCreate = root.operations.iterator.toSeq.map { op =>
+      s"after${op.toString}${root.name}Hooks" -> s"[]*${generateAfterHookType(root, op)}"
+
     }
 
     mkCode.lines(
@@ -74,36 +72,36 @@ object GoServiceHookGenerator {
     )
   }
 
-  private def generateAddHookComment(action: String, op: CRUD): String = op match {
-    case CRUD.List =>
-      s"// ${action.capitalize}List adds a new hook to be executed ${action.toLowerCase} listing the objects in the datastore"
+  private def generateAddHookComment(action: String, op: CRUD, structName: String): String = op match {
+    case List =>
+      s"// ${action.capitalize}List$structName adds a new hook to be executed ${action.toLowerCase} listing the objects in the datastore"
     case _ =>
-      s"// ${action.capitalize}${op.toString.capitalize} adds a new hook to be executed ${action.toLowerCase} ${presentParticiple(op)} an object in the datastore"
+      s"// ${action.capitalize}${op.toString.capitalize}$structName adds a new hook to be executed ${action.toLowerCase} ${presentParticiple(op)} an object in the datastore"
   }
 
-  private def generateAddHookMethod(action: String, hookType: String, op: CRUD): String =
+  private def generateAddHookMethod(action: String, hookType: String, op: CRUD, structName: String): String =
     mkCode.lines(
-      generateAddHookComment(action, op),
+      generateAddHookComment(action, op, structName),
       genMethod(
         "h",
         "*Hook",
-        s"${action.capitalize}${op.toString.capitalize}",
+        s"${action.capitalize}${op.toString.capitalize}$structName",
         Seq(s"hook $hookType"),
-        Option.empty,
+        None,
         genAssign(
-          genFunctionCall("append", s"h.${action.toLowerCase}${op.toString.capitalize}Hooks", "&hook"),
-          s"h.${action.toLowerCase}${op.toString.capitalize}Hooks",
+          genFunctionCall("append", s"h.${action.toLowerCase}${op.toString.capitalize}${structName}Hooks", "&hook"),
+          s"h.${action.toLowerCase}${op.toString.capitalize}${structName}Hooks",
         ),
       ),
     )
 
   private[service] def generateAddHookMethods(root: ServiceRoot): String = {
     val beforeHooks = root.operations.toSeq.map { op =>
-      generateAddHookMethod("before", generateBeforeHookType(root, op), op)
+      generateAddHookMethod("before", generateBeforeHookType(root, op), op, root.name)
     }
 
     val afterHooks = root.operations.toSeq.map { op =>
-      generateAddHookMethod("after", generateAfterHookType(root, op), op)
+      generateAddHookMethod("after", generateAfterHookType(root, op), op, root.name)
     }
 
     mkCode.doubleLines(beforeHooks, afterHooks)

--- a/src/main/scala/temple/generate/server/go/service/main/GoServiceMainHandlersGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/main/GoServiceMainHandlersGenerator.scala
@@ -385,7 +385,7 @@ object GoServiceMainHandlersGenerator {
       }) ++ when(root.projectUsesAuth) { "auth" }
 
     genForLoop(
-      genDeclareAndAssign(s"range env.hook.before${operation.toString}Hooks", "_", "hook"),
+      genDeclareAndAssign(s"range env.hook.before${operation.toString}${root.name}Hooks", "_", "hook"),
       mkCode.lines(
         genDeclareAndAssign(
           genFunctionCall("(*hook)", hookArguments),
@@ -411,7 +411,7 @@ object GoServiceMainHandlersGenerator {
       }) ++ when(root.projectUsesAuth) { "auth" }
 
     genForLoop(
-      genDeclareAndAssign(s"range env.hook.after${operation.toString}Hooks", "_", "hook"),
+      genDeclareAndAssign(s"range env.hook.after${operation.toString}${root.name}Hooks", "_", "hook"),
       mkCode.lines(
         genDeclareAndAssign(
           genFunctionCall("(*hook)", hookArguments),

--- a/src/test/resources/generate-server-test/match/hook.go
+++ b/src/test/resources/generate-server-test/match/hook.go
@@ -8,17 +8,17 @@ import (
 // Hook allows additional code to be executed before and after every datastore interaction
 // Hooks are executed in the order they are defined, such that if any hook errors, future hooks are not executed and the request is terminated
 type Hook struct {
-	beforeListHooks   []*func(env *env, input *dao.ListMatchInput, auth *util.Auth) *HookError
-	beforeCreateHooks []*func(env *env, req createMatchRequest, input *dao.CreateMatchInput, auth *util.Auth) *HookError
-	beforeReadHooks   []*func(env *env, input *dao.ReadMatchInput, auth *util.Auth) *HookError
-	beforeUpdateHooks []*func(env *env, req updateMatchRequest, input *dao.UpdateMatchInput, auth *util.Auth) *HookError
-	beforeDeleteHooks []*func(env *env, input *dao.DeleteMatchInput, auth *util.Auth) *HookError
+	beforeListMatchHooks   []*func(env *env, input *dao.ListMatchInput, auth *util.Auth) *HookError
+	beforeCreateMatchHooks []*func(env *env, req createMatchRequest, input *dao.CreateMatchInput, auth *util.Auth) *HookError
+	beforeReadMatchHooks   []*func(env *env, input *dao.ReadMatchInput, auth *util.Auth) *HookError
+	beforeUpdateMatchHooks []*func(env *env, req updateMatchRequest, input *dao.UpdateMatchInput, auth *util.Auth) *HookError
+	beforeDeleteMatchHooks []*func(env *env, input *dao.DeleteMatchInput, auth *util.Auth) *HookError
 
-	afterListHooks   []*func(env *env, matchList *[]dao.Match, auth *util.Auth) *HookError
-	afterCreateHooks []*func(env *env, match *dao.Match, auth *util.Auth) *HookError
-	afterReadHooks   []*func(env *env, match *dao.Match, auth *util.Auth) *HookError
-	afterUpdateHooks []*func(env *env, match *dao.Match, auth *util.Auth) *HookError
-	afterDeleteHooks []*func(env *env, auth *util.Auth) *HookError
+	afterListMatchHooks   []*func(env *env, matchList *[]dao.Match, auth *util.Auth) *HookError
+	afterCreateMatchHooks []*func(env *env, match *dao.Match, auth *util.Auth) *HookError
+	afterReadMatchHooks   []*func(env *env, match *dao.Match, auth *util.Auth) *HookError
+	afterUpdateMatchHooks []*func(env *env, match *dao.Match, auth *util.Auth) *HookError
+	afterDeleteMatchHooks []*func(env *env, auth *util.Auth) *HookError
 }
 
 // HookError wraps an existing error with HTTP status code
@@ -31,52 +31,52 @@ func (e *HookError) Error() string {
 	return e.error.Error()
 }
 
-// BeforeList adds a new hook to be executed before listing the objects in the datastore
-func (h *Hook) BeforeList(hook func(env *env, input *dao.ListMatchInput, auth *util.Auth) *HookError) {
-	h.beforeListHooks = append(h.beforeListHooks, &hook)
+// BeforeListMatch adds a new hook to be executed before listing the objects in the datastore
+func (h *Hook) BeforeListMatch(hook func(env *env, input *dao.ListMatchInput, auth *util.Auth) *HookError) {
+	h.beforeListMatchHooks = append(h.beforeListMatchHooks, &hook)
 }
 
-// BeforeCreate adds a new hook to be executed before creating an object in the datastore
-func (h *Hook) BeforeCreate(hook func(env *env, req createMatchRequest, input *dao.CreateMatchInput, auth *util.Auth) *HookError) {
-	h.beforeCreateHooks = append(h.beforeCreateHooks, &hook)
+// BeforeCreateMatch adds a new hook to be executed before creating an object in the datastore
+func (h *Hook) BeforeCreateMatch(hook func(env *env, req createMatchRequest, input *dao.CreateMatchInput, auth *util.Auth) *HookError) {
+	h.beforeCreateMatchHooks = append(h.beforeCreateMatchHooks, &hook)
 }
 
-// BeforeRead adds a new hook to be executed before reading an object in the datastore
-func (h *Hook) BeforeRead(hook func(env *env, input *dao.ReadMatchInput, auth *util.Auth) *HookError) {
-	h.beforeReadHooks = append(h.beforeReadHooks, &hook)
+// BeforeReadMatch adds a new hook to be executed before reading an object in the datastore
+func (h *Hook) BeforeReadMatch(hook func(env *env, input *dao.ReadMatchInput, auth *util.Auth) *HookError) {
+	h.beforeReadMatchHooks = append(h.beforeReadMatchHooks, &hook)
 }
 
-// BeforeUpdate adds a new hook to be executed before updating an object in the datastore
-func (h *Hook) BeforeUpdate(hook func(env *env, req updateMatchRequest, input *dao.UpdateMatchInput, auth *util.Auth) *HookError) {
-	h.beforeUpdateHooks = append(h.beforeUpdateHooks, &hook)
+// BeforeUpdateMatch adds a new hook to be executed before updating an object in the datastore
+func (h *Hook) BeforeUpdateMatch(hook func(env *env, req updateMatchRequest, input *dao.UpdateMatchInput, auth *util.Auth) *HookError) {
+	h.beforeUpdateMatchHooks = append(h.beforeUpdateMatchHooks, &hook)
 }
 
-// BeforeDelete adds a new hook to be executed before deleting an object in the datastore
-func (h *Hook) BeforeDelete(hook func(env *env, input *dao.DeleteMatchInput, auth *util.Auth) *HookError) {
-	h.beforeDeleteHooks = append(h.beforeDeleteHooks, &hook)
+// BeforeDeleteMatch adds a new hook to be executed before deleting an object in the datastore
+func (h *Hook) BeforeDeleteMatch(hook func(env *env, input *dao.DeleteMatchInput, auth *util.Auth) *HookError) {
+	h.beforeDeleteMatchHooks = append(h.beforeDeleteMatchHooks, &hook)
 }
 
-// AfterList adds a new hook to be executed after listing the objects in the datastore
-func (h *Hook) AfterList(hook func(env *env, matchList *[]dao.Match, auth *util.Auth) *HookError) {
-	h.afterListHooks = append(h.afterListHooks, &hook)
+// AfterListMatch adds a new hook to be executed after listing the objects in the datastore
+func (h *Hook) AfterListMatch(hook func(env *env, matchList *[]dao.Match, auth *util.Auth) *HookError) {
+	h.afterListMatchHooks = append(h.afterListMatchHooks, &hook)
 }
 
-// AfterCreate adds a new hook to be executed after creating an object in the datastore
-func (h *Hook) AfterCreate(hook func(env *env, match *dao.Match, auth *util.Auth) *HookError) {
-	h.afterCreateHooks = append(h.afterCreateHooks, &hook)
+// AfterCreateMatch adds a new hook to be executed after creating an object in the datastore
+func (h *Hook) AfterCreateMatch(hook func(env *env, match *dao.Match, auth *util.Auth) *HookError) {
+	h.afterCreateMatchHooks = append(h.afterCreateMatchHooks, &hook)
 }
 
-// AfterRead adds a new hook to be executed after reading an object in the datastore
-func (h *Hook) AfterRead(hook func(env *env, match *dao.Match, auth *util.Auth) *HookError) {
-	h.afterReadHooks = append(h.afterReadHooks, &hook)
+// AfterReadMatch adds a new hook to be executed after reading an object in the datastore
+func (h *Hook) AfterReadMatch(hook func(env *env, match *dao.Match, auth *util.Auth) *HookError) {
+	h.afterReadMatchHooks = append(h.afterReadMatchHooks, &hook)
 }
 
-// AfterUpdate adds a new hook to be executed after updating an object in the datastore
-func (h *Hook) AfterUpdate(hook func(env *env, match *dao.Match, auth *util.Auth) *HookError) {
-	h.afterUpdateHooks = append(h.afterUpdateHooks, &hook)
+// AfterUpdateMatch adds a new hook to be executed after updating an object in the datastore
+func (h *Hook) AfterUpdateMatch(hook func(env *env, match *dao.Match, auth *util.Auth) *HookError) {
+	h.afterUpdateMatchHooks = append(h.afterUpdateMatchHooks, &hook)
 }
 
-// AfterDelete adds a new hook to be executed after deleting an object in the datastore
-func (h *Hook) AfterDelete(hook func(env *env, auth *util.Auth) *HookError) {
-	h.afterDeleteHooks = append(h.afterDeleteHooks, &hook)
+// AfterDeleteMatch adds a new hook to be executed after deleting an object in the datastore
+func (h *Hook) AfterDeleteMatch(hook func(env *env, auth *util.Auth) *HookError) {
+	h.afterDeleteMatchHooks = append(h.afterDeleteMatchHooks, &hook)
 }

--- a/src/test/resources/generate-server-test/match/match.go
+++ b/src/test/resources/generate-server-test/match/match.go
@@ -162,7 +162,7 @@ func (env *env) listMatchHandler(w http.ResponseWriter, r *http.Request) {
 		AuthID: auth.ID,
 	}
 
-	for _, hook := range env.hook.beforeListHooks {
+	for _, hook := range env.hook.beforeListMatchHooks {
 		err := (*hook)(env, &input, auth)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestList)
@@ -178,7 +178,7 @@ func (env *env) listMatchHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	for _, hook := range env.hook.afterListHooks {
+	for _, hook := range env.hook.afterListMatchHooks {
 		err := (*hook)(env, matchList, auth)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestList)
@@ -262,7 +262,7 @@ func (env *env) createMatchHandler(w http.ResponseWriter, r *http.Request) {
 		UserTwo: *req.UserTwo,
 	}
 
-	for _, hook := range env.hook.beforeCreateHooks {
+	for _, hook := range env.hook.beforeCreateMatchHooks {
 		err := (*hook)(env, req, &input, auth)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestCreate)
@@ -278,7 +278,7 @@ func (env *env) createMatchHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	for _, hook := range env.hook.afterCreateHooks {
+	for _, hook := range env.hook.afterCreateMatchHooks {
 		err := (*hook)(env, match, auth)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestCreate)
@@ -328,7 +328,7 @@ func (env *env) readMatchHandler(w http.ResponseWriter, r *http.Request) {
 		ID: matchID,
 	}
 
-	for _, hook := range env.hook.beforeReadHooks {
+	for _, hook := range env.hook.beforeReadMatchHooks {
 		err := (*hook)(env, &input, auth)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestRead)
@@ -349,7 +349,7 @@ func (env *env) readMatchHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	for _, hook := range env.hook.afterReadHooks {
+	for _, hook := range env.hook.afterReadMatchHooks {
 		err := (*hook)(env, match, auth)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestRead)
@@ -439,7 +439,7 @@ func (env *env) updateMatchHandler(w http.ResponseWriter, r *http.Request) {
 		UserTwo: *req.UserTwo,
 	}
 
-	for _, hook := range env.hook.beforeUpdateHooks {
+	for _, hook := range env.hook.beforeUpdateMatchHooks {
 		err := (*hook)(env, req, &input, auth)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestUpdate)
@@ -460,7 +460,7 @@ func (env *env) updateMatchHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	for _, hook := range env.hook.afterUpdateHooks {
+	for _, hook := range env.hook.afterUpdateMatchHooks {
 		err := (*hook)(env, match, auth)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestUpdate)
@@ -510,7 +510,7 @@ func (env *env) deleteMatchHandler(w http.ResponseWriter, r *http.Request) {
 		ID: matchID,
 	}
 
-	for _, hook := range env.hook.beforeDeleteHooks {
+	for _, hook := range env.hook.beforeDeleteMatchHooks {
 		err := (*hook)(env, &input, auth)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestDelete)
@@ -531,7 +531,7 @@ func (env *env) deleteMatchHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	for _, hook := range env.hook.afterDeleteHooks {
+	for _, hook := range env.hook.afterDeleteMatchHooks {
 		err := (*hook)(env, auth)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestDelete)

--- a/src/test/resources/generate-server-test/user/hook.go
+++ b/src/test/resources/generate-server-test/user/hook.go
@@ -8,15 +8,15 @@ import (
 // Hook allows additional code to be executed before and after every datastore interaction
 // Hooks are executed in the order they are defined, such that if any hook errors, future hooks are not executed and the request is terminated
 type Hook struct {
-	beforeCreateHooks []*func(env *env, req createUserRequest, input *dao.CreateUserInput, auth *util.Auth) *HookError
-	beforeReadHooks   []*func(env *env, input *dao.ReadUserInput, auth *util.Auth) *HookError
-	beforeUpdateHooks []*func(env *env, req updateUserRequest, input *dao.UpdateUserInput, auth *util.Auth) *HookError
-	beforeDeleteHooks []*func(env *env, input *dao.DeleteUserInput, auth *util.Auth) *HookError
+	beforeCreateUserHooks []*func(env *env, req createUserRequest, input *dao.CreateUserInput, auth *util.Auth) *HookError
+	beforeReadUserHooks   []*func(env *env, input *dao.ReadUserInput, auth *util.Auth) *HookError
+	beforeUpdateUserHooks []*func(env *env, req updateUserRequest, input *dao.UpdateUserInput, auth *util.Auth) *HookError
+	beforeDeleteUserHooks []*func(env *env, input *dao.DeleteUserInput, auth *util.Auth) *HookError
 
-	afterCreateHooks []*func(env *env, user *dao.User, auth *util.Auth) *HookError
-	afterReadHooks   []*func(env *env, user *dao.User, auth *util.Auth) *HookError
-	afterUpdateHooks []*func(env *env, user *dao.User, auth *util.Auth) *HookError
-	afterDeleteHooks []*func(env *env, auth *util.Auth) *HookError
+	afterCreateUserHooks []*func(env *env, user *dao.User, auth *util.Auth) *HookError
+	afterReadUserHooks   []*func(env *env, user *dao.User, auth *util.Auth) *HookError
+	afterUpdateUserHooks []*func(env *env, user *dao.User, auth *util.Auth) *HookError
+	afterDeleteUserHooks []*func(env *env, auth *util.Auth) *HookError
 }
 
 // HookError wraps an existing error with HTTP status code
@@ -29,42 +29,42 @@ func (e *HookError) Error() string {
 	return e.error.Error()
 }
 
-// BeforeCreate adds a new hook to be executed before creating an object in the datastore
-func (h *Hook) BeforeCreate(hook func(env *env, req createUserRequest, input *dao.CreateUserInput, auth *util.Auth) *HookError) {
-	h.beforeCreateHooks = append(h.beforeCreateHooks, &hook)
+// BeforeCreateUser adds a new hook to be executed before creating an object in the datastore
+func (h *Hook) BeforeCreateUser(hook func(env *env, req createUserRequest, input *dao.CreateUserInput, auth *util.Auth) *HookError) {
+	h.beforeCreateUserHooks = append(h.beforeCreateUserHooks, &hook)
 }
 
-// BeforeRead adds a new hook to be executed before reading an object in the datastore
-func (h *Hook) BeforeRead(hook func(env *env, input *dao.ReadUserInput, auth *util.Auth) *HookError) {
-	h.beforeReadHooks = append(h.beforeReadHooks, &hook)
+// BeforeReadUser adds a new hook to be executed before reading an object in the datastore
+func (h *Hook) BeforeReadUser(hook func(env *env, input *dao.ReadUserInput, auth *util.Auth) *HookError) {
+	h.beforeReadUserHooks = append(h.beforeReadUserHooks, &hook)
 }
 
-// BeforeUpdate adds a new hook to be executed before updating an object in the datastore
-func (h *Hook) BeforeUpdate(hook func(env *env, req updateUserRequest, input *dao.UpdateUserInput, auth *util.Auth) *HookError) {
-	h.beforeUpdateHooks = append(h.beforeUpdateHooks, &hook)
+// BeforeUpdateUser adds a new hook to be executed before updating an object in the datastore
+func (h *Hook) BeforeUpdateUser(hook func(env *env, req updateUserRequest, input *dao.UpdateUserInput, auth *util.Auth) *HookError) {
+	h.beforeUpdateUserHooks = append(h.beforeUpdateUserHooks, &hook)
 }
 
-// BeforeDelete adds a new hook to be executed before deleting an object in the datastore
-func (h *Hook) BeforeDelete(hook func(env *env, input *dao.DeleteUserInput, auth *util.Auth) *HookError) {
-	h.beforeDeleteHooks = append(h.beforeDeleteHooks, &hook)
+// BeforeDeleteUser adds a new hook to be executed before deleting an object in the datastore
+func (h *Hook) BeforeDeleteUser(hook func(env *env, input *dao.DeleteUserInput, auth *util.Auth) *HookError) {
+	h.beforeDeleteUserHooks = append(h.beforeDeleteUserHooks, &hook)
 }
 
-// AfterCreate adds a new hook to be executed after creating an object in the datastore
-func (h *Hook) AfterCreate(hook func(env *env, user *dao.User, auth *util.Auth) *HookError) {
-	h.afterCreateHooks = append(h.afterCreateHooks, &hook)
+// AfterCreateUser adds a new hook to be executed after creating an object in the datastore
+func (h *Hook) AfterCreateUser(hook func(env *env, user *dao.User, auth *util.Auth) *HookError) {
+	h.afterCreateUserHooks = append(h.afterCreateUserHooks, &hook)
 }
 
-// AfterRead adds a new hook to be executed after reading an object in the datastore
-func (h *Hook) AfterRead(hook func(env *env, user *dao.User, auth *util.Auth) *HookError) {
-	h.afterReadHooks = append(h.afterReadHooks, &hook)
+// AfterReadUser adds a new hook to be executed after reading an object in the datastore
+func (h *Hook) AfterReadUser(hook func(env *env, user *dao.User, auth *util.Auth) *HookError) {
+	h.afterReadUserHooks = append(h.afterReadUserHooks, &hook)
 }
 
-// AfterUpdate adds a new hook to be executed after updating an object in the datastore
-func (h *Hook) AfterUpdate(hook func(env *env, user *dao.User, auth *util.Auth) *HookError) {
-	h.afterUpdateHooks = append(h.afterUpdateHooks, &hook)
+// AfterUpdateUser adds a new hook to be executed after updating an object in the datastore
+func (h *Hook) AfterUpdateUser(hook func(env *env, user *dao.User, auth *util.Auth) *HookError) {
+	h.afterUpdateUserHooks = append(h.afterUpdateUserHooks, &hook)
 }
 
-// AfterDelete adds a new hook to be executed after deleting an object in the datastore
-func (h *Hook) AfterDelete(hook func(env *env, auth *util.Auth) *HookError) {
-	h.afterDeleteHooks = append(h.afterDeleteHooks, &hook)
+// AfterDeleteUser adds a new hook to be executed after deleting an object in the datastore
+func (h *Hook) AfterDeleteUser(hook func(env *env, auth *util.Auth) *HookError) {
+	h.afterDeleteUserHooks = append(h.afterDeleteUserHooks, &hook)
 }

--- a/src/test/resources/generate-server-test/user/user.go
+++ b/src/test/resources/generate-server-test/user/user.go
@@ -143,7 +143,7 @@ func (env *env) createUserHandler(w http.ResponseWriter, r *http.Request) {
 		Name: *req.Name,
 	}
 
-	for _, hook := range env.hook.beforeCreateHooks {
+	for _, hook := range env.hook.beforeCreateUserHooks {
 		err := (*hook)(env, req, &input, auth)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestCreate)
@@ -159,7 +159,7 @@ func (env *env) createUserHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	for _, hook := range env.hook.afterCreateHooks {
+	for _, hook := range env.hook.afterCreateUserHooks {
 		err := (*hook)(env, user, auth)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestCreate)
@@ -192,7 +192,7 @@ func (env *env) readUserHandler(w http.ResponseWriter, r *http.Request) {
 		ID: userID,
 	}
 
-	for _, hook := range env.hook.beforeReadHooks {
+	for _, hook := range env.hook.beforeReadUserHooks {
 		err := (*hook)(env, &input, auth)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestRead)
@@ -213,7 +213,7 @@ func (env *env) readUserHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	for _, hook := range env.hook.afterReadHooks {
+	for _, hook := range env.hook.afterReadUserHooks {
 		err := (*hook)(env, user, auth)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestRead)
@@ -270,7 +270,7 @@ func (env *env) updateUserHandler(w http.ResponseWriter, r *http.Request) {
 		Name: *req.Name,
 	}
 
-	for _, hook := range env.hook.beforeUpdateHooks {
+	for _, hook := range env.hook.beforeUpdateUserHooks {
 		err := (*hook)(env, req, &input, auth)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestUpdate)
@@ -291,7 +291,7 @@ func (env *env) updateUserHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	for _, hook := range env.hook.afterUpdateHooks {
+	for _, hook := range env.hook.afterUpdateUserHooks {
 		err := (*hook)(env, user, auth)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestUpdate)
@@ -329,7 +329,7 @@ func (env *env) deleteUserHandler(w http.ResponseWriter, r *http.Request) {
 		ID: userID,
 	}
 
-	for _, hook := range env.hook.beforeDeleteHooks {
+	for _, hook := range env.hook.beforeDeleteUserHooks {
 		err := (*hook)(env, &input, auth)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestDelete)
@@ -350,7 +350,7 @@ func (env *env) deleteUserHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	for _, hook := range env.hook.afterDeleteHooks {
+	for _, hook := range env.hook.afterDeleteUserHooks {
 		err := (*hook)(env, auth)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestDelete)

--- a/src/test/resources/project-builder-complex/complex-user/complex-user.go
+++ b/src/test/resources/project-builder-complex/complex-user/complex-user.go
@@ -236,7 +236,7 @@ func (env *env) createComplexUserHandler(w http.ResponseWriter, r *http.Request)
 		BlobField:          blobField,
 	}
 
-	for _, hook := range env.hook.beforeCreateHooks {
+	for _, hook := range env.hook.beforeCreateComplexUserHooks {
 		err := (*hook)(env, req, &input, auth)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestCreate)
@@ -252,7 +252,7 @@ func (env *env) createComplexUserHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	for _, hook := range env.hook.afterCreateHooks {
+	for _, hook := range env.hook.afterCreateComplexUserHooks {
 		err := (*hook)(env, complexUser, auth)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestCreate)
@@ -301,7 +301,7 @@ func (env *env) readComplexUserHandler(w http.ResponseWriter, r *http.Request) {
 		ID: complexUserID,
 	}
 
-	for _, hook := range env.hook.beforeReadHooks {
+	for _, hook := range env.hook.beforeReadComplexUserHooks {
 		err := (*hook)(env, &input, auth)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestRead)
@@ -322,7 +322,7 @@ func (env *env) readComplexUserHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	for _, hook := range env.hook.afterReadHooks {
+	for _, hook := range env.hook.afterReadComplexUserHooks {
 		err := (*hook)(env, complexUser, auth)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestRead)
@@ -425,7 +425,7 @@ func (env *env) updateComplexUserHandler(w http.ResponseWriter, r *http.Request)
 		BlobField:          blobField,
 	}
 
-	for _, hook := range env.hook.beforeUpdateHooks {
+	for _, hook := range env.hook.beforeUpdateComplexUserHooks {
 		err := (*hook)(env, req, &input, auth)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestUpdate)
@@ -446,7 +446,7 @@ func (env *env) updateComplexUserHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	for _, hook := range env.hook.afterUpdateHooks {
+	for _, hook := range env.hook.afterUpdateComplexUserHooks {
 		err := (*hook)(env, complexUser, auth)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestUpdate)
@@ -495,7 +495,7 @@ func (env *env) deleteComplexUserHandler(w http.ResponseWriter, r *http.Request)
 		ID: complexUserID,
 	}
 
-	for _, hook := range env.hook.beforeDeleteHooks {
+	for _, hook := range env.hook.beforeDeleteComplexUserHooks {
 		err := (*hook)(env, &input, auth)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestDelete)
@@ -516,7 +516,7 @@ func (env *env) deleteComplexUserHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	for _, hook := range env.hook.afterDeleteHooks {
+	for _, hook := range env.hook.afterDeleteComplexUserHooks {
 		err := (*hook)(env, auth)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestDelete)
@@ -540,7 +540,7 @@ func (env *env) identifyComplexUserHandler(w http.ResponseWriter, r *http.Reques
 		ID: auth.ID,
 	}
 
-	for _, hook := range env.hook.beforeIdentifyHooks {
+	for _, hook := range env.hook.beforeIdentifyComplexUserHooks {
 		err := (*hook)(env, &input, auth)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestIdentify)
@@ -561,7 +561,7 @@ func (env *env) identifyComplexUserHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	for _, hook := range env.hook.afterIdentifyHooks {
+	for _, hook := range env.hook.afterIdentifyComplexUserHooks {
 		err := (*hook)(env, complexUser, auth)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestIdentify)

--- a/src/test/resources/project-builder-complex/complex-user/hook.go
+++ b/src/test/resources/project-builder-complex/complex-user/hook.go
@@ -8,17 +8,17 @@ import (
 // Hook allows additional code to be executed before and after every datastore interaction
 // Hooks are executed in the order they are defined, such that if any hook errors, future hooks are not executed and the request is terminated
 type Hook struct {
-	beforeCreateHooks   []*func(env *env, req createComplexUserRequest, input *dao.CreateComplexUserInput, auth *util.Auth) *HookError
-	beforeReadHooks     []*func(env *env, input *dao.ReadComplexUserInput, auth *util.Auth) *HookError
-	beforeUpdateHooks   []*func(env *env, req updateComplexUserRequest, input *dao.UpdateComplexUserInput, auth *util.Auth) *HookError
-	beforeDeleteHooks   []*func(env *env, input *dao.DeleteComplexUserInput, auth *util.Auth) *HookError
-	beforeIdentifyHooks []*func(env *env, input *dao.IdentifyComplexUserInput, auth *util.Auth) *HookError
+	beforeCreateComplexUserHooks   []*func(env *env, req createComplexUserRequest, input *dao.CreateComplexUserInput, auth *util.Auth) *HookError
+	beforeReadComplexUserHooks     []*func(env *env, input *dao.ReadComplexUserInput, auth *util.Auth) *HookError
+	beforeUpdateComplexUserHooks   []*func(env *env, req updateComplexUserRequest, input *dao.UpdateComplexUserInput, auth *util.Auth) *HookError
+	beforeDeleteComplexUserHooks   []*func(env *env, input *dao.DeleteComplexUserInput, auth *util.Auth) *HookError
+	beforeIdentifyComplexUserHooks []*func(env *env, input *dao.IdentifyComplexUserInput, auth *util.Auth) *HookError
 
-	afterCreateHooks   []*func(env *env, complexUser *dao.ComplexUser, auth *util.Auth) *HookError
-	afterReadHooks     []*func(env *env, complexUser *dao.ComplexUser, auth *util.Auth) *HookError
-	afterUpdateHooks   []*func(env *env, complexUser *dao.ComplexUser, auth *util.Auth) *HookError
-	afterDeleteHooks   []*func(env *env, auth *util.Auth) *HookError
-	afterIdentifyHooks []*func(env *env, complexUser *dao.ComplexUser, auth *util.Auth) *HookError
+	afterCreateComplexUserHooks   []*func(env *env, complexUser *dao.ComplexUser, auth *util.Auth) *HookError
+	afterReadComplexUserHooks     []*func(env *env, complexUser *dao.ComplexUser, auth *util.Auth) *HookError
+	afterUpdateComplexUserHooks   []*func(env *env, complexUser *dao.ComplexUser, auth *util.Auth) *HookError
+	afterDeleteComplexUserHooks   []*func(env *env, auth *util.Auth) *HookError
+	afterIdentifyComplexUserHooks []*func(env *env, complexUser *dao.ComplexUser, auth *util.Auth) *HookError
 }
 
 // HookError wraps an existing error with HTTP status code
@@ -31,52 +31,52 @@ func (e *HookError) Error() string {
 	return e.error.Error()
 }
 
-// BeforeCreate adds a new hook to be executed before creating an object in the datastore
-func (h *Hook) BeforeCreate(hook func(env *env, req createComplexUserRequest, input *dao.CreateComplexUserInput, auth *util.Auth) *HookError) {
-	h.beforeCreateHooks = append(h.beforeCreateHooks, &hook)
+// BeforeCreateComplexUser adds a new hook to be executed before creating an object in the datastore
+func (h *Hook) BeforeCreateComplexUser(hook func(env *env, req createComplexUserRequest, input *dao.CreateComplexUserInput, auth *util.Auth) *HookError) {
+	h.beforeCreateComplexUserHooks = append(h.beforeCreateComplexUserHooks, &hook)
 }
 
-// BeforeRead adds a new hook to be executed before reading an object in the datastore
-func (h *Hook) BeforeRead(hook func(env *env, input *dao.ReadComplexUserInput, auth *util.Auth) *HookError) {
-	h.beforeReadHooks = append(h.beforeReadHooks, &hook)
+// BeforeReadComplexUser adds a new hook to be executed before reading an object in the datastore
+func (h *Hook) BeforeReadComplexUser(hook func(env *env, input *dao.ReadComplexUserInput, auth *util.Auth) *HookError) {
+	h.beforeReadComplexUserHooks = append(h.beforeReadComplexUserHooks, &hook)
 }
 
-// BeforeUpdate adds a new hook to be executed before updating an object in the datastore
-func (h *Hook) BeforeUpdate(hook func(env *env, req updateComplexUserRequest, input *dao.UpdateComplexUserInput, auth *util.Auth) *HookError) {
-	h.beforeUpdateHooks = append(h.beforeUpdateHooks, &hook)
+// BeforeUpdateComplexUser adds a new hook to be executed before updating an object in the datastore
+func (h *Hook) BeforeUpdateComplexUser(hook func(env *env, req updateComplexUserRequest, input *dao.UpdateComplexUserInput, auth *util.Auth) *HookError) {
+	h.beforeUpdateComplexUserHooks = append(h.beforeUpdateComplexUserHooks, &hook)
 }
 
-// BeforeDelete adds a new hook to be executed before deleting an object in the datastore
-func (h *Hook) BeforeDelete(hook func(env *env, input *dao.DeleteComplexUserInput, auth *util.Auth) *HookError) {
-	h.beforeDeleteHooks = append(h.beforeDeleteHooks, &hook)
+// BeforeDeleteComplexUser adds a new hook to be executed before deleting an object in the datastore
+func (h *Hook) BeforeDeleteComplexUser(hook func(env *env, input *dao.DeleteComplexUserInput, auth *util.Auth) *HookError) {
+	h.beforeDeleteComplexUserHooks = append(h.beforeDeleteComplexUserHooks, &hook)
 }
 
-// BeforeIdentify adds a new hook to be executed before identifying an object in the datastore
-func (h *Hook) BeforeIdentify(hook func(env *env, input *dao.IdentifyComplexUserInput, auth *util.Auth) *HookError) {
-	h.beforeIdentifyHooks = append(h.beforeIdentifyHooks, &hook)
+// BeforeIdentifyComplexUser adds a new hook to be executed before identifying an object in the datastore
+func (h *Hook) BeforeIdentifyComplexUser(hook func(env *env, input *dao.IdentifyComplexUserInput, auth *util.Auth) *HookError) {
+	h.beforeIdentifyComplexUserHooks = append(h.beforeIdentifyComplexUserHooks, &hook)
 }
 
-// AfterCreate adds a new hook to be executed after creating an object in the datastore
-func (h *Hook) AfterCreate(hook func(env *env, complexUser *dao.ComplexUser, auth *util.Auth) *HookError) {
-	h.afterCreateHooks = append(h.afterCreateHooks, &hook)
+// AfterCreateComplexUser adds a new hook to be executed after creating an object in the datastore
+func (h *Hook) AfterCreateComplexUser(hook func(env *env, complexUser *dao.ComplexUser, auth *util.Auth) *HookError) {
+	h.afterCreateComplexUserHooks = append(h.afterCreateComplexUserHooks, &hook)
 }
 
-// AfterRead adds a new hook to be executed after reading an object in the datastore
-func (h *Hook) AfterRead(hook func(env *env, complexUser *dao.ComplexUser, auth *util.Auth) *HookError) {
-	h.afterReadHooks = append(h.afterReadHooks, &hook)
+// AfterReadComplexUser adds a new hook to be executed after reading an object in the datastore
+func (h *Hook) AfterReadComplexUser(hook func(env *env, complexUser *dao.ComplexUser, auth *util.Auth) *HookError) {
+	h.afterReadComplexUserHooks = append(h.afterReadComplexUserHooks, &hook)
 }
 
-// AfterUpdate adds a new hook to be executed after updating an object in the datastore
-func (h *Hook) AfterUpdate(hook func(env *env, complexUser *dao.ComplexUser, auth *util.Auth) *HookError) {
-	h.afterUpdateHooks = append(h.afterUpdateHooks, &hook)
+// AfterUpdateComplexUser adds a new hook to be executed after updating an object in the datastore
+func (h *Hook) AfterUpdateComplexUser(hook func(env *env, complexUser *dao.ComplexUser, auth *util.Auth) *HookError) {
+	h.afterUpdateComplexUserHooks = append(h.afterUpdateComplexUserHooks, &hook)
 }
 
-// AfterDelete adds a new hook to be executed after deleting an object in the datastore
-func (h *Hook) AfterDelete(hook func(env *env, auth *util.Auth) *HookError) {
-	h.afterDeleteHooks = append(h.afterDeleteHooks, &hook)
+// AfterDeleteComplexUser adds a new hook to be executed after deleting an object in the datastore
+func (h *Hook) AfterDeleteComplexUser(hook func(env *env, auth *util.Auth) *HookError) {
+	h.afterDeleteComplexUserHooks = append(h.afterDeleteComplexUserHooks, &hook)
 }
 
-// AfterIdentify adds a new hook to be executed after identifying an object in the datastore
-func (h *Hook) AfterIdentify(hook func(env *env, complexUser *dao.ComplexUser, auth *util.Auth) *HookError) {
-	h.afterIdentifyHooks = append(h.afterIdentifyHooks, &hook)
+// AfterIdentifyComplexUser adds a new hook to be executed after identifying an object in the datastore
+func (h *Hook) AfterIdentifyComplexUser(hook func(env *env, complexUser *dao.ComplexUser, auth *util.Auth) *HookError) {
+	h.afterIdentifyComplexUserHooks = append(h.afterIdentifyComplexUserHooks, &hook)
 }

--- a/src/test/resources/project-builder-simple/temple-user/hook.go
+++ b/src/test/resources/project-builder-simple/temple-user/hook.go
@@ -5,15 +5,15 @@ import "github.com/squat/and/dab/temple-user/dao"
 // Hook allows additional code to be executed before and after every datastore interaction
 // Hooks are executed in the order they are defined, such that if any hook errors, future hooks are not executed and the request is terminated
 type Hook struct {
-	beforeCreateHooks []*func(env *env, req createTempleUserRequest, input *dao.CreateTempleUserInput) *HookError
-	beforeReadHooks   []*func(env *env, input *dao.ReadTempleUserInput) *HookError
-	beforeUpdateHooks []*func(env *env, req updateTempleUserRequest, input *dao.UpdateTempleUserInput) *HookError
-	beforeDeleteHooks []*func(env *env, input *dao.DeleteTempleUserInput) *HookError
+	beforeCreateTempleUserHooks []*func(env *env, req createTempleUserRequest, input *dao.CreateTempleUserInput) *HookError
+	beforeReadTempleUserHooks   []*func(env *env, input *dao.ReadTempleUserInput) *HookError
+	beforeUpdateTempleUserHooks []*func(env *env, req updateTempleUserRequest, input *dao.UpdateTempleUserInput) *HookError
+	beforeDeleteTempleUserHooks []*func(env *env, input *dao.DeleteTempleUserInput) *HookError
 
-	afterCreateHooks []*func(env *env, templeUser *dao.TempleUser) *HookError
-	afterReadHooks   []*func(env *env, templeUser *dao.TempleUser) *HookError
-	afterUpdateHooks []*func(env *env, templeUser *dao.TempleUser) *HookError
-	afterDeleteHooks []*func(env *env) *HookError
+	afterCreateTempleUserHooks []*func(env *env, templeUser *dao.TempleUser) *HookError
+	afterReadTempleUserHooks   []*func(env *env, templeUser *dao.TempleUser) *HookError
+	afterUpdateTempleUserHooks []*func(env *env, templeUser *dao.TempleUser) *HookError
+	afterDeleteTempleUserHooks []*func(env *env) *HookError
 }
 
 // HookError wraps an existing error with HTTP status code
@@ -26,42 +26,42 @@ func (e *HookError) Error() string {
 	return e.error.Error()
 }
 
-// BeforeCreate adds a new hook to be executed before creating an object in the datastore
-func (h *Hook) BeforeCreate(hook func(env *env, req createTempleUserRequest, input *dao.CreateTempleUserInput) *HookError) {
-	h.beforeCreateHooks = append(h.beforeCreateHooks, &hook)
+// BeforeCreateTempleUser adds a new hook to be executed before creating an object in the datastore
+func (h *Hook) BeforeCreateTempleUser(hook func(env *env, req createTempleUserRequest, input *dao.CreateTempleUserInput) *HookError) {
+	h.beforeCreateTempleUserHooks = append(h.beforeCreateTempleUserHooks, &hook)
 }
 
-// BeforeRead adds a new hook to be executed before reading an object in the datastore
-func (h *Hook) BeforeRead(hook func(env *env, input *dao.ReadTempleUserInput) *HookError) {
-	h.beforeReadHooks = append(h.beforeReadHooks, &hook)
+// BeforeReadTempleUser adds a new hook to be executed before reading an object in the datastore
+func (h *Hook) BeforeReadTempleUser(hook func(env *env, input *dao.ReadTempleUserInput) *HookError) {
+	h.beforeReadTempleUserHooks = append(h.beforeReadTempleUserHooks, &hook)
 }
 
-// BeforeUpdate adds a new hook to be executed before updating an object in the datastore
-func (h *Hook) BeforeUpdate(hook func(env *env, req updateTempleUserRequest, input *dao.UpdateTempleUserInput) *HookError) {
-	h.beforeUpdateHooks = append(h.beforeUpdateHooks, &hook)
+// BeforeUpdateTempleUser adds a new hook to be executed before updating an object in the datastore
+func (h *Hook) BeforeUpdateTempleUser(hook func(env *env, req updateTempleUserRequest, input *dao.UpdateTempleUserInput) *HookError) {
+	h.beforeUpdateTempleUserHooks = append(h.beforeUpdateTempleUserHooks, &hook)
 }
 
-// BeforeDelete adds a new hook to be executed before deleting an object in the datastore
-func (h *Hook) BeforeDelete(hook func(env *env, input *dao.DeleteTempleUserInput) *HookError) {
-	h.beforeDeleteHooks = append(h.beforeDeleteHooks, &hook)
+// BeforeDeleteTempleUser adds a new hook to be executed before deleting an object in the datastore
+func (h *Hook) BeforeDeleteTempleUser(hook func(env *env, input *dao.DeleteTempleUserInput) *HookError) {
+	h.beforeDeleteTempleUserHooks = append(h.beforeDeleteTempleUserHooks, &hook)
 }
 
-// AfterCreate adds a new hook to be executed after creating an object in the datastore
-func (h *Hook) AfterCreate(hook func(env *env, templeUser *dao.TempleUser) *HookError) {
-	h.afterCreateHooks = append(h.afterCreateHooks, &hook)
+// AfterCreateTempleUser adds a new hook to be executed after creating an object in the datastore
+func (h *Hook) AfterCreateTempleUser(hook func(env *env, templeUser *dao.TempleUser) *HookError) {
+	h.afterCreateTempleUserHooks = append(h.afterCreateTempleUserHooks, &hook)
 }
 
-// AfterRead adds a new hook to be executed after reading an object in the datastore
-func (h *Hook) AfterRead(hook func(env *env, templeUser *dao.TempleUser) *HookError) {
-	h.afterReadHooks = append(h.afterReadHooks, &hook)
+// AfterReadTempleUser adds a new hook to be executed after reading an object in the datastore
+func (h *Hook) AfterReadTempleUser(hook func(env *env, templeUser *dao.TempleUser) *HookError) {
+	h.afterReadTempleUserHooks = append(h.afterReadTempleUserHooks, &hook)
 }
 
-// AfterUpdate adds a new hook to be executed after updating an object in the datastore
-func (h *Hook) AfterUpdate(hook func(env *env, templeUser *dao.TempleUser) *HookError) {
-	h.afterUpdateHooks = append(h.afterUpdateHooks, &hook)
+// AfterUpdateTempleUser adds a new hook to be executed after updating an object in the datastore
+func (h *Hook) AfterUpdateTempleUser(hook func(env *env, templeUser *dao.TempleUser) *HookError) {
+	h.afterUpdateTempleUserHooks = append(h.afterUpdateTempleUserHooks, &hook)
 }
 
-// AfterDelete adds a new hook to be executed after deleting an object in the datastore
-func (h *Hook) AfterDelete(hook func(env *env) *HookError) {
-	h.afterDeleteHooks = append(h.afterDeleteHooks, &hook)
+// AfterDeleteTempleUser adds a new hook to be executed after deleting an object in the datastore
+func (h *Hook) AfterDeleteTempleUser(hook func(env *env) *HookError) {
+	h.afterDeleteTempleUserHooks = append(h.afterDeleteTempleUserHooks, &hook)
 }

--- a/src/test/resources/project-builder-simple/temple-user/temple-user.go
+++ b/src/test/resources/project-builder-simple/temple-user/temple-user.go
@@ -196,7 +196,7 @@ func (env *env) createTempleUserHandler(w http.ResponseWriter, r *http.Request) 
 		BlobField:     blobField,
 	}
 
-	for _, hook := range env.hook.beforeCreateHooks {
+	for _, hook := range env.hook.beforeCreateTempleUserHooks {
 		err := (*hook)(env, req, &input)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode)
@@ -210,7 +210,7 @@ func (env *env) createTempleUserHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	for _, hook := range env.hook.afterCreateHooks {
+	for _, hook := range env.hook.afterCreateTempleUserHooks {
 		err := (*hook)(env, templeUser)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode)
@@ -242,7 +242,7 @@ func (env *env) readTempleUserHandler(w http.ResponseWriter, r *http.Request) {
 		ID: templeUserID,
 	}
 
-	for _, hook := range env.hook.beforeReadHooks {
+	for _, hook := range env.hook.beforeReadTempleUserHooks {
 		err := (*hook)(env, &input)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode)
@@ -261,7 +261,7 @@ func (env *env) readTempleUserHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	for _, hook := range env.hook.afterReadHooks {
+	for _, hook := range env.hook.afterReadTempleUserHooks {
 		err := (*hook)(env, templeUser)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode)
@@ -343,7 +343,7 @@ func (env *env) updateTempleUserHandler(w http.ResponseWriter, r *http.Request) 
 		BlobField:     blobField,
 	}
 
-	for _, hook := range env.hook.beforeUpdateHooks {
+	for _, hook := range env.hook.beforeUpdateTempleUserHooks {
 		err := (*hook)(env, req, &input)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode)
@@ -362,7 +362,7 @@ func (env *env) updateTempleUserHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	for _, hook := range env.hook.afterUpdateHooks {
+	for _, hook := range env.hook.afterUpdateTempleUserHooks {
 		err := (*hook)(env, templeUser)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode)
@@ -394,7 +394,7 @@ func (env *env) deleteTempleUserHandler(w http.ResponseWriter, r *http.Request) 
 		ID: templeUserID,
 	}
 
-	for _, hook := range env.hook.beforeDeleteHooks {
+	for _, hook := range env.hook.beforeDeleteTempleUserHooks {
 		err := (*hook)(env, &input)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode)
@@ -413,7 +413,7 @@ func (env *env) deleteTempleUserHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	for _, hook := range env.hook.afterDeleteHooks {
+	for _, hook := range env.hook.afterDeleteTempleUserHooks {
 		err := (*hook)(env)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode)


### PR DESCRIPTION
This is in preparation for introducing hooks for structs.

No stacking, so ready for review immediately.

A bit more generalising `root: ServiceRoot` to `block: AttributesBlock`, and otherwise basically all the changes are of test resources