### PR TITLE
[example] Add ImageServer example

### DIFF
--- a/examples/airbnb.temple
+++ b/examples/airbnb.temple
@@ -70,7 +70,7 @@ Review: service {
   tenant: Tenant;
   reservation: Reservation;
   stars: int(5, 0);
-  review: string;
+  message: string;
   #readable(by: all);
   // implicit #writable(by: this) since project has auth
 }

--- a/examples/deliveroo.temple
+++ b/examples/deliveroo.temple
@@ -69,7 +69,7 @@ Dish: service {
     restaurant: Restaurant;
 
     Img: struct {
-        img: data(4M);
+        data: data(4M);
         #enumerable;
     }
     #enumerable;

--- a/examples/image-server.temple
+++ b/examples/image-server.temple
@@ -7,7 +7,7 @@ ImageServer: project {
 }
 
 Image: service {
-    image: data(4M);
+    imageData: data(4M);
     description: string;
     owner: User;
     #enumerable;

--- a/examples/image-server.temple
+++ b/examples/image-server.temple
@@ -1,0 +1,21 @@
+ImageServer: project {
+    #language(go);
+    #database(postgres);
+    #provider(dockerCompose);
+    #metrics(prometheus);
+    #authMethod(email);
+}
+
+Image: service {
+    image: data(4M);
+    description: string;
+    owner: User;
+    #enumerable;
+    #readable(by: all);
+    #writable(by: this);
+}
+
+User: service {
+    displayName: string(30);
+    #auth;
+}

--- a/src/e2e/resources/simple-temple-expected/api/simple-temple-test.openapi.yaml
+++ b/src/e2e/resources/simple-temple-expected/api/simple-temple-test.openapi.yaml
@@ -23,7 +23,7 @@ paths:
                     id:
                       type: string
                       format: uuid
-                    simpleTempleTestUser:
+                    simpleTempleTestLog:
                       type: string
                     email:
                       type: string
@@ -64,7 +64,7 @@ paths:
             schema:
               type: object
               properties:
-                simpleTempleTestUser:
+                simpleTempleTestLog:
                   type: string
                 email:
                   type: string
@@ -101,7 +101,7 @@ paths:
                   id:
                     type: string
                     format: uuid
-                  simpleTempleTestUser:
+                  simpleTempleTestLog:
                     type: string
                   email:
                     type: string
@@ -180,7 +180,7 @@ paths:
                   id:
                     type: string
                     format: uuid
-                  simpleTempleTestUser:
+                  simpleTempleTestLog:
                     type: string
                   email:
                     type: string
@@ -226,7 +226,7 @@ paths:
             schema:
               type: object
               properties:
-                simpleTempleTestUser:
+                simpleTempleTestLog:
                   type: string
                 email:
                   type: string
@@ -263,7 +263,7 @@ paths:
                   id:
                     type: string
                     format: uuid
-                  simpleTempleTestUser:
+                  simpleTempleTestLog:
                     type: string
                   email:
                     type: string

--- a/src/e2e/resources/simple-temple-expected/simple-temple-test-user-db/init.sql
+++ b/src/e2e/resources/simple-temple-expected/simple-temple-test-user-db/init.sql
@@ -1,6 +1,6 @@
 CREATE TABLE simple_temple_test_user (
   id UUID NOT NULL PRIMARY KEY,
-  simple_temple_test_user TEXT NOT NULL,
+  simple_temple_test_log TEXT NOT NULL,
   email VARCHAR(40) CHECK (length(email) >= 5) NOT NULL,
   first_name TEXT NOT NULL,
   last_name TEXT NOT NULL,

--- a/src/e2e/resources/simple-temple-expected/simple-temple-test-user/dao/dao.go
+++ b/src/e2e/resources/simple-temple-expected/simple-temple-test-user/dao/dao.go
@@ -34,17 +34,17 @@ type DAO struct {
 
 // SimpleTempleTestUser encapsulates the object stored in the datastore
 type SimpleTempleTestUser struct {
-	ID                   uuid.UUID
-	SimpleTempleTestUser string
-	Email                string
-	FirstName            string
-	LastName             string
-	CreatedAt            time.Time
-	NumberOfDogs         int32
-	Yeets                bool
-	CurrentBankBalance   float32
-	BirthDate            time.Time
-	BreakfastTime        time.Time
+	ID                  uuid.UUID
+	SimpleTempleTestLog string
+	Email               string
+	FirstName           string
+	LastName            string
+	CreatedAt           time.Time
+	NumberOfDogs        int32
+	Yeets               bool
+	CurrentBankBalance  float32
+	BirthDate           time.Time
+	BreakfastTime       time.Time
 }
 
 // Fred encapsulates the object stored in the datastore
@@ -58,17 +58,17 @@ type Fred struct {
 
 // CreateSimpleTempleTestUserInput encapsulates the information required to create a single simpleTempleTestUser in the datastore
 type CreateSimpleTempleTestUserInput struct {
-	ID                   uuid.UUID
-	SimpleTempleTestUser string
-	Email                string
-	FirstName            string
-	LastName             string
-	CreatedAt            time.Time
-	NumberOfDogs         int32
-	Yeets                bool
-	CurrentBankBalance   float32
-	BirthDate            time.Time
-	BreakfastTime        time.Time
+	ID                  uuid.UUID
+	SimpleTempleTestLog string
+	Email               string
+	FirstName           string
+	LastName            string
+	CreatedAt           time.Time
+	NumberOfDogs        int32
+	Yeets               bool
+	CurrentBankBalance  float32
+	BirthDate           time.Time
+	BreakfastTime       time.Time
 }
 
 // ReadSimpleTempleTestUserInput encapsulates the information required to read a single simpleTempleTestUser in the datastore
@@ -78,17 +78,17 @@ type ReadSimpleTempleTestUserInput struct {
 
 // UpdateSimpleTempleTestUserInput encapsulates the information required to update a single simpleTempleTestUser in the datastore
 type UpdateSimpleTempleTestUserInput struct {
-	ID                   uuid.UUID
-	SimpleTempleTestUser string
-	Email                string
-	FirstName            string
-	LastName             string
-	CreatedAt            time.Time
-	NumberOfDogs         int32
-	Yeets                bool
-	CurrentBankBalance   float32
-	BirthDate            time.Time
-	BreakfastTime        time.Time
+	ID                  uuid.UUID
+	SimpleTempleTestLog string
+	Email               string
+	FirstName           string
+	LastName            string
+	CreatedAt           time.Time
+	NumberOfDogs        int32
+	Yeets               bool
+	CurrentBankBalance  float32
+	BirthDate           time.Time
+	BreakfastTime       time.Time
 }
 
 // IdentifySimpleTempleTestUserInput encapsulates the information required to identify the current simpleTempleTestUser in the datastore
@@ -162,7 +162,7 @@ func executeQuery(db *sql.DB, query string, args ...interface{}) (int64, error) 
 
 // ListSimpleTempleTestUser returns a list containing every simpleTempleTestUser in the datastore
 func (dao *DAO) ListSimpleTempleTestUser() (*[]SimpleTempleTestUser, error) {
-	rows, err := executeQueryWithRowResponses(dao.DB, "SELECT id, simple_temple_test_user, email, first_name, last_name, created_at, number_of_dogs, yeets, current_bank_balance, birth_date, breakfast_time FROM simple_temple_test_user;")
+	rows, err := executeQueryWithRowResponses(dao.DB, "SELECT id, simple_temple_test_log, email, first_name, last_name, created_at, number_of_dogs, yeets, current_bank_balance, birth_date, breakfast_time FROM simple_temple_test_user;")
 	if err != nil {
 		return nil, err
 	}
@@ -170,7 +170,7 @@ func (dao *DAO) ListSimpleTempleTestUser() (*[]SimpleTempleTestUser, error) {
 	simpleTempleTestUserList := make([]SimpleTempleTestUser, 0)
 	for rows.Next() {
 		var simpleTempleTestUser SimpleTempleTestUser
-		err = rows.Scan(&simpleTempleTestUser.ID, &simpleTempleTestUser.SimpleTempleTestUser, &simpleTempleTestUser.Email, &simpleTempleTestUser.FirstName, &simpleTempleTestUser.LastName, &simpleTempleTestUser.CreatedAt, &simpleTempleTestUser.NumberOfDogs, &simpleTempleTestUser.Yeets, &simpleTempleTestUser.CurrentBankBalance, &simpleTempleTestUser.BirthDate, &simpleTempleTestUser.BreakfastTime)
+		err = rows.Scan(&simpleTempleTestUser.ID, &simpleTempleTestUser.SimpleTempleTestLog, &simpleTempleTestUser.Email, &simpleTempleTestUser.FirstName, &simpleTempleTestUser.LastName, &simpleTempleTestUser.CreatedAt, &simpleTempleTestUser.NumberOfDogs, &simpleTempleTestUser.Yeets, &simpleTempleTestUser.CurrentBankBalance, &simpleTempleTestUser.BirthDate, &simpleTempleTestUser.BreakfastTime)
 		if err != nil {
 			return nil, err
 		}
@@ -186,10 +186,10 @@ func (dao *DAO) ListSimpleTempleTestUser() (*[]SimpleTempleTestUser, error) {
 
 // CreateSimpleTempleTestUser creates a new simpleTempleTestUser in the datastore, returning the newly created simpleTempleTestUser
 func (dao *DAO) CreateSimpleTempleTestUser(input CreateSimpleTempleTestUserInput) (*SimpleTempleTestUser, error) {
-	row := executeQueryWithRowResponse(dao.DB, "INSERT INTO simple_temple_test_user (id, simple_temple_test_user, email, first_name, last_name, created_at, number_of_dogs, yeets, current_bank_balance, birth_date, breakfast_time) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) RETURNING id, simple_temple_test_user, email, first_name, last_name, created_at, number_of_dogs, yeets, current_bank_balance, birth_date, breakfast_time;", input.ID, input.SimpleTempleTestUser, input.Email, input.FirstName, input.LastName, input.CreatedAt, input.NumberOfDogs, input.Yeets, input.CurrentBankBalance, input.BirthDate, input.BreakfastTime)
+	row := executeQueryWithRowResponse(dao.DB, "INSERT INTO simple_temple_test_user (id, simple_temple_test_log, email, first_name, last_name, created_at, number_of_dogs, yeets, current_bank_balance, birth_date, breakfast_time) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) RETURNING id, simple_temple_test_log, email, first_name, last_name, created_at, number_of_dogs, yeets, current_bank_balance, birth_date, breakfast_time;", input.ID, input.SimpleTempleTestLog, input.Email, input.FirstName, input.LastName, input.CreatedAt, input.NumberOfDogs, input.Yeets, input.CurrentBankBalance, input.BirthDate, input.BreakfastTime)
 
 	var simpleTempleTestUser SimpleTempleTestUser
-	err := row.Scan(&simpleTempleTestUser.ID, &simpleTempleTestUser.SimpleTempleTestUser, &simpleTempleTestUser.Email, &simpleTempleTestUser.FirstName, &simpleTempleTestUser.LastName, &simpleTempleTestUser.CreatedAt, &simpleTempleTestUser.NumberOfDogs, &simpleTempleTestUser.Yeets, &simpleTempleTestUser.CurrentBankBalance, &simpleTempleTestUser.BirthDate, &simpleTempleTestUser.BreakfastTime)
+	err := row.Scan(&simpleTempleTestUser.ID, &simpleTempleTestUser.SimpleTempleTestLog, &simpleTempleTestUser.Email, &simpleTempleTestUser.FirstName, &simpleTempleTestUser.LastName, &simpleTempleTestUser.CreatedAt, &simpleTempleTestUser.NumberOfDogs, &simpleTempleTestUser.Yeets, &simpleTempleTestUser.CurrentBankBalance, &simpleTempleTestUser.BirthDate, &simpleTempleTestUser.BreakfastTime)
 	if err != nil {
 		// pq specific error
 		if err, ok := err.(*pq.Error); ok {
@@ -206,10 +206,10 @@ func (dao *DAO) CreateSimpleTempleTestUser(input CreateSimpleTempleTestUserInput
 
 // ReadSimpleTempleTestUser returns the simpleTempleTestUser in the datastore for a given ID
 func (dao *DAO) ReadSimpleTempleTestUser(input ReadSimpleTempleTestUserInput) (*SimpleTempleTestUser, error) {
-	row := executeQueryWithRowResponse(dao.DB, "SELECT id, simple_temple_test_user, email, first_name, last_name, created_at, number_of_dogs, yeets, current_bank_balance, birth_date, breakfast_time FROM simple_temple_test_user WHERE id = $1;", input.ID)
+	row := executeQueryWithRowResponse(dao.DB, "SELECT id, simple_temple_test_log, email, first_name, last_name, created_at, number_of_dogs, yeets, current_bank_balance, birth_date, breakfast_time FROM simple_temple_test_user WHERE id = $1;", input.ID)
 
 	var simpleTempleTestUser SimpleTempleTestUser
-	err := row.Scan(&simpleTempleTestUser.ID, &simpleTempleTestUser.SimpleTempleTestUser, &simpleTempleTestUser.Email, &simpleTempleTestUser.FirstName, &simpleTempleTestUser.LastName, &simpleTempleTestUser.CreatedAt, &simpleTempleTestUser.NumberOfDogs, &simpleTempleTestUser.Yeets, &simpleTempleTestUser.CurrentBankBalance, &simpleTempleTestUser.BirthDate, &simpleTempleTestUser.BreakfastTime)
+	err := row.Scan(&simpleTempleTestUser.ID, &simpleTempleTestUser.SimpleTempleTestLog, &simpleTempleTestUser.Email, &simpleTempleTestUser.FirstName, &simpleTempleTestUser.LastName, &simpleTempleTestUser.CreatedAt, &simpleTempleTestUser.NumberOfDogs, &simpleTempleTestUser.Yeets, &simpleTempleTestUser.CurrentBankBalance, &simpleTempleTestUser.BirthDate, &simpleTempleTestUser.BreakfastTime)
 	if err != nil {
 		switch err {
 		case sql.ErrNoRows:
@@ -224,10 +224,10 @@ func (dao *DAO) ReadSimpleTempleTestUser(input ReadSimpleTempleTestUserInput) (*
 
 // UpdateSimpleTempleTestUser updates the simpleTempleTestUser in the datastore for a given ID, returning the newly updated simpleTempleTestUser
 func (dao *DAO) UpdateSimpleTempleTestUser(input UpdateSimpleTempleTestUserInput) (*SimpleTempleTestUser, error) {
-	row := executeQueryWithRowResponse(dao.DB, "UPDATE simple_temple_test_user SET simple_temple_test_user = $1, email = $2, first_name = $3, last_name = $4, created_at = $5, number_of_dogs = $6, yeets = $7, current_bank_balance = $8, birth_date = $9, breakfast_time = $10 WHERE id = $11 RETURNING id, simple_temple_test_user, email, first_name, last_name, created_at, number_of_dogs, yeets, current_bank_balance, birth_date, breakfast_time;", input.SimpleTempleTestUser, input.Email, input.FirstName, input.LastName, input.CreatedAt, input.NumberOfDogs, input.Yeets, input.CurrentBankBalance, input.BirthDate, input.BreakfastTime, input.ID)
+	row := executeQueryWithRowResponse(dao.DB, "UPDATE simple_temple_test_user SET simple_temple_test_log = $1, email = $2, first_name = $3, last_name = $4, created_at = $5, number_of_dogs = $6, yeets = $7, current_bank_balance = $8, birth_date = $9, breakfast_time = $10 WHERE id = $11 RETURNING id, simple_temple_test_log, email, first_name, last_name, created_at, number_of_dogs, yeets, current_bank_balance, birth_date, breakfast_time;", input.SimpleTempleTestLog, input.Email, input.FirstName, input.LastName, input.CreatedAt, input.NumberOfDogs, input.Yeets, input.CurrentBankBalance, input.BirthDate, input.BreakfastTime, input.ID)
 
 	var simpleTempleTestUser SimpleTempleTestUser
-	err := row.Scan(&simpleTempleTestUser.ID, &simpleTempleTestUser.SimpleTempleTestUser, &simpleTempleTestUser.Email, &simpleTempleTestUser.FirstName, &simpleTempleTestUser.LastName, &simpleTempleTestUser.CreatedAt, &simpleTempleTestUser.NumberOfDogs, &simpleTempleTestUser.Yeets, &simpleTempleTestUser.CurrentBankBalance, &simpleTempleTestUser.BirthDate, &simpleTempleTestUser.BreakfastTime)
+	err := row.Scan(&simpleTempleTestUser.ID, &simpleTempleTestUser.SimpleTempleTestLog, &simpleTempleTestUser.Email, &simpleTempleTestUser.FirstName, &simpleTempleTestUser.LastName, &simpleTempleTestUser.CreatedAt, &simpleTempleTestUser.NumberOfDogs, &simpleTempleTestUser.Yeets, &simpleTempleTestUser.CurrentBankBalance, &simpleTempleTestUser.BirthDate, &simpleTempleTestUser.BreakfastTime)
 	if err != nil {
 		// pq specific error
 		if err, ok := err.(*pq.Error); ok {
@@ -249,10 +249,10 @@ func (dao *DAO) UpdateSimpleTempleTestUser(input UpdateSimpleTempleTestUserInput
 
 // IdentifySimpleTempleTestUser returns the simpleTempleTestUser in the datastore for a given ID
 func (dao *DAO) IdentifySimpleTempleTestUser(input IdentifySimpleTempleTestUserInput) (*SimpleTempleTestUser, error) {
-	row := executeQueryWithRowResponse(dao.DB, "SELECT id, simple_temple_test_user, email, first_name, last_name, created_at, number_of_dogs, yeets, current_bank_balance, birth_date, breakfast_time FROM simple_temple_test_user WHERE id = $1;", input.ID)
+	row := executeQueryWithRowResponse(dao.DB, "SELECT id, simple_temple_test_log, email, first_name, last_name, created_at, number_of_dogs, yeets, current_bank_balance, birth_date, breakfast_time FROM simple_temple_test_user WHERE id = $1;", input.ID)
 
 	var simpleTempleTestUser SimpleTempleTestUser
-	err := row.Scan(&simpleTempleTestUser.ID, &simpleTempleTestUser.SimpleTempleTestUser, &simpleTempleTestUser.Email, &simpleTempleTestUser.FirstName, &simpleTempleTestUser.LastName, &simpleTempleTestUser.CreatedAt, &simpleTempleTestUser.NumberOfDogs, &simpleTempleTestUser.Yeets, &simpleTempleTestUser.CurrentBankBalance, &simpleTempleTestUser.BirthDate, &simpleTempleTestUser.BreakfastTime)
+	err := row.Scan(&simpleTempleTestUser.ID, &simpleTempleTestUser.SimpleTempleTestLog, &simpleTempleTestUser.Email, &simpleTempleTestUser.FirstName, &simpleTempleTestUser.LastName, &simpleTempleTestUser.CreatedAt, &simpleTempleTestUser.NumberOfDogs, &simpleTempleTestUser.Yeets, &simpleTempleTestUser.CurrentBankBalance, &simpleTempleTestUser.BirthDate, &simpleTempleTestUser.BreakfastTime)
 	if err != nil {
 		switch err {
 		case sql.ErrNoRows:

--- a/src/e2e/resources/simple-temple-expected/simple-temple-test-user/simple-temple-test-user.go
+++ b/src/e2e/resources/simple-temple-expected/simple-temple-test-user/simple-temple-test-user.go
@@ -28,28 +28,28 @@ type env struct {
 
 // createSimpleTempleTestUserRequest contains the client-provided information required to create a single simpleTempleTestUser
 type createSimpleTempleTestUserRequest struct {
-	SimpleTempleTestUser *string  `json:"simpleTempleTestUser" validate:"required"`
-	Email                *string  `json:"email" validate:"required,gte=5,lte=40"`
-	FirstName            *string  `json:"firstName" validate:"required"`
-	LastName             *string  `json:"lastName" validate:"required"`
-	CreatedAt            *string  `json:"createdAt" validate:"required,datetime=2006-01-02T15:04:05.999999999Z07:00"`
-	NumberOfDogs         *int32   `json:"numberOfDogs" validate:"required"`
-	CurrentBankBalance   *float32 `json:"currentBankBalance" validate:"required,gte=0.0"`
-	BirthDate            *string  `json:"birthDate" validate:"required"`
-	BreakfastTime        *string  `json:"breakfastTime" validate:"required"`
+	SimpleTempleTestLog *string  `json:"simpleTempleTestLog" validate:"required"`
+	Email               *string  `json:"email" validate:"required,gte=5,lte=40"`
+	FirstName           *string  `json:"firstName" validate:"required"`
+	LastName            *string  `json:"lastName" validate:"required"`
+	CreatedAt           *string  `json:"createdAt" validate:"required,datetime=2006-01-02T15:04:05.999999999Z07:00"`
+	NumberOfDogs        *int32   `json:"numberOfDogs" validate:"required"`
+	CurrentBankBalance  *float32 `json:"currentBankBalance" validate:"required,gte=0.0"`
+	BirthDate           *string  `json:"birthDate" validate:"required"`
+	BreakfastTime       *string  `json:"breakfastTime" validate:"required"`
 }
 
 // updateSimpleTempleTestUserRequest contains the client-provided information required to update a single simpleTempleTestUser
 type updateSimpleTempleTestUserRequest struct {
-	SimpleTempleTestUser *string  `json:"simpleTempleTestUser" validate:"required"`
-	Email                *string  `json:"email" validate:"required,gte=5,lte=40"`
-	FirstName            *string  `json:"firstName" validate:"required"`
-	LastName             *string  `json:"lastName" validate:"required"`
-	CreatedAt            *string  `json:"createdAt" validate:"required,datetime=2006-01-02T15:04:05.999999999Z07:00"`
-	NumberOfDogs         *int32   `json:"numberOfDogs" validate:"required"`
-	CurrentBankBalance   *float32 `json:"currentBankBalance" validate:"required,gte=0.0"`
-	BirthDate            *string  `json:"birthDate" validate:"required"`
-	BreakfastTime        *string  `json:"breakfastTime" validate:"required"`
+	SimpleTempleTestLog *string  `json:"simpleTempleTestLog" validate:"required"`
+	Email               *string  `json:"email" validate:"required,gte=5,lte=40"`
+	FirstName           *string  `json:"firstName" validate:"required"`
+	LastName            *string  `json:"lastName" validate:"required"`
+	CreatedAt           *string  `json:"createdAt" validate:"required,datetime=2006-01-02T15:04:05.999999999Z07:00"`
+	NumberOfDogs        *int32   `json:"numberOfDogs" validate:"required"`
+	CurrentBankBalance  *float32 `json:"currentBankBalance" validate:"required,gte=0.0"`
+	BirthDate           *string  `json:"birthDate" validate:"required"`
+	BreakfastTime       *string  `json:"breakfastTime" validate:"required"`
 }
 
 // createFredRequest contains the client-provided information required to create a single fred
@@ -68,16 +68,16 @@ type updateFredRequest struct {
 
 // listSimpleTempleTestUserElement contains a single simpleTempleTestUser list element
 type listSimpleTempleTestUserElement struct {
-	ID                   uuid.UUID `json:"id"`
-	SimpleTempleTestUser string    `json:"simpleTempleTestUser"`
-	Email                string    `json:"email"`
-	FirstName            string    `json:"firstName"`
-	LastName             string    `json:"lastName"`
-	CreatedAt            string    `json:"createdAt"`
-	NumberOfDogs         int32     `json:"numberOfDogs"`
-	CurrentBankBalance   float32   `json:"currentBankBalance"`
-	BirthDate            string    `json:"birthDate"`
-	BreakfastTime        string    `json:"breakfastTime"`
+	ID                  uuid.UUID `json:"id"`
+	SimpleTempleTestLog string    `json:"simpleTempleTestLog"`
+	Email               string    `json:"email"`
+	FirstName           string    `json:"firstName"`
+	LastName            string    `json:"lastName"`
+	CreatedAt           string    `json:"createdAt"`
+	NumberOfDogs        int32     `json:"numberOfDogs"`
+	CurrentBankBalance  float32   `json:"currentBankBalance"`
+	BirthDate           string    `json:"birthDate"`
+	BreakfastTime       string    `json:"breakfastTime"`
 }
 
 // listSimpleTempleTestUserResponse contains a single simpleTempleTestUser list to be returned to the client
@@ -87,44 +87,44 @@ type listSimpleTempleTestUserResponse struct {
 
 // createSimpleTempleTestUserResponse contains a newly created simpleTempleTestUser to be returned to the client
 type createSimpleTempleTestUserResponse struct {
-	ID                   uuid.UUID `json:"id"`
-	SimpleTempleTestUser string    `json:"simpleTempleTestUser"`
-	Email                string    `json:"email"`
-	FirstName            string    `json:"firstName"`
-	LastName             string    `json:"lastName"`
-	CreatedAt            string    `json:"createdAt"`
-	NumberOfDogs         int32     `json:"numberOfDogs"`
-	CurrentBankBalance   float32   `json:"currentBankBalance"`
-	BirthDate            string    `json:"birthDate"`
-	BreakfastTime        string    `json:"breakfastTime"`
+	ID                  uuid.UUID `json:"id"`
+	SimpleTempleTestLog string    `json:"simpleTempleTestLog"`
+	Email               string    `json:"email"`
+	FirstName           string    `json:"firstName"`
+	LastName            string    `json:"lastName"`
+	CreatedAt           string    `json:"createdAt"`
+	NumberOfDogs        int32     `json:"numberOfDogs"`
+	CurrentBankBalance  float32   `json:"currentBankBalance"`
+	BirthDate           string    `json:"birthDate"`
+	BreakfastTime       string    `json:"breakfastTime"`
 }
 
 // readSimpleTempleTestUserResponse contains a single simpleTempleTestUser to be returned to the client
 type readSimpleTempleTestUserResponse struct {
-	ID                   uuid.UUID `json:"id"`
-	SimpleTempleTestUser string    `json:"simpleTempleTestUser"`
-	Email                string    `json:"email"`
-	FirstName            string    `json:"firstName"`
-	LastName             string    `json:"lastName"`
-	CreatedAt            string    `json:"createdAt"`
-	NumberOfDogs         int32     `json:"numberOfDogs"`
-	CurrentBankBalance   float32   `json:"currentBankBalance"`
-	BirthDate            string    `json:"birthDate"`
-	BreakfastTime        string    `json:"breakfastTime"`
+	ID                  uuid.UUID `json:"id"`
+	SimpleTempleTestLog string    `json:"simpleTempleTestLog"`
+	Email               string    `json:"email"`
+	FirstName           string    `json:"firstName"`
+	LastName            string    `json:"lastName"`
+	CreatedAt           string    `json:"createdAt"`
+	NumberOfDogs        int32     `json:"numberOfDogs"`
+	CurrentBankBalance  float32   `json:"currentBankBalance"`
+	BirthDate           string    `json:"birthDate"`
+	BreakfastTime       string    `json:"breakfastTime"`
 }
 
 // updateSimpleTempleTestUserResponse contains a newly updated simpleTempleTestUser to be returned to the client
 type updateSimpleTempleTestUserResponse struct {
-	ID                   uuid.UUID `json:"id"`
-	SimpleTempleTestUser string    `json:"simpleTempleTestUser"`
-	Email                string    `json:"email"`
-	FirstName            string    `json:"firstName"`
-	LastName             string    `json:"lastName"`
-	CreatedAt            string    `json:"createdAt"`
-	NumberOfDogs         int32     `json:"numberOfDogs"`
-	CurrentBankBalance   float32   `json:"currentBankBalance"`
-	BirthDate            string    `json:"birthDate"`
-	BreakfastTime        string    `json:"breakfastTime"`
+	ID                  uuid.UUID `json:"id"`
+	SimpleTempleTestLog string    `json:"simpleTempleTestLog"`
+	Email               string    `json:"email"`
+	FirstName           string    `json:"firstName"`
+	LastName            string    `json:"lastName"`
+	CreatedAt           string    `json:"createdAt"`
+	NumberOfDogs        int32     `json:"numberOfDogs"`
+	CurrentBankBalance  float32   `json:"currentBankBalance"`
+	BirthDate           string    `json:"birthDate"`
+	BreakfastTime       string    `json:"breakfastTime"`
 }
 
 // listFredElement contains a single fred list element
@@ -262,16 +262,16 @@ func (env *env) listSimpleTempleTestUserHandler(w http.ResponseWriter, r *http.R
 
 	for _, simpleTempleTestUser := range *simpleTempleTestUserList {
 		simpleTempleTestUserListResp.SimpleTempleTestUserList = append(simpleTempleTestUserListResp.SimpleTempleTestUserList, listSimpleTempleTestUserElement{
-			ID:                   simpleTempleTestUser.ID,
-			SimpleTempleTestUser: simpleTempleTestUser.SimpleTempleTestUser,
-			Email:                simpleTempleTestUser.Email,
-			FirstName:            simpleTempleTestUser.FirstName,
-			LastName:             simpleTempleTestUser.LastName,
-			CreatedAt:            simpleTempleTestUser.CreatedAt.Format(time.RFC3339),
-			NumberOfDogs:         simpleTempleTestUser.NumberOfDogs,
-			CurrentBankBalance:   simpleTempleTestUser.CurrentBankBalance,
-			BirthDate:            simpleTempleTestUser.BirthDate.Format("2006-01-02"),
-			BreakfastTime:        simpleTempleTestUser.BreakfastTime.Format("15:04:05.999999999"),
+			ID:                  simpleTempleTestUser.ID,
+			SimpleTempleTestLog: simpleTempleTestUser.SimpleTempleTestLog,
+			Email:               simpleTempleTestUser.Email,
+			FirstName:           simpleTempleTestUser.FirstName,
+			LastName:            simpleTempleTestUser.LastName,
+			CreatedAt:           simpleTempleTestUser.CreatedAt.Format(time.RFC3339),
+			NumberOfDogs:        simpleTempleTestUser.NumberOfDogs,
+			CurrentBankBalance:  simpleTempleTestUser.CurrentBankBalance,
+			BirthDate:           simpleTempleTestUser.BirthDate.Format("2006-01-02"),
+			BreakfastTime:       simpleTempleTestUser.BreakfastTime.Format("15:04:05.999999999"),
 		})
 	}
 
@@ -294,7 +294,7 @@ func (env *env) createSimpleTempleTestUserHandler(w http.ResponseWriter, r *http
 		return
 	}
 
-	if req.SimpleTempleTestUser == nil || req.Email == nil || req.FirstName == nil || req.LastName == nil || req.CreatedAt == nil || req.NumberOfDogs == nil || req.CurrentBankBalance == nil || req.BirthDate == nil || req.BreakfastTime == nil {
+	if req.SimpleTempleTestLog == nil || req.Email == nil || req.FirstName == nil || req.LastName == nil || req.CreatedAt == nil || req.NumberOfDogs == nil || req.CurrentBankBalance == nil || req.BirthDate == nil || req.BreakfastTime == nil {
 		respondWithError(w, "Missing request parameter(s)", http.StatusBadRequest, metric.RequestCreate)
 		return
 	}
@@ -324,16 +324,16 @@ func (env *env) createSimpleTempleTestUserHandler(w http.ResponseWriter, r *http
 	}
 
 	input := dao.CreateSimpleTempleTestUserInput{
-		ID:                   auth.ID,
-		SimpleTempleTestUser: *req.SimpleTempleTestUser,
-		Email:                *req.Email,
-		FirstName:            *req.FirstName,
-		LastName:             *req.LastName,
-		CreatedAt:            createdAt,
-		NumberOfDogs:         *req.NumberOfDogs,
-		CurrentBankBalance:   *req.CurrentBankBalance,
-		BirthDate:            birthDate,
-		BreakfastTime:        breakfastTime,
+		ID:                  auth.ID,
+		SimpleTempleTestLog: *req.SimpleTempleTestLog,
+		Email:               *req.Email,
+		FirstName:           *req.FirstName,
+		LastName:            *req.LastName,
+		CreatedAt:           createdAt,
+		NumberOfDogs:        *req.NumberOfDogs,
+		CurrentBankBalance:  *req.CurrentBankBalance,
+		BirthDate:           birthDate,
+		BreakfastTime:       breakfastTime,
 	}
 
 	for _, hook := range env.hook.beforeCreateHooks {
@@ -366,16 +366,16 @@ func (env *env) createSimpleTempleTestUserHandler(w http.ResponseWriter, r *http
 	}
 
 	json.NewEncoder(w).Encode(createSimpleTempleTestUserResponse{
-		ID:                   simpleTempleTestUser.ID,
-		SimpleTempleTestUser: simpleTempleTestUser.SimpleTempleTestUser,
-		Email:                simpleTempleTestUser.Email,
-		FirstName:            simpleTempleTestUser.FirstName,
-		LastName:             simpleTempleTestUser.LastName,
-		CreatedAt:            simpleTempleTestUser.CreatedAt.Format(time.RFC3339),
-		NumberOfDogs:         simpleTempleTestUser.NumberOfDogs,
-		CurrentBankBalance:   simpleTempleTestUser.CurrentBankBalance,
-		BirthDate:            simpleTempleTestUser.BirthDate.Format("2006-01-02"),
-		BreakfastTime:        simpleTempleTestUser.BreakfastTime.Format("15:04:05.999999999"),
+		ID:                  simpleTempleTestUser.ID,
+		SimpleTempleTestLog: simpleTempleTestUser.SimpleTempleTestLog,
+		Email:               simpleTempleTestUser.Email,
+		FirstName:           simpleTempleTestUser.FirstName,
+		LastName:            simpleTempleTestUser.LastName,
+		CreatedAt:           simpleTempleTestUser.CreatedAt.Format(time.RFC3339),
+		NumberOfDogs:        simpleTempleTestUser.NumberOfDogs,
+		CurrentBankBalance:  simpleTempleTestUser.CurrentBankBalance,
+		BirthDate:           simpleTempleTestUser.BirthDate.Format("2006-01-02"),
+		BreakfastTime:       simpleTempleTestUser.BreakfastTime.Format("15:04:05.999999999"),
 	})
 
 	metric.RequestSuccess.WithLabelValues(metric.RequestCreate).Inc()
@@ -428,16 +428,16 @@ func (env *env) readSimpleTempleTestUserHandler(w http.ResponseWriter, r *http.R
 	}
 
 	json.NewEncoder(w).Encode(readSimpleTempleTestUserResponse{
-		ID:                   simpleTempleTestUser.ID,
-		SimpleTempleTestUser: simpleTempleTestUser.SimpleTempleTestUser,
-		Email:                simpleTempleTestUser.Email,
-		FirstName:            simpleTempleTestUser.FirstName,
-		LastName:             simpleTempleTestUser.LastName,
-		CreatedAt:            simpleTempleTestUser.CreatedAt.Format(time.RFC3339),
-		NumberOfDogs:         simpleTempleTestUser.NumberOfDogs,
-		CurrentBankBalance:   simpleTempleTestUser.CurrentBankBalance,
-		BirthDate:            simpleTempleTestUser.BirthDate.Format("2006-01-02"),
-		BreakfastTime:        simpleTempleTestUser.BreakfastTime.Format("15:04:05.999999999"),
+		ID:                  simpleTempleTestUser.ID,
+		SimpleTempleTestLog: simpleTempleTestUser.SimpleTempleTestLog,
+		Email:               simpleTempleTestUser.Email,
+		FirstName:           simpleTempleTestUser.FirstName,
+		LastName:            simpleTempleTestUser.LastName,
+		CreatedAt:           simpleTempleTestUser.CreatedAt.Format(time.RFC3339),
+		NumberOfDogs:        simpleTempleTestUser.NumberOfDogs,
+		CurrentBankBalance:  simpleTempleTestUser.CurrentBankBalance,
+		BirthDate:           simpleTempleTestUser.BirthDate.Format("2006-01-02"),
+		BreakfastTime:       simpleTempleTestUser.BreakfastTime.Format("15:04:05.999999999"),
 	})
 
 	metric.RequestSuccess.WithLabelValues(metric.RequestRead).Inc()
@@ -468,7 +468,7 @@ func (env *env) updateSimpleTempleTestUserHandler(w http.ResponseWriter, r *http
 		return
 	}
 
-	if req.SimpleTempleTestUser == nil || req.Email == nil || req.FirstName == nil || req.LastName == nil || req.CreatedAt == nil || req.NumberOfDogs == nil || req.CurrentBankBalance == nil || req.BirthDate == nil || req.BreakfastTime == nil {
+	if req.SimpleTempleTestLog == nil || req.Email == nil || req.FirstName == nil || req.LastName == nil || req.CreatedAt == nil || req.NumberOfDogs == nil || req.CurrentBankBalance == nil || req.BirthDate == nil || req.BreakfastTime == nil {
 		respondWithError(w, "Missing request parameter(s)", http.StatusBadRequest, metric.RequestUpdate)
 		return
 	}
@@ -498,16 +498,16 @@ func (env *env) updateSimpleTempleTestUserHandler(w http.ResponseWriter, r *http
 	}
 
 	input := dao.UpdateSimpleTempleTestUserInput{
-		ID:                   simpleTempleTestUserID,
-		SimpleTempleTestUser: *req.SimpleTempleTestUser,
-		Email:                *req.Email,
-		FirstName:            *req.FirstName,
-		LastName:             *req.LastName,
-		CreatedAt:            createdAt,
-		NumberOfDogs:         *req.NumberOfDogs,
-		CurrentBankBalance:   *req.CurrentBankBalance,
-		BirthDate:            birthDate,
-		BreakfastTime:        breakfastTime,
+		ID:                  simpleTempleTestUserID,
+		SimpleTempleTestLog: *req.SimpleTempleTestLog,
+		Email:               *req.Email,
+		FirstName:           *req.FirstName,
+		LastName:            *req.LastName,
+		CreatedAt:           createdAt,
+		NumberOfDogs:        *req.NumberOfDogs,
+		CurrentBankBalance:  *req.CurrentBankBalance,
+		BirthDate:           birthDate,
+		BreakfastTime:       breakfastTime,
 	}
 
 	for _, hook := range env.hook.beforeUpdateHooks {
@@ -542,16 +542,16 @@ func (env *env) updateSimpleTempleTestUserHandler(w http.ResponseWriter, r *http
 	}
 
 	json.NewEncoder(w).Encode(updateSimpleTempleTestUserResponse{
-		ID:                   simpleTempleTestUser.ID,
-		SimpleTempleTestUser: simpleTempleTestUser.SimpleTempleTestUser,
-		Email:                simpleTempleTestUser.Email,
-		FirstName:            simpleTempleTestUser.FirstName,
-		LastName:             simpleTempleTestUser.LastName,
-		CreatedAt:            simpleTempleTestUser.CreatedAt.Format(time.RFC3339),
-		NumberOfDogs:         simpleTempleTestUser.NumberOfDogs,
-		CurrentBankBalance:   simpleTempleTestUser.CurrentBankBalance,
-		BirthDate:            simpleTempleTestUser.BirthDate.Format("2006-01-02"),
-		BreakfastTime:        simpleTempleTestUser.BreakfastTime.Format("15:04:05.999999999"),
+		ID:                  simpleTempleTestUser.ID,
+		SimpleTempleTestLog: simpleTempleTestUser.SimpleTempleTestLog,
+		Email:               simpleTempleTestUser.Email,
+		FirstName:           simpleTempleTestUser.FirstName,
+		LastName:            simpleTempleTestUser.LastName,
+		CreatedAt:           simpleTempleTestUser.CreatedAt.Format(time.RFC3339),
+		NumberOfDogs:        simpleTempleTestUser.NumberOfDogs,
+		CurrentBankBalance:  simpleTempleTestUser.CurrentBankBalance,
+		BirthDate:           simpleTempleTestUser.BirthDate.Format("2006-01-02"),
+		BreakfastTime:       simpleTempleTestUser.BreakfastTime.Format("15:04:05.999999999"),
 	})
 
 	metric.RequestSuccess.WithLabelValues(metric.RequestUpdate).Inc()

--- a/src/e2e/scala/temple/DSL/ParserE2ETest.scala
+++ b/src/e2e/scala/temple/DSL/ParserE2ETest.scala
@@ -32,17 +32,17 @@ class ParserE2ETest extends FlatSpec with Matchers with DSLParserMatchers {
       services = Map(
         "SimpleTempleTestUser" -> ServiceBlock(
           attributes = ListMap(
-            "id"                   -> IDAttribute,
-            "simpleTempleTestUser" -> Attribute(StringType()),
-            "email"                -> Attribute(StringType(Some(40), Some(5))),
-            "firstName"            -> Attribute(StringType()),
-            "lastName"             -> Attribute(StringType()),
-            "createdAt"            -> Attribute(DateTimeType),
-            "numberOfDogs"         -> Attribute(IntType()),
-            "yeets"                -> Attribute(BoolType, Some(Server), Set(Unique)),
-            "currentBankBalance"   -> Attribute(FloatType(min = Some(0.0), precision = 2)),
-            "birthDate"            -> Attribute(DateType),
-            "breakfastTime"        -> Attribute(TimeType),
+            "id"                  -> IDAttribute,
+            "simpleTempleTestLog" -> Attribute(StringType()),
+            "email"               -> Attribute(StringType(Some(40), Some(5))),
+            "firstName"           -> Attribute(StringType()),
+            "lastName"            -> Attribute(StringType()),
+            "createdAt"           -> Attribute(DateTimeType),
+            "numberOfDogs"        -> Attribute(IntType()),
+            "yeets"               -> Attribute(BoolType, Some(Server), Set(Unique)),
+            "currentBankBalance"  -> Attribute(FloatType(min = Some(0.0), precision = 2)),
+            "birthDate"           -> Attribute(DateType),
+            "breakfastTime"       -> Attribute(TimeType),
           ),
           metadata = Seq(
             ServiceEnumerable,

--- a/src/main/scala/temple/DSL/semantics/NameClashes.scala
+++ b/src/main/scala/temple/DSL/semantics/NameClashes.scala
@@ -234,7 +234,7 @@ object NameClashes {
   case class NameValidator private (private val validators: Iterable[String => Boolean]) {
 
     def isValid(word: String): Boolean = validators.forall { validator =>
-      val normalized = NameValidator.normalize(word)
+      val normalized = normalize(word)
       validator(normalized)
     }
 
@@ -242,8 +242,9 @@ object NameClashes {
     def &(that: NameValidator): NameValidator = NameValidator(this.validators ++ that.validators)
   }
 
+  def normalize(string: String): String = string.toLowerCase.replaceAll("[^a-z0-9]", "")
+
   private[NameClashes] object NameValidator {
-    private def normalize(string: String): String = string.toLowerCase.replaceAll("[^a-z0-9]", "")
 
     // Combine many validators
     def combine(validators: IterableOnce[NameValidator]): NameValidator =

--- a/src/main/scala/temple/DSL/semantics/NameClashes.scala
+++ b/src/main/scala/temple/DSL/semantics/NameClashes.scala
@@ -124,7 +124,8 @@ object NameClashes {
   def goServiceValidator: NameValidator =
     templeGoNameValidator & goGlobalsValidator & goKeywordValidator & templeServiceNameValidator & templeGoServiceValidator
 
-  val goAttributeValidator: NameValidator = goKeywordValidator & templeAttributeNameValidator
+  val goAttributeValidator: NameValidator =
+    goGlobalsValidator & goKeywordValidator & templeAttributeNameValidator & templeGoServiceValidator
 
   // https://www.postgresql.org/docs/10/sql-keywords-appendix.html
   // only those marked as "reserved"/"reserved (can be function or type)" in Postgres

--- a/src/main/scala/temple/DSL/semantics/Validator.scala
+++ b/src/main/scala/temple/DSL/semantics/Validator.scala
@@ -26,6 +26,7 @@ private class Validator private (templefile: Templefile) {
 
   private def validateAttributes(
     block: AttributeBlock[_],
+    blockName: String,
     serviceName: String,
     context: SemanticContext,
   ): Map[String, AbstractAttribute] = {
@@ -53,11 +54,15 @@ private class Validator private (templefile: Templefile) {
         val database = block.lookupMetadata[Metadata.Database].getOrElse(ProjectConfig.defaultDatabase)
         val language = block.lookupMetadata[Metadata.ServiceLanguage].getOrElse(ProjectConfig.defaultLanguage)
 
+        if (normalize(attributeName) == normalize(blockName)) {
+          errors += context.errorMessage("Illegal attribute with same name as service")
+        }
+
         // takenNames includes this attribute’s names, so remove it
         val newName = constructUniqueName(
           attributeName,
           templefile.projectName,
-          takenNames.toSet - attributeName,
+          takenNames.toSet + serviceName - attributeName,
         )(
           validators = Seq(
             Some(templeAttributeNameValidator),
@@ -77,10 +82,9 @@ private class Validator private (templefile: Templefile) {
     * languages that are generated from the block), and entering it into the map of renamings. Note that an entry is
     * always inserted into this block, even if the same name is kept. */
   private def renameBlock(name: String, block: AttributeBlock[_]): Unit = {
-    val database      = block.lookupMetadata[Metadata.Database].getOrElse(ProjectConfig.defaultDatabase)
-    val language      = block.lookupMetadata[Metadata.ServiceLanguage].getOrElse(ProjectConfig.defaultLanguage)
-    val reservedNames = allGlobalNames ++ block.attributes.keySet - name
-    val newServiceName = constructUniqueName(name, templefile.projectName, reservedNames)(
+    val database = block.lookupMetadata[Metadata.Database].getOrElse(ProjectConfig.defaultDatabase)
+    val language = block.lookupMetadata[Metadata.ServiceLanguage].getOrElse(ProjectConfig.defaultLanguage)
+    val newServiceName = constructUniqueName(name, templefile.projectName, allGlobalNames - name)(
       validators = Seq(
         Some(templeServiceNameValidator),
         when(database == Metadata.Database.Postgres) { postgresValidator },
@@ -96,7 +100,7 @@ private class Validator private (templefile: Templefile) {
     val newStructs = service.structs.transform {
       case (name, struct) => validateStruct(name, struct, serviceName, context :+ name)
     }
-    val newAttributes = validateAttributes(service, serviceName, context)
+    val newAttributes = validateAttributes(service, serviceName, serviceName, context)
     val newMetadata   = validateStructMetadata(service.metadata, newAttributes, context)
 
     ServiceBlock(newAttributes, newMetadata, newStructs)
@@ -110,7 +114,7 @@ private class Validator private (templefile: Templefile) {
   ): StructBlock = {
     renameBlock(structName, struct)
 
-    val newAttributes = validateAttributes(struct, serviceName, context)
+    val newAttributes = validateAttributes(struct, structName, serviceName, context)
     val newMetadata   = validateStructMetadata(struct.metadata, newAttributes, context)
 
     StructBlock(newAttributes, newMetadata)

--- a/src/main/scala/temple/DSL/semantics/Validator.scala
+++ b/src/main/scala/temple/DSL/semantics/Validator.scala
@@ -77,9 +77,10 @@ private class Validator private (templefile: Templefile) {
     * languages that are generated from the block), and entering it into the map of renamings. Note that an entry is
     * always inserted into this block, even if the same name is kept. */
   private def renameBlock(name: String, block: AttributeBlock[_]): Unit = {
-    val database = block.lookupMetadata[Metadata.Database].getOrElse(ProjectConfig.defaultDatabase)
-    val language = block.lookupMetadata[Metadata.ServiceLanguage].getOrElse(ProjectConfig.defaultLanguage)
-    val newServiceName = constructUniqueName(name, templefile.projectName, allGlobalNames - name)(
+    val database      = block.lookupMetadata[Metadata.Database].getOrElse(ProjectConfig.defaultDatabase)
+    val language      = block.lookupMetadata[Metadata.ServiceLanguage].getOrElse(ProjectConfig.defaultLanguage)
+    val reservedNames = allGlobalNames ++ block.attributes.keySet - name
+    val newServiceName = constructUniqueName(name, templefile.projectName, reservedNames)(
       validators = Seq(
         Some(templeServiceNameValidator),
         when(database == Metadata.Database.Postgres) { postgresValidator },

--- a/src/test/scala/temple/DSL/parser/DSLParserTest.scala
+++ b/src/test/scala/temple/DSL/parser/DSLParserTest.scala
@@ -65,7 +65,7 @@ class DSLParserTest extends FlatSpec with DSLParserMatchers {
         "User",
         "service",
         Seq(
-          Attribute("user", AttributeType.Primitive("string")),
+          Attribute("log", AttributeType.Primitive("string")),
           Attribute("email", AttributeType.Primitive("string", Args(Seq(Arg.IntArg(40), Arg.IntArg(5))))),
           Attribute("firstName", AttributeType.Primitive("string")),
           Attribute("lastName", AttributeType.Primitive("string")),

--- a/src/test/scala/temple/DSL/semantics/ValidatorTest.scala
+++ b/src/test/scala/temple/DSL/semantics/ValidatorTest.scala
@@ -289,6 +289,29 @@ class ValidatorTest extends FlatSpec with Matchers {
     ) shouldBe Set("Invalid foreign key Baz in baz, in Foo", "Invalid foreign key Baz in baz, in Quux, in Foo")
   }
 
+  it should "fail when attribute names are identical to their service name" in {
+    validationErrors(
+      Templefile(
+        "MyProject",
+        services = Map(
+          "Foo" -> ServiceBlock(
+            attributes = Map(
+              "foo" -> Attribute(IntType()),
+            ),
+            structs = Map(
+              "Bar" -> StructBlock(
+                attributes = Map("bar" -> Attribute(StringType())),
+              ),
+            ),
+          ),
+        ),
+      ),
+    ) shouldBe Set(
+      "Illegal attribute with same name as service in Bar, in Foo",
+      "Illegal attribute with same name as service in Foo",
+    )
+  }
+
   it should "enforce the existence of an auth block when other dependent metadata are used" in {
     validationErrors(
       Templefile(
@@ -391,7 +414,7 @@ class ValidatorTest extends FlatSpec with Matchers {
       Templefile(
         "MyProject",
         services = Map(
-          "Box" -> ServiceBlock(Map("box" -> Attribute(ForeignKey("Box")))),
+          "Box" -> ServiceBlock(Map("otherBox" -> Attribute(ForeignKey("Box")))),
         ),
       ),
     ) shouldBe Set("Cycle(s) were detected in foreign keys, between elements: { Box }")

--- a/src/test/scala/temple/testfiles/simple-dc.temple
+++ b/src/test/scala/temple/testfiles/simple-dc.temple
@@ -5,7 +5,7 @@ SimpleTempleTest: project {
 }
 
 User: service {
-  user: string;
+  log: string;
   email: string(40,5);
   firstName: string;
   lastName: string;

--- a/src/test/scala/temple/testfiles/simple.temple
+++ b/src/test/scala/temple/testfiles/simple.temple
@@ -5,7 +5,7 @@ SimpleTempleTest: project {
 }
 
 User: service {
-  user: string;
+  log: string;
   email: string(40,5);
   firstName: string;
   lastName: string;


### PR DESCRIPTION
This is going to break because an attribute (of type data or date/time) having the same name as its class will result in a name clash (source: https://github.com/TempleEight/temple/blob/develop/src/main/scala/temple/generate/server/go/service/main/GoServiceMainCreateHandlerGenerator.scala#L90). I’d be interested in people’s solutions to this: ban all attributes from having the same name as their services, rename the new struct in the create block from `image` to `newImage`, or ban specifically this case?

I raise this because the Deliveroo example has the equivalent of this in a struct, which my generation has raised.

Update: now naming an attribute the same as its block is a validation error. This triggered a naming error in the simple.temple, which has been updated at the cost of many lines.

Also spotted was another issue based on the original incorrect assumption: attributes may not be named the same as imports etc, as they are sometimes rendered as local variables. This has been fixed too, with the changes to NameClashes

_Previous solution: rename the parent in the case of a clash. This means the service is now called ImageServerImage, and the attribute remains as before._ (issue: the API should not change that much when children are added.)