### PR TITLE
[Go-gen] Add struct hooks without renaming old hooks

### DIFF
--- a/src/e2e/resources/simple-temple-expected/simple-temple-test-user/hook.go
+++ b/src/e2e/resources/simple-temple-expected/simple-temple-test-user/hook.go
@@ -14,11 +14,23 @@ type Hook struct {
 	beforeUpdateHooks   []*func(env *env, req updateSimpleTempleTestUserRequest, input *dao.UpdateSimpleTempleTestUserInput, auth *util.Auth) *HookError
 	beforeIdentifyHooks []*func(env *env, input *dao.IdentifySimpleTempleTestUserInput, auth *util.Auth) *HookError
 
+	beforeListFredHooks   []*func(env *env, auth *util.Auth) *HookError
+	beforeCreateFredHooks []*func(env *env, req createFredRequest, input *dao.CreateFredInput, auth *util.Auth) *HookError
+	beforeReadFredHooks   []*func(env *env, input *dao.ReadFredInput, auth *util.Auth) *HookError
+	beforeUpdateFredHooks []*func(env *env, req updateFredRequest, input *dao.UpdateFredInput, auth *util.Auth) *HookError
+	beforeDeleteFredHooks []*func(env *env, input *dao.DeleteFredInput, auth *util.Auth) *HookError
+
 	afterListHooks     []*func(env *env, simpleTempleTestUserList *[]dao.SimpleTempleTestUser, auth *util.Auth) *HookError
 	afterCreateHooks   []*func(env *env, simpleTempleTestUser *dao.SimpleTempleTestUser, auth *util.Auth) *HookError
 	afterReadHooks     []*func(env *env, simpleTempleTestUser *dao.SimpleTempleTestUser, auth *util.Auth) *HookError
 	afterUpdateHooks   []*func(env *env, simpleTempleTestUser *dao.SimpleTempleTestUser, auth *util.Auth) *HookError
 	afterIdentifyHooks []*func(env *env, simpleTempleTestUser *dao.SimpleTempleTestUser, auth *util.Auth) *HookError
+
+	afterListFredHooks   []*func(env *env, fredList *[]dao.Fred, auth *util.Auth) *HookError
+	afterCreateFredHooks []*func(env *env, fred *dao.Fred, auth *util.Auth) *HookError
+	afterReadFredHooks   []*func(env *env, fred *dao.Fred, auth *util.Auth) *HookError
+	afterUpdateFredHooks []*func(env *env, fred *dao.Fred, auth *util.Auth) *HookError
+	afterDeleteFredHooks []*func(env *env, auth *util.Auth) *HookError
 }
 
 // HookError wraps an existing error with HTTP status code
@@ -56,6 +68,31 @@ func (h *Hook) BeforeIdentify(hook func(env *env, input *dao.IdentifySimpleTempl
 	h.beforeIdentifyHooks = append(h.beforeIdentifyHooks, &hook)
 }
 
+// BeforeListFred adds a new hook to be executed before listing the objects in the datastore
+func (h *Hook) BeforeListFred(hook func(env *env, auth *util.Auth) *HookError) {
+	h.beforeListFredHooks = append(h.beforeListFredHooks, &hook)
+}
+
+// BeforeCreateFred adds a new hook to be executed before creating an object in the datastore
+func (h *Hook) BeforeCreateFred(hook func(env *env, req createFredRequest, input *dao.CreateFredInput, auth *util.Auth) *HookError) {
+	h.beforeCreateFredHooks = append(h.beforeCreateFredHooks, &hook)
+}
+
+// BeforeReadFred adds a new hook to be executed before reading an object in the datastore
+func (h *Hook) BeforeReadFred(hook func(env *env, input *dao.ReadFredInput, auth *util.Auth) *HookError) {
+	h.beforeReadFredHooks = append(h.beforeReadFredHooks, &hook)
+}
+
+// BeforeUpdateFred adds a new hook to be executed before updating an object in the datastore
+func (h *Hook) BeforeUpdateFred(hook func(env *env, req updateFredRequest, input *dao.UpdateFredInput, auth *util.Auth) *HookError) {
+	h.beforeUpdateFredHooks = append(h.beforeUpdateFredHooks, &hook)
+}
+
+// BeforeDeleteFred adds a new hook to be executed before deleting an object in the datastore
+func (h *Hook) BeforeDeleteFred(hook func(env *env, input *dao.DeleteFredInput, auth *util.Auth) *HookError) {
+	h.beforeDeleteFredHooks = append(h.beforeDeleteFredHooks, &hook)
+}
+
 // AfterList adds a new hook to be executed after listing the objects in the datastore
 func (h *Hook) AfterList(hook func(env *env, simpleTempleTestUserList *[]dao.SimpleTempleTestUser, auth *util.Auth) *HookError) {
 	h.afterListHooks = append(h.afterListHooks, &hook)
@@ -79,4 +116,29 @@ func (h *Hook) AfterUpdate(hook func(env *env, simpleTempleTestUser *dao.SimpleT
 // AfterIdentify adds a new hook to be executed after identifying an object in the datastore
 func (h *Hook) AfterIdentify(hook func(env *env, simpleTempleTestUser *dao.SimpleTempleTestUser, auth *util.Auth) *HookError) {
 	h.afterIdentifyHooks = append(h.afterIdentifyHooks, &hook)
+}
+
+// AfterListFred adds a new hook to be executed after listing the objects in the datastore
+func (h *Hook) AfterListFred(hook func(env *env, fredList *[]dao.Fred, auth *util.Auth) *HookError) {
+	h.afterListFredHooks = append(h.afterListFredHooks, &hook)
+}
+
+// AfterCreateFred adds a new hook to be executed after creating an object in the datastore
+func (h *Hook) AfterCreateFred(hook func(env *env, fred *dao.Fred, auth *util.Auth) *HookError) {
+	h.afterCreateFredHooks = append(h.afterCreateFredHooks, &hook)
+}
+
+// AfterReadFred adds a new hook to be executed after reading an object in the datastore
+func (h *Hook) AfterReadFred(hook func(env *env, fred *dao.Fred, auth *util.Auth) *HookError) {
+	h.afterReadFredHooks = append(h.afterReadFredHooks, &hook)
+}
+
+// AfterUpdateFred adds a new hook to be executed after updating an object in the datastore
+func (h *Hook) AfterUpdateFred(hook func(env *env, fred *dao.Fred, auth *util.Auth) *HookError) {
+	h.afterUpdateFredHooks = append(h.afterUpdateFredHooks, &hook)
+}
+
+// AfterDeleteFred adds a new hook to be executed after deleting an object in the datastore
+func (h *Hook) AfterDeleteFred(hook func(env *env, auth *util.Auth) *HookError) {
+	h.afterDeleteFredHooks = append(h.afterDeleteFredHooks, &hook)
 }

--- a/src/e2e/resources/simple-temple-expected/simple-temple-test-user/simple-temple-test-user.go
+++ b/src/e2e/resources/simple-temple-expected/simple-temple-test-user/simple-temple-test-user.go
@@ -52,6 +52,20 @@ type updateSimpleTempleTestUserRequest struct {
 	BreakfastTime        *string  `json:"breakfastTime" validate:"required"`
 }
 
+// createFredRequest contains the client-provided information required to create a single fred
+type createFredRequest struct {
+	Field  *string    `json:"field" validate:"required"`
+	Friend *uuid.UUID `json:"friend" validate:"required"`
+	Image  *string    `json:"image" validate:"base64,required"`
+}
+
+// updateFredRequest contains the client-provided information required to update a single fred
+type updateFredRequest struct {
+	Field  *string    `json:"field" validate:"required"`
+	Friend *uuid.UUID `json:"friend" validate:"required"`
+	Image  *string    `json:"image" validate:"base64,required"`
+}
+
 // listSimpleTempleTestUserElement contains a single simpleTempleTestUser list element
 type listSimpleTempleTestUserElement struct {
 	ID                   uuid.UUID `json:"id"`
@@ -111,6 +125,43 @@ type updateSimpleTempleTestUserResponse struct {
 	CurrentBankBalance   float32   `json:"currentBankBalance"`
 	BirthDate            string    `json:"birthDate"`
 	BreakfastTime        string    `json:"breakfastTime"`
+}
+
+// listFredElement contains a single fred list element
+type listFredElement struct {
+	ID     uuid.UUID `json:"id"`
+	Field  string    `json:"field"`
+	Friend uuid.UUID `json:"friend"`
+	Image  string    `json:"image"`
+}
+
+// listFredResponse contains a single fred list to be returned to the client
+type listFredResponse struct {
+	FredList []listFredElement
+}
+
+// createFredResponse contains a newly created fred to be returned to the client
+type createFredResponse struct {
+	ID     uuid.UUID `json:"id"`
+	Field  string    `json:"field"`
+	Friend uuid.UUID `json:"friend"`
+	Image  string    `json:"image"`
+}
+
+// readFredResponse contains a single fred to be returned to the client
+type readFredResponse struct {
+	ID     uuid.UUID `json:"id"`
+	Field  string    `json:"field"`
+	Friend uuid.UUID `json:"friend"`
+	Image  string    `json:"image"`
+}
+
+// updateFredResponse contains a newly updated fred to be returned to the client
+type updateFredResponse struct {
+	ID     uuid.UUID `json:"id"`
+	Field  string    `json:"field"`
+	Friend uuid.UUID `json:"friend"`
+	Image  string    `json:"image"`
 }
 
 // defaultRouter generates a router for this service

--- a/src/main/scala/temple/generate/server/go/service/GoServiceGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/GoServiceGenerator.scala
@@ -45,13 +45,17 @@ object GoServiceGenerator extends ServiceGenerator {
         GoCommonGenerator.generatePackage("main"),
         GoServiceMainGenerator.generateImports(root, usesBase64, usesTime, usesComms, usesMetrics),
         GoServiceMainStructGenerator.generateEnvStruct(usesComms),
-        when(
-          root.requestAttributes.nonEmpty
-          && (root.operations.contains(CRUD.Create) || root.operations.contains(CRUD.Update)),
-        ) {
-          GoServiceMainStructGenerator.generateRequestStructs(root)
+        root.blockIterator.map { block =>
+          when(
+            block.requestAttributes.nonEmpty
+            && (block.opQueries.contains(CRUD.Create) || block.opQueries.contains(CRUD.Update)),
+          ) {
+            GoServiceMainStructGenerator.generateRequestStructs(block)
+          }
         },
-        GoServiceMainStructGenerator.generateResponseStructs(root),
+        root.blockIterator.map { block =>
+          GoServiceMainStructGenerator.generateResponseStructs(block)
+        },
         GoServiceMainGenerator.generateRouter(root),
         GoCommonMainGenerator.generateMain(root, usesComms, isAuth = false, usesMetrics),
         GoCommonMainGenerator.generateJsonMiddleware(),

--- a/src/main/scala/temple/generate/server/go/service/GoServiceGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/GoServiceGenerator.scala
@@ -24,7 +24,7 @@ object GoServiceGenerator extends ServiceGenerator {
     // Whether or not this service uses the time type, by checking for attributes of type date, time or datetime
     val usesTime =
       Set[AttributeType](AttributeType.DateType, AttributeType.TimeType, AttributeType.DateTimeType)
-        .intersect(root.attributes.values.map(_.attributeType).toSet)
+        .intersect(root.blockIterator.flatMap(_.attributes.values).map(_.attributeType).toSet)
         .nonEmpty
 
     // Whether or not this service uses base64, by checking for attributes of type blob

--- a/src/main/scala/temple/generate/server/go/service/GoServiceHookGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/GoServiceHookGenerator.scala
@@ -1,8 +1,8 @@
 package temple.generate.server.go.service
 
 import temple.ast.Metadata.Readable
-import temple.generate.CRUD
-import temple.generate.CRUD.{CRUD, presentParticiple}
+import temple.generate.CRUD._
+import temple.generate.server.AttributesRoot
 import temple.generate.server.AttributesRoot.ServiceRoot
 import temple.generate.server.go.common.GoCommonGenerator._
 import temple.generate.server.go.common.GoCommonHookGenerator
@@ -13,6 +13,9 @@ import scala.Option.when
 
 object GoServiceHookGenerator {
 
+  private[service] def hookSuffix(block: AttributesRoot): String =
+    if (block.parentAttribute.nonEmpty) block.name else ""
+
   private[service] def generateImports(root: ServiceRoot): String = {
     val daoImport = s"${doubleQuote(root.module + "/dao")}"
     if (root.projectUsesAuth)
@@ -20,90 +23,95 @@ object GoServiceHookGenerator {
     else mkCode("import", daoImport)
   }
 
-  private def generateHookType(root: ServiceRoot, args: String*): String =
+  private def generateHookType(block: AttributesRoot, args: String*): String =
     mkCode(
-      CodeWrap.parens
-        .prefix("func")
-        .list("env *env", args, when(root.projectUsesAuth) { "auth *util.Auth" }),
+      CodeWrap.parens.prefix("func").list("env *env", args, when(block.projectUsesAuth) { "auth *util.Auth" }),
       "*HookError",
     )
 
-  private def generateBeforeHookType(root: ServiceRoot, operation: CRUD): String =
+  private def generateBeforeHookType(block: AttributesRoot, operation: CRUD): String =
     operation match {
-      case CRUD.List =>
-        root.readable match {
-          case Readable.This => generateHookType(root, s"input *dao.List${root.name}Input")
-          case Readable.All  => generateHookType(root)
+      case List =>
+        block.readable match {
+          case Readable.This => generateHookType(block, s"input *dao.List${block.name}Input")
+          case Readable.All  => generateHookType(block)
         }
-      case op @ (CRUD.Read | CRUD.Delete | CRUD.Identify) =>
-        generateHookType(root, s"input *dao.${op.toString}${root.name}Input")
-      case op @ (CRUD.Create | CRUD.Update) =>
-        if (root.requestAttributes.isEmpty)
-          generateHookType(root, s"input *dao.${op.toString}${root.name}Input")
+      case op @ (Read | Delete | Identify) =>
+        generateHookType(block, s"input *dao.${op.toString}${block.name}Input")
+      case op @ (Create | Update) =>
+        if (block.requestAttributes.isEmpty)
+          generateHookType(block, s"input *dao.${op.toString}${block.name}Input")
         else
           generateHookType(
-            root,
-            s"req ${op.toString.toLowerCase}${root.name}Request",
-            s"input *dao.${op.toString}${root.name}Input",
+            block,
+            s"req ${op.toString.toLowerCase}${block.name}Request",
+            s"input *dao.${op.toString}${block.name}Input",
           )
 
     }
 
-  private def generateAfterHookType(root: ServiceRoot, operation: CRUD): String =
-    operation match {
-      case CRUD.List =>
-        generateHookType(root, s"${root.decapitalizedName}List *[]dao.${root.name}")
-      case CRUD.Create | CRUD.Read | CRUD.Update | CRUD.Identify =>
-        generateHookType(root, s"${root.decapitalizedName} *dao.${root.name}")
-      case CRUD.Delete =>
-        generateHookType(root)
-    }
+  private def generateAfterHookType(block: AttributesRoot, operation: CRUD): String = operation match {
+    case List =>
+      generateHookType(block, s"${block.decapitalizedName}List *[]dao.${block.name}")
+    case Create | Read | Update | Identify =>
+      generateHookType(block, s"${block.decapitalizedName} *dao.${block.name}")
+    case Delete =>
+      generateHookType(block)
+  }
 
   private[service] def generateHookStruct(root: ServiceRoot): String = {
-    val beforeCreate = root.operations.toSeq.map { op =>
-      s"before${op.toString}Hooks" -> s"[]*${generateBeforeHookType(root, op)}"
+    val beforeCreate = root.blockIterator.map { block =>
+      block.operations.toSeq.map { op =>
+        s"before${op.toString}${hookSuffix(block)}Hooks" -> s"[]*${generateBeforeHookType(block, op)}"
+      }
     }
 
-    val afterCreate = root.operations.toSeq.map { op =>
-      s"after${op.toString}Hooks" -> s"[]*${generateAfterHookType(root, op)}"
+    val afterCreate = root.blockIterator.map { block =>
+      block.operations.toSeq.map { op =>
+        s"after${op.toString}${hookSuffix(block)}Hooks" -> s"[]*${generateAfterHookType(block, op)}"
+      }
     }
 
     mkCode.lines(
       GoCommonHookGenerator.generateHookStructComment,
-      genStruct("Hook", beforeCreate, afterCreate),
+      genStruct("Hook", (beforeCreate ++ afterCreate).toSeq: _*),
     )
   }
 
-  private def generateAddHookComment(action: String, op: CRUD): String = op match {
-    case CRUD.List =>
-      s"// ${action.capitalize}List adds a new hook to be executed ${action.toLowerCase} listing the objects in the datastore"
+  private def generateAddHookComment(action: String, op: CRUD, structName: String): String = op match {
+    case List =>
+      s"// ${action.capitalize}List$structName adds a new hook to be executed ${action.toLowerCase} listing the objects in the datastore"
     case _ =>
-      s"// ${action.capitalize}${op.toString.capitalize} adds a new hook to be executed ${action.toLowerCase} ${presentParticiple(op)} an object in the datastore"
+      s"// ${action.capitalize}${op.toString.capitalize}$structName adds a new hook to be executed ${action.toLowerCase} ${presentParticiple(op)} an object in the datastore"
   }
 
-  private def generateAddHookMethod(action: String, hookType: String, op: CRUD): String =
+  private def generateAddHookMethod(action: String, hookType: String, op: CRUD, structName: String): String =
     mkCode.lines(
-      generateAddHookComment(action, op),
+      generateAddHookComment(action, op, structName),
       genMethod(
         "h",
         "*Hook",
-        s"${action.capitalize}${op.toString.capitalize}",
+        s"${action.capitalize}${op.toString.capitalize}$structName",
         Seq(s"hook $hookType"),
-        Option.empty,
+        None,
         genAssign(
-          genFunctionCall("append", s"h.${action.toLowerCase}${op.toString.capitalize}Hooks", "&hook"),
-          s"h.${action.toLowerCase}${op.toString.capitalize}Hooks",
+          genFunctionCall("append", s"h.${action.toLowerCase}${op.toString.capitalize}${structName}Hooks", "&hook"),
+          s"h.${action.toLowerCase}${op.toString.capitalize}${structName}Hooks",
         ),
       ),
     )
 
   private[service] def generateAddHookMethods(root: ServiceRoot): String = {
-    val beforeHooks = root.operations.toSeq.map { op =>
-      generateAddHookMethod("before", generateBeforeHookType(root, op), op)
+    val beforeHooks = root.blockIterator.flatMap { block =>
+      block.operations.toSeq.map { op =>
+        generateAddHookMethod("before", generateBeforeHookType(block, op), op, hookSuffix(block))
+      }
     }
 
-    val afterHooks = root.operations.toSeq.map { op =>
-      generateAddHookMethod("after", generateAfterHookType(root, op), op)
+    val afterHooks = root.blockIterator.flatMap { block =>
+      block.operations.toSeq.map { op =>
+        generateAddHookMethod("after", generateAfterHookType(block, op), op, hookSuffix(block))
+      }
     }
 
     mkCode.doubleLines(beforeHooks, afterHooks)

--- a/src/main/scala/temple/generate/server/go/service/main/GoServiceMainHandlersGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/main/GoServiceMainHandlersGenerator.scala
@@ -8,6 +8,7 @@ import temple.generate.CRUD._
 import temple.generate.server.AttributesRoot.ServiceRoot
 import temple.generate.server.go.GoHTTPStatus._
 import temple.generate.server.go.common.GoCommonGenerator._
+import temple.generate.server.go.service.GoServiceHookGenerator.hookSuffix
 import temple.generate.server.go.service.main.GoServiceMainCreateHandlerGenerator.generateCreateHandler
 import temple.generate.server.go.service.main.GoServiceMainDeleteHandlerGenerator.generateDeleteHandler
 import temple.generate.server.go.service.main.GoServiceMainIdentifyHandlerGenerator.generateIdentifyHandler
@@ -385,7 +386,7 @@ object GoServiceMainHandlersGenerator {
       }) ++ when(root.projectUsesAuth) { "auth" }
 
     genForLoop(
-      genDeclareAndAssign(s"range env.hook.before${operation.toString}Hooks", "_", "hook"),
+      genDeclareAndAssign(s"range env.hook.before${operation.toString}${hookSuffix(root)}Hooks", "_", "hook"),
       mkCode.lines(
         genDeclareAndAssign(
           genFunctionCall("(*hook)", hookArguments),
@@ -411,7 +412,7 @@ object GoServiceMainHandlersGenerator {
       }) ++ when(root.projectUsesAuth) { "auth" }
 
     genForLoop(
-      genDeclareAndAssign(s"range env.hook.after${operation.toString}Hooks", "_", "hook"),
+      genDeclareAndAssign(s"range env.hook.after${operation.toString}${hookSuffix(root)}Hooks", "_", "hook"),
       mkCode.lines(
         genDeclareAndAssign(
           genFunctionCall("(*hook)", hookArguments),

--- a/src/test/resources/project-builder-complex/complex-user/complex-user.go
+++ b/src/test/resources/project-builder-complex/complex-user/complex-user.go
@@ -59,6 +59,30 @@ type updateComplexUserRequest struct {
 	BlobField          *string  `json:"blobField" validate:"base64,required"`
 }
 
+// createTempleUserRequest contains the client-provided information required to create a single templeUser
+type createTempleUserRequest struct {
+	IntField      *int32   `json:"intField" validate:"required"`
+	DoubleField   *float64 `json:"doubleField" validate:"required"`
+	StringField   *string  `json:"stringField" validate:"required"`
+	BoolField     *bool    `json:"boolField" validate:"required"`
+	DateField     *string  `json:"dateField" validate:"required"`
+	TimeField     *string  `json:"timeField" validate:"required"`
+	DateTimeField *string  `json:"dateTimeField" validate:"required,datetime=2006-01-02T15:04:05.999999999Z07:00"`
+	BlobField     *string  `json:"blobField" validate:"base64,required"`
+}
+
+// updateTempleUserRequest contains the client-provided information required to update a single templeUser
+type updateTempleUserRequest struct {
+	IntField      *int32   `json:"intField" validate:"required"`
+	DoubleField   *float64 `json:"doubleField" validate:"required"`
+	StringField   *string  `json:"stringField" validate:"required"`
+	BoolField     *bool    `json:"boolField" validate:"required"`
+	DateField     *string  `json:"dateField" validate:"required"`
+	TimeField     *string  `json:"timeField" validate:"required"`
+	DateTimeField *string  `json:"dateTimeField" validate:"required,datetime=2006-01-02T15:04:05.999999999Z07:00"`
+	BlobField     *string  `json:"blobField" validate:"base64,required"`
+}
+
 // createComplexUserResponse contains a newly created complexUser to be returned to the client
 type createComplexUserResponse struct {
 	ID                 uuid.UUID `json:"id"`
@@ -108,6 +132,45 @@ type updateComplexUserResponse struct {
 	TimeField          string    `json:"timeField"`
 	DateTimeField      string    `json:"dateTimeField"`
 	BlobField          string    `json:"blobField"`
+}
+
+// createTempleUserResponse contains a newly created templeUser to be returned to the client
+type createTempleUserResponse struct {
+	ID            uuid.UUID `json:"id"`
+	IntField      int32     `json:"intField"`
+	DoubleField   float64   `json:"doubleField"`
+	StringField   string    `json:"stringField"`
+	BoolField     bool      `json:"boolField"`
+	DateField     string    `json:"dateField"`
+	TimeField     string    `json:"timeField"`
+	DateTimeField string    `json:"dateTimeField"`
+	BlobField     string    `json:"blobField"`
+}
+
+// readTempleUserResponse contains a single templeUser to be returned to the client
+type readTempleUserResponse struct {
+	ID            uuid.UUID `json:"id"`
+	IntField      int32     `json:"intField"`
+	DoubleField   float64   `json:"doubleField"`
+	StringField   string    `json:"stringField"`
+	BoolField     bool      `json:"boolField"`
+	DateField     string    `json:"dateField"`
+	TimeField     string    `json:"timeField"`
+	DateTimeField string    `json:"dateTimeField"`
+	BlobField     string    `json:"blobField"`
+}
+
+// updateTempleUserResponse contains a newly updated templeUser to be returned to the client
+type updateTempleUserResponse struct {
+	ID            uuid.UUID `json:"id"`
+	IntField      int32     `json:"intField"`
+	DoubleField   float64   `json:"doubleField"`
+	StringField   string    `json:"stringField"`
+	BoolField     bool      `json:"boolField"`
+	DateField     string    `json:"dateField"`
+	TimeField     string    `json:"timeField"`
+	DateTimeField string    `json:"dateTimeField"`
+	BlobField     string    `json:"blobField"`
 }
 
 // defaultRouter generates a router for this service

--- a/src/test/resources/project-builder-complex/complex-user/hook.go
+++ b/src/test/resources/project-builder-complex/complex-user/hook.go
@@ -14,11 +14,21 @@ type Hook struct {
 	beforeDeleteHooks   []*func(env *env, input *dao.DeleteComplexUserInput, auth *util.Auth) *HookError
 	beforeIdentifyHooks []*func(env *env, input *dao.IdentifyComplexUserInput, auth *util.Auth) *HookError
 
+	beforeCreateTempleUserHooks []*func(env *env, req createTempleUserRequest, input *dao.CreateTempleUserInput, auth *util.Auth) *HookError
+	beforeReadTempleUserHooks   []*func(env *env, input *dao.ReadTempleUserInput, auth *util.Auth) *HookError
+	beforeUpdateTempleUserHooks []*func(env *env, req updateTempleUserRequest, input *dao.UpdateTempleUserInput, auth *util.Auth) *HookError
+	beforeDeleteTempleUserHooks []*func(env *env, input *dao.DeleteTempleUserInput, auth *util.Auth) *HookError
+
 	afterCreateHooks   []*func(env *env, complexUser *dao.ComplexUser, auth *util.Auth) *HookError
 	afterReadHooks     []*func(env *env, complexUser *dao.ComplexUser, auth *util.Auth) *HookError
 	afterUpdateHooks   []*func(env *env, complexUser *dao.ComplexUser, auth *util.Auth) *HookError
 	afterDeleteHooks   []*func(env *env, auth *util.Auth) *HookError
 	afterIdentifyHooks []*func(env *env, complexUser *dao.ComplexUser, auth *util.Auth) *HookError
+
+	afterCreateTempleUserHooks []*func(env *env, templeUser *dao.TempleUser, auth *util.Auth) *HookError
+	afterReadTempleUserHooks   []*func(env *env, templeUser *dao.TempleUser, auth *util.Auth) *HookError
+	afterUpdateTempleUserHooks []*func(env *env, templeUser *dao.TempleUser, auth *util.Auth) *HookError
+	afterDeleteTempleUserHooks []*func(env *env, auth *util.Auth) *HookError
 }
 
 // HookError wraps an existing error with HTTP status code
@@ -56,6 +66,26 @@ func (h *Hook) BeforeIdentify(hook func(env *env, input *dao.IdentifyComplexUser
 	h.beforeIdentifyHooks = append(h.beforeIdentifyHooks, &hook)
 }
 
+// BeforeCreateTempleUser adds a new hook to be executed before creating an object in the datastore
+func (h *Hook) BeforeCreateTempleUser(hook func(env *env, req createTempleUserRequest, input *dao.CreateTempleUserInput, auth *util.Auth) *HookError) {
+	h.beforeCreateTempleUserHooks = append(h.beforeCreateTempleUserHooks, &hook)
+}
+
+// BeforeReadTempleUser adds a new hook to be executed before reading an object in the datastore
+func (h *Hook) BeforeReadTempleUser(hook func(env *env, input *dao.ReadTempleUserInput, auth *util.Auth) *HookError) {
+	h.beforeReadTempleUserHooks = append(h.beforeReadTempleUserHooks, &hook)
+}
+
+// BeforeUpdateTempleUser adds a new hook to be executed before updating an object in the datastore
+func (h *Hook) BeforeUpdateTempleUser(hook func(env *env, req updateTempleUserRequest, input *dao.UpdateTempleUserInput, auth *util.Auth) *HookError) {
+	h.beforeUpdateTempleUserHooks = append(h.beforeUpdateTempleUserHooks, &hook)
+}
+
+// BeforeDeleteTempleUser adds a new hook to be executed before deleting an object in the datastore
+func (h *Hook) BeforeDeleteTempleUser(hook func(env *env, input *dao.DeleteTempleUserInput, auth *util.Auth) *HookError) {
+	h.beforeDeleteTempleUserHooks = append(h.beforeDeleteTempleUserHooks, &hook)
+}
+
 // AfterCreate adds a new hook to be executed after creating an object in the datastore
 func (h *Hook) AfterCreate(hook func(env *env, complexUser *dao.ComplexUser, auth *util.Auth) *HookError) {
 	h.afterCreateHooks = append(h.afterCreateHooks, &hook)
@@ -79,4 +109,24 @@ func (h *Hook) AfterDelete(hook func(env *env, auth *util.Auth) *HookError) {
 // AfterIdentify adds a new hook to be executed after identifying an object in the datastore
 func (h *Hook) AfterIdentify(hook func(env *env, complexUser *dao.ComplexUser, auth *util.Auth) *HookError) {
 	h.afterIdentifyHooks = append(h.afterIdentifyHooks, &hook)
+}
+
+// AfterCreateTempleUser adds a new hook to be executed after creating an object in the datastore
+func (h *Hook) AfterCreateTempleUser(hook func(env *env, templeUser *dao.TempleUser, auth *util.Auth) *HookError) {
+	h.afterCreateTempleUserHooks = append(h.afterCreateTempleUserHooks, &hook)
+}
+
+// AfterReadTempleUser adds a new hook to be executed after reading an object in the datastore
+func (h *Hook) AfterReadTempleUser(hook func(env *env, templeUser *dao.TempleUser, auth *util.Auth) *HookError) {
+	h.afterReadTempleUserHooks = append(h.afterReadTempleUserHooks, &hook)
+}
+
+// AfterUpdateTempleUser adds a new hook to be executed after updating an object in the datastore
+func (h *Hook) AfterUpdateTempleUser(hook func(env *env, templeUser *dao.TempleUser, auth *util.Auth) *HookError) {
+	h.afterUpdateTempleUserHooks = append(h.afterUpdateTempleUserHooks, &hook)
+}
+
+// AfterDeleteTempleUser adds a new hook to be executed after deleting an object in the datastore
+func (h *Hook) AfterDeleteTempleUser(hook func(env *env, auth *util.Auth) *HookError) {
+	h.afterDeleteTempleUserHooks = append(h.afterDeleteTempleUserHooks, &hook)
 }

--- a/src/test/scala/temple/builder/project/ProjectBuilderTest.scala
+++ b/src/test/scala/temple/builder/project/ProjectBuilderTest.scala
@@ -20,7 +20,6 @@ class ProjectBuilderTest extends FlatSpec with FileMatchers {
     val expected = FileUtils.buildFileMap(Paths.get("src/test/resources/project-builder-simple"))
     val actual =
       ProjectBuilder.build(ProjectBuilderTestData.simpleTemplefile, GoLanguageDetail("github.com/squat/and/dab"))
-    temple.utils.FileUtils.outputProject("src/test/resources/project-builder-simple", actual)
     projectFilesShouldMatch(actual, expected)
   }
 

--- a/src/test/scala/temple/builder/project/ProjectBuilderTest.scala
+++ b/src/test/scala/temple/builder/project/ProjectBuilderTest.scala
@@ -20,6 +20,7 @@ class ProjectBuilderTest extends FlatSpec with FileMatchers {
     val expected = FileUtils.buildFileMap(Paths.get("src/test/resources/project-builder-simple"))
     val actual =
       ProjectBuilder.build(ProjectBuilderTestData.simpleTemplefile, GoLanguageDetail("github.com/squat/and/dab"))
+    temple.utils.FileUtils.outputProject("src/test/resources/project-builder-simple", actual)
     projectFilesShouldMatch(actual, expected)
   }
 


### PR DESCRIPTION
After #378 was shouted down, here’s a second attempt at adding hooks for structs. Includes more renaming `root: ServiceRoot` to `block: AttributesRoot`: I’m doing this as I widen the types of each function. I can’t really do that refactor separately, as it means the function now needs to be able to handle StructBlocks too

The fall in codecov is a single line added to keep a match exhaustive: it throws an explanatory error when an impossible case is reached.