### PR TITLE
[Go-gen] Add metrics entries for structs

### DIFF
--- a/src/e2e/resources/simple-temple-expected/simple-temple-test-user/metric/metric.go
+++ b/src/e2e/resources/simple-temple-expected/simple-temple-test-user/metric/metric.go
@@ -6,11 +6,16 @@ import (
 )
 
 var (
-	RequestList     = "list"
-	RequestCreate   = "create"
-	RequestRead     = "read"
-	RequestUpdate   = "update"
-	RequestIdentify = "identify"
+	RequestList       = "list"
+	RequestCreate     = "create"
+	RequestRead       = "read"
+	RequestUpdate     = "update"
+	RequestIdentify   = "identify"
+	RequestListFred   = "list_fred"
+	RequestCreateFred = "create_fred"
+	RequestReadFred   = "read_fred"
+	RequestUpdateFred = "update_fred"
+	RequestDeleteFred = "delete_fred"
 
 	RequestSuccess = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "simpletempletestuser_request_success_total",

--- a/src/main/scala/temple/generate/server/AttributesRoot.scala
+++ b/src/main/scala/temple/generate/server/AttributesRoot.scala
@@ -21,6 +21,8 @@ sealed trait AttributesRoot extends AbstractAttributesRoot {
   def hasAuthBlock: Boolean
   def projectUsesAuth: Boolean
 
+  def structName: String
+
   def requestAttributes: ListMap[String, AbstractAttribute] = attributes.filter { case (_, attr) => attr.inRequest }
   def storedAttributes: ListMap[String, AbstractAttribute]  = attributes.filter { case (_, attr) => attr.isStored }
 
@@ -74,6 +76,8 @@ object AttributesRoot {
     def blockIterator: Iterator[AttributesRoot] = Iterator(this) ++ structs
 
     override def parentAttribute: None.type = None
+
+    override def structName: String = ""
   }
 
   case class StructRoot(
@@ -88,5 +92,7 @@ object AttributesRoot {
   ) extends AttributesRoot {
     override def createdByAttribute: None.type = None
     override def hasAuthBlock: Boolean         = false
+
+    override def structName: String = name
   }
 }

--- a/src/main/scala/temple/generate/server/ServiceName.scala
+++ b/src/main/scala/temple/generate/server/ServiceName.scala
@@ -9,6 +9,8 @@ trait ServiceName {
   def decapitalizedName: String = StringUtils.decapitalize(name)
 
   def kebabName: String = StringUtils.kebabCase(name)
+
+  def snakeName: String = StringUtils.snakeCase(name)
 }
 
 object ServiceName {

--- a/src/main/scala/temple/generate/server/go/service/GoServiceMetricGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/GoServiceMetricGenerator.scala
@@ -10,9 +10,18 @@ object GoServiceMetricGenerator {
   // Generate global variables for metrics, including string identifiers and metric objects
   private[service] def generateVars(root: ServiceRoot): String = {
     // Assign strings to variables of form `RequestCreate = "create"`
-    val serviceGlobals = CodeUtils.pad(root.operations.toSeq.map { operation =>
-      (s"Request${operation.toString.capitalize}", doubleQuote(operation.toString.toLowerCase))
-    }, separator = " = ")
+    val serviceGlobals = CodeUtils.pad(
+      root.blockIterator.flatMap { block =>
+        block.operations.toSeq.map { operation =>
+          val suffix = if (block.parentAttribute.nonEmpty) "_" + block.snakeName else ""
+          (
+            s"Request${operation.toString.capitalize}${block.structName}",
+            doubleQuote(operation.toString.toLowerCase + suffix),
+          )
+        }
+      }.toSeq,
+      separator = " = ",
+    )
 
     GoCommonMetricGenerator.generateVars(serviceGlobals, root.name)
   }

--- a/src/test/resources/project-builder-complex/complex-user/metric/metric.go
+++ b/src/test/resources/project-builder-complex/complex-user/metric/metric.go
@@ -6,11 +6,15 @@ import (
 )
 
 var (
-	RequestCreate   = "create"
-	RequestRead     = "read"
-	RequestUpdate   = "update"
-	RequestDelete   = "delete"
-	RequestIdentify = "identify"
+	RequestCreate           = "create"
+	RequestRead             = "read"
+	RequestUpdate           = "update"
+	RequestDelete           = "delete"
+	RequestIdentify         = "identify"
+	RequestCreateTempleUser = "create_temple_user"
+	RequestReadTempleUser   = "read_temple_user"
+	RequestUpdateTempleUser = "update_temple_user"
+	RequestDeleteTempleUser = "delete_temple_user"
 
 	RequestSuccess = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "complexuser_request_success_total",


### PR DESCRIPTION
On top of #383, so the diff will shrink shortly. Preview the diff [here](https://github.com/TempleEight/temple/pull/384/commits/dd39215110baaf57be682abe278b50db06293d08), it’s only +39-13.

Add the strings for use with metric services to `metric.go`. Still to do is to add them to the dashboard.