### PR TITLE
[Validator] Remove fruitless struct access metadata checks

### DIFF
--- a/src/main/scala/temple/DSL/semantics/ServiceRenamer.scala
+++ b/src/main/scala/temple/DSL/semantics/ServiceRenamer.scala
@@ -47,10 +47,8 @@ case class ServiceRenamer(renamingMap: Map[String, String]) {
 
   def renameStructMetadata(metadata: Metadata.StructMetadata): Metadata.StructMetadata = metadata match {
     // currently `identity`, as no metadata contains a service name
-    case readable: Metadata.Readable => readable
-    case writable: Metadata.Writable => writable
-    case omit: Metadata.Omit         => omit
-    case Metadata.ServiceEnumerable  => Metadata.ServiceEnumerable
+    case omit: Metadata.Omit        => omit
+    case Metadata.ServiceEnumerable => Metadata.ServiceEnumerable
   }
 
   private def renameStructBlock(block: StructBlock): StructBlock =


### PR DESCRIPTION
Fixes a warning introduced in #347, by removing `#readable`/`#writable` from structs but not from a pattern match