### PR TITLE
[Testing] [go-gen] Print go directory structure on Go compilation error

### DIFF
--- a/src/it/scala/temple/containers/GolangSpec.scala
+++ b/src/it/scala/temple/containers/GolangSpec.scala
@@ -5,17 +5,16 @@ import com.whisk.docker.DockerFactory
 import com.whisk.docker.impl.spotify.SpotifyDockerFactory
 import com.whisk.docker.scalatest.DockerTestKit
 import io.circe.syntax._
-import org.scalatest.BeforeAndAfterAll
 import scalaj.http.Http
 import temple.DSL.DSLProcessor
 import temple.DSL.semantics.Analyzer
 import temple.builder.project.ProjectBuilder
 import temple.detail.LanguageDetail.GoLanguageDetail
 import temple.generate.FileSystem._
-import temple.utils.StringUtils
 import temple.utils.MonadUtils.FromEither
+import temple.utils.StringUtils
 
-abstract class GolangSpec extends DockerShell2HttpService(8081) with DockerTestKit with BeforeAndAfterAll {
+abstract class GolangSpec extends DockerShell2HttpService(8081) with DockerTestKit {
   implicit override val dockerFactory: DockerFactory = new SpotifyDockerFactory(DefaultDockerClient.fromEnv().build())
 
   // Validate a given Go file, returning the output of the Go compiler
@@ -25,7 +24,7 @@ abstract class GolangSpec extends DockerShell2HttpService(8081) with DockerTestK
   }
 
   def validateAll(files: Files, entryFile: File): String = {
-    val json = files.map { case (file, contents) => (file.folder + "/" + file.filename, contents) }.asJson.toString()
+    val json = files.asJson.toString()
     Http(golangVerifyUrl)
       .params(Map("src" -> json, "root" -> entryFile.folder, "entrypoint" -> entryFile.filename))
       .timeout(connTimeoutMs = 1000, readTimeoutMs = 30000)

--- a/src/it/scala/temple/containers/GolangSpec.scala
+++ b/src/it/scala/temple/containers/GolangSpec.scala
@@ -35,8 +35,9 @@ abstract class GolangSpec extends DockerShell2HttpService(8081) with DockerTestK
     if (errors.nonEmpty) {
       for ((file, content) <- files.to(SortedMap)) {
         System.err.println(s"$file:")
+        val marginWidth = 6 // width of margin for column numbers: ≤4 for line number, 1 for colon, ≥1 space
         for ((line, i) <- content.linesIterator.zipWithIndex) {
-          System.err.println(s"${i + 1}:".padTo(6, ' ') + line)
+          System.err.println(s"${i + 1}:".padTo(marginWidth, ' ') + line)
         }
       }
     }

--- a/src/it/scala/temple/containers/KubeSpec.scala
+++ b/src/it/scala/temple/containers/KubeSpec.scala
@@ -13,7 +13,7 @@ abstract class KubeSpec extends DockerShell2HttpService(8084) with DockerTestKit
   implicit override val dockerFactory: DockerFactory = new SpotifyDockerFactory(DefaultDockerClient.fromEnv().build())
 
   def validateAll(files: Files, entryFile: File): String = {
-    val json = files.map { case (file, contents) => (file.folder + "/" + file.filename, contents) }.asJson.toString()
+    val json = files.asJson.toString()
     Http(kubeVerifyUrl)
       .params(Map("src" -> json, "root" -> entryFile.folder))
       .timeout(connTimeoutMs = 1000, readTimeoutMs = 30000)

--- a/src/main/scala/temple/generate/FileSystem.scala
+++ b/src/main/scala/temple/generate/FileSystem.scala
@@ -1,5 +1,7 @@
 package temple.generate
 
+import io.circe.KeyEncoder
+
 object FileSystem {
   type Files       = Map[File, FileContent]
   type FileContent = String
@@ -11,4 +13,5 @@ object FileSystem {
 
     override def toString: FileContent = s"$folder/$filename"
   }
+  implicit def fileKeyEncoder: KeyEncoder[File] = _.toString
 }


### PR DESCRIPTION
This makes dealing with Go compilation errors slightly easier. The line numbers are printed with the source code.

Also simplifies the logic for encoding `Files` to JSON, using circe’s KeyEncoder