### PR TITLE
[docker] Add Dockerfile for installation on Windows/Linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM java:8-jdk-alpine
+WORKDIR /usr/bin
+
+RUN apk add --update ca-certificates openssl && update-ca-certificates
+RUN wget -O /usr/bin/temple https://github.com/TempleEight/temple/releases/download/v0.1.0/temple-latest
+RUN chmod +x /usr/bin/temple
+
+CMD ["temple", "--version"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jdk-alpine
+FROM openjdk:13-alpine
 WORKDIR /usr/bin
 
 RUN apk add --update ca-certificates openssl && update-ca-certificates


### PR DESCRIPTION
Since some of our testers might not have a Mac, nor use `brew`, so I thought the easiest solution would be to create a Docker image of the Temple binary.

This does exactly that - we grab the release from GitHub, make it executable, and run `--version` by default.

This means that as a user, you can just do the following:
```bash
❯❯❯ docker run templeeight/temple:0.1
temple 0.1 (c) 2020 TempleEight
```

Actually performing generation is a little complex, since you have to create a bind mount into the container:
```bash
❯❯❯ docker run -v /Users/jay/Desktop/project:/home/project:rw  templeeight/temple:0.1 temple generate -o /home/project/generated /home/project/airbnb.temple
Generated project in /home/project/generated
```
We can create a new release on Docker Hub by doing the following:
```bash
❯❯❯ docker build -t temple .
❯❯❯ docker tag temple:latest templeeight/temple:0.1
❯❯❯ docker push templeeight/temple:0.1
```

This version should be available now at https://hub.docker.com/repository/registry-1.docker.io/templeeight/temple

I'll add this all to the README and Documentation next 😄 

I can't test how well `temple test` works in this setting, because it's not actually released yet. I'm envisaging that it might have a few issues with dependencies etc., but we can fix them when that gets released. 