### PR TITLE
[Go-gen] Add method for getting parent ID from a URL

### DIFF
--- a/src/e2e/resources/simple-temple-expected/simple-temple-test-user/util/util.go
+++ b/src/e2e/resources/simple-temple-expected/simple-temple-test-user/util/util.go
@@ -97,3 +97,13 @@ func ExtractAuthIDFromRequest(headers http.Header) (*Auth, error) {
 
 	return &Auth{uuid}, nil
 }
+
+// ExtractIDFromRequest extracts the parameter provided under parameter parent_id and converts it into a UUID
+func ExtractParentIDFromRequest(requestParams map[string]string) (uuid.UUID, error) {
+	id := requestParams["parent_id"]
+	if len(id) == 0 {
+		return uuid.Nil, errors.New("No Service ID provided")
+	}
+
+	return uuid.Parse(id)
+}

--- a/src/main/resources/go/genFiles/service/util/struct_parent_id_from_request.go.snippet
+++ b/src/main/resources/go/genFiles/service/util/struct_parent_id_from_request.go.snippet
@@ -1,0 +1,9 @@
+// ExtractIDFromRequest extracts the parameter provided under parameter parent_id and converts it into a UUID
+func ExtractParentIDFromRequest(requestParams map[string]string) (uuid.UUID, error) {
+	id := requestParams["parent_id"]
+	if len(id) == 0 {
+		return uuid.Nil, errors.New("No Service ID provided")
+	}
+
+	return uuid.Parse(id)
+}

--- a/src/main/scala/temple/generate/server/AttributesRoot.scala
+++ b/src/main/scala/temple/generate/server/AttributesRoot.scala
@@ -29,6 +29,8 @@ sealed trait AttributesRoot extends AbstractAttributesRoot {
   }
 
   def operations: SortedSet[CRUD] = opQueries.keySet
+
+  @inline final def isStruct: Boolean = parentAttribute.nonEmpty
 }
 
 object AttributesRoot {

--- a/src/main/scala/temple/generate/server/go/service/GoServiceGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/GoServiceGenerator.scala
@@ -107,7 +107,7 @@ object GoServiceGenerator extends ServiceGenerator {
         GoServiceUtilGenerator.generateAuthStruct(),
         GoCommonUtilGenerator.generateGetConfig(),
         GoCommonUtilGenerator.generateCreateErrorJSON(),
-        GoServiceUtilGenerator.generateIDsFromRequest(),
+        GoServiceUtilGenerator.generateIDsFromRequest(root.structs.nonEmpty),
       ),
     ) ++ when(usesComms)(
       File(s"${root.kebabName}/comm", "handler.go") -> mkCode.doubleLines(

--- a/src/main/scala/temple/generate/server/go/service/GoServiceHookGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/GoServiceHookGenerator.scala
@@ -14,7 +14,7 @@ import scala.Option.when
 object GoServiceHookGenerator {
 
   private[service] def hookSuffix(block: AttributesRoot): String =
-    if (block.parentAttribute.nonEmpty) block.name else ""
+    if (block.isStruct) block.name else ""
 
   private[service] def generateImports(root: ServiceRoot): String = {
     val daoImport = s"${doubleQuote(root.module + "/dao")}"

--- a/src/main/scala/temple/generate/server/go/service/GoServiceUtilGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/GoServiceUtilGenerator.scala
@@ -4,6 +4,8 @@ import temple.generate.utils.CodeTerm.{CodeWrap, mkCode}
 import temple.utils.FileUtils
 import temple.utils.StringUtils.doubleQuote
 
+import scala.Option.when
+
 object GoServiceUtilGenerator {
 
   private[service] def generateImports(): String = {
@@ -16,6 +18,11 @@ object GoServiceUtilGenerator {
   private[service] def generateAuthStruct(): String =
     FileUtils.readResources("go/genFiles/service/util/auth_struct.go.snippet").stripLineEnd
 
-  private[service] def generateIDsFromRequest(): String =
-    FileUtils.readResources("go/genFiles/service/util/ids_from_request.go.snippet").stripLineEnd
+  private[service] def generateIDsFromRequest(hasStructs: Boolean): String =
+    mkCode.doubleLines(
+      FileUtils.readResources("go/genFiles/service/util/ids_from_request.go.snippet").stripLineEnd,
+      when(hasStructs) {
+        FileUtils.readResources("go/genFiles/service/util/struct_parent_id_from_request.go.snippet").stripLineEnd
+      },
+    )
 }

--- a/src/main/scala/temple/generate/server/go/service/dao/GoServiceDAOFunctionsGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/dao/GoServiceDAOFunctionsGenerator.scala
@@ -46,7 +46,7 @@ object GoServiceDAOFunctionsGenerator {
         Seq(s"$prefix.${inputName.capitalize}")
       case _ => Seq.empty
     }
-    lazy val parentBlock = when(block.parentAttribute.isDefined) { "input.ParentID" }
+    lazy val parentBlock = when(block.isStruct) { "input.ParentID" }
     lazy val attributes  = block.storedAttributes.map { case name -> _ => s"$prefix.${name.capitalize}" }.toSeq
 
     operation match {

--- a/src/main/scala/temple/generate/server/go/service/dao/GoServiceDAOInputStructsGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/dao/GoServiceDAOInputStructsGenerator.scala
@@ -63,7 +63,7 @@ object GoServiceDAOInputStructsGenerator {
     mkCode.doubleLines(
       // Generate input struct for each operation, except for List when not enumerating by creator
       for (operation <- block.operations.toSeq
-           if operation != List || block.readable == Readable.This || block.parentAttribute.nonEmpty)
+           if operation != List || block.readable == Readable.This || block.isStruct)
         yield generateStruct(block, operation),
     )
 }

--- a/src/main/scala/temple/generate/server/go/service/dao/GoServiceDAOInterfaceGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/dao/GoServiceDAOInterfaceGenerator.scala
@@ -26,9 +26,7 @@ object GoServiceDAOInterfaceGenerator {
       CodeWrap.parens
         .prefix(functionName)
         .list(
-          when(block.readable == Readable.This || operation != List || block.parentAttribute.isDefined) {
-            s"input ${functionName}Input"
-          },
+          when(block.readable == Readable.This || operation != List || block.isStruct) { s"input ${functionName}Input" },
         ),
       generateInterfaceFunctionReturnType(block, operation),
     )

--- a/src/test/resources/project-builder-complex/complex-user/util/util.go
+++ b/src/test/resources/project-builder-complex/complex-user/util/util.go
@@ -97,3 +97,13 @@ func ExtractAuthIDFromRequest(headers http.Header) (*Auth, error) {
 
 	return &Auth{uuid}, nil
 }
+
+// ExtractIDFromRequest extracts the parameter provided under parameter parent_id and converts it into a UUID
+func ExtractParentIDFromRequest(requestParams map[string]string) (uuid.UUID, error) {
+	id := requestParams["parent_id"]
+	if len(id) == 0 {
+		return uuid.Nil, errors.New("No Service ID provided")
+	}
+
+	return uuid.Parse(id)
+}


### PR DESCRIPTION
Generate a method for extracting the parent ID from a URL, and output it whenever a service has structs.

Side effects: add a method for determining whether an AttributesRoot describes a struct