### PR TITLE
Fix unique implementation

### DIFF
--- a/src/e2e/resources/simple-temple-expected/simple-temple-test-user/dao/dao.go
+++ b/src/e2e/resources/simple-temple-expected/simple-temple-test-user/dao/dao.go
@@ -194,7 +194,7 @@ func (dao *DAO) CreateSimpleTempleTestUser(input CreateSimpleTempleTestUserInput
 		// pq specific error
 		if err, ok := err.(*pq.Error); ok {
 			if err.Code.Name() == psqlUniqueViolation {
-				return nil, ErrDuplicateSimpleTempleTestUser
+				return nil, ErrDuplicateSimpleTempleTestUser("")
 			}
 		}
 
@@ -232,7 +232,7 @@ func (dao *DAO) UpdateSimpleTempleTestUser(input UpdateSimpleTempleTestUserInput
 		// pq specific error
 		if err, ok := err.(*pq.Error); ok {
 			if err.Code.Name() == psqlUniqueViolation {
-				return nil, ErrDuplicateSimpleTempleTestUser
+				return nil, ErrDuplicateSimpleTempleTestUser("")
 			}
 		}
 

--- a/src/e2e/resources/simple-temple-expected/simple-temple-test-user/dao/dao.go
+++ b/src/e2e/resources/simple-temple-expected/simple-temple-test-user/dao/dao.go
@@ -194,7 +194,7 @@ func (dao *DAO) CreateSimpleTempleTestUser(input CreateSimpleTempleTestUserInput
 		// pq specific error
 		if err, ok := err.(*pq.Error); ok {
 			if err.Code.Name() == psqlUniqueViolation {
-				return nil, ErrDuplicateSimpleTempleTestUser("")
+				return nil, ErrDuplicateSimpleTempleTestUser(err.Detail)
 			}
 		}
 
@@ -232,7 +232,7 @@ func (dao *DAO) UpdateSimpleTempleTestUser(input UpdateSimpleTempleTestUserInput
 		// pq specific error
 		if err, ok := err.(*pq.Error); ok {
 			if err.Code.Name() == psqlUniqueViolation {
-				return nil, ErrDuplicateSimpleTempleTestUser("")
+				return nil, ErrDuplicateSimpleTempleTestUser(err.Detail)
 			}
 		}
 

--- a/src/e2e/resources/simple-temple-expected/simple-temple-test-user/dao/errors.go
+++ b/src/e2e/resources/simple-temple-expected/simple-temple-test-user/dao/errors.go
@@ -13,7 +13,7 @@ func (e ErrSimpleTempleTestUserNotFound) Error() string {
 type ErrDuplicateSimpleTempleTestUser string
 
 func (e ErrDuplicateSimpleTempleTestUser) Error() string {
-	return "Duplicate SimpleTempleTestUser found"
+	return string(e)
 }
 
 // ErrFredNotFound is returned when a fred for the provided ID was not found

--- a/src/e2e/resources/simple-temple-expected/simple-temple-test-user/dao/errors.go
+++ b/src/e2e/resources/simple-temple-expected/simple-temple-test-user/dao/errors.go
@@ -9,6 +9,13 @@ func (e ErrSimpleTempleTestUserNotFound) Error() string {
 	return fmt.Sprintf("simpleTempleTestUser not found with ID %s", string(e))
 }
 
+// ErrDuplicateSimpleTempleTestUserNotFound is returned when a simpleTempleTestUser already exists for some unique constraint
+type ErrDuplicateSimpleTempleTestUser string
+
+func (e ErrDuplicateSimpleTempleTestUser) Error() string {
+	return "Duplicate SimpleTempleTestUser found"
+}
+
 // ErrFredNotFound is returned when a fred for the provided ID was not found
 type ErrFredNotFound string
 

--- a/src/e2e/resources/simple-temple-expected/simple-temple-test-user/simple-temple-test-user.go
+++ b/src/e2e/resources/simple-temple-expected/simple-temple-test-user/simple-temple-test-user.go
@@ -348,7 +348,12 @@ func (env *env) createSimpleTempleTestUserHandler(w http.ResponseWriter, r *http
 	simpleTempleTestUser, err := env.dao.CreateSimpleTempleTestUser(input)
 	timer.ObserveDuration()
 	if err != nil {
-		respondWithError(w, fmt.Sprintf("Something went wrong: %s", err.Error()), http.StatusInternalServerError, metric.RequestCreate)
+		switch err.(type) {
+		case dao.ErrDuplicateSimpleTempleTestUser:
+			respondWithError(w, err.Error(), http.StatusForbidden, metric.RequestCreate)
+		default:
+			respondWithError(w, fmt.Sprintf("Something went wrong: %s", err.Error()), http.StatusInternalServerError, metric.RequestCreate)
+		}
 		return
 	}
 
@@ -520,6 +525,8 @@ func (env *env) updateSimpleTempleTestUserHandler(w http.ResponseWriter, r *http
 		switch err.(type) {
 		case dao.ErrSimpleTempleTestUserNotFound:
 			respondWithError(w, err.Error(), http.StatusNotFound, metric.RequestUpdate)
+		case dao.ErrDuplicateSimpleTempleTestUser:
+			respondWithError(w, err.Error(), http.StatusForbidden, metric.RequestUpdate)
 		default:
 			respondWithError(w, fmt.Sprintf("Something went wrong: %s", err.Error()), http.StatusInternalServerError, metric.RequestUpdate)
 		}

--- a/src/main/scala/temple/generate/server/AttributesRoot.scala
+++ b/src/main/scala/temple/generate/server/AttributesRoot.scala
@@ -2,6 +2,7 @@ package temple.generate.server
 
 import temple.ast.AbstractAttribute
 import temple.ast.AbstractAttribute.Attribute
+import temple.ast.Annotation.ValueAnnotation
 import temple.ast.Metadata.{Database, Metrics, Readable, Writable}
 import temple.generate.CRUD.CRUD
 import temple.generate.server.AbstractAttributesRoot.AbstractServiceRoot
@@ -33,6 +34,10 @@ sealed trait AttributesRoot extends AbstractAttributesRoot {
   def operations: SortedSet[CRUD] = opQueries.keySet
 
   @inline final def isStruct: Boolean = parentAttribute.nonEmpty
+
+  // Determine if any attribute in this block contains a given annotation
+  def contains(annotation: ValueAnnotation): Boolean =
+    attributes.values.map(_.valueAnnotations).exists(_.contains(annotation))
 }
 
 object AttributesRoot {

--- a/src/main/scala/temple/generate/server/go/GoHTTPStatus.scala
+++ b/src/main/scala/temple/generate/server/go/GoHTTPStatus.scala
@@ -2,5 +2,5 @@ package temple.generate.server.go
 
 object GoHTTPStatus extends Enumeration {
   type GoHTTPStatus = Value
-  val StatusBadRequest, StatusUnauthorized, StatusNotFound, StatusInternalServerError = Value
+  val StatusBadRequest, StatusUnauthorized, StatusForbidden, StatusNotFound, StatusInternalServerError = Value
 }

--- a/src/main/scala/temple/generate/server/go/service/GoServiceGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/GoServiceGenerator.scala
@@ -1,5 +1,6 @@
 package temple.generate.server.go.service
 
+import temple.ast.Annotation.Unique
 import temple.ast.AttributeType
 import temple.ast.Metadata.{Readable, Writable}
 import temple.generate.CRUD
@@ -90,6 +91,7 @@ object GoServiceGenerator extends ServiceGenerator {
         root.blockIterator.map { block =>
           GoServiceDAOInputStructsGenerator.generateStructs(block)
         },
+        when(root.contains(Unique)) { GoServiceDAOGenerator.generateUniqueConstant() },
         GoCommonDAOGenerator.generateInit(),
         GoServiceDAOGenerator.generateQueryFunctions(root.blockIterator.flatMap(_.operations).toSet),
         root.blockIterator.map { block =>

--- a/src/main/scala/temple/generate/server/go/service/dao/GoServiceDAOFunctionsGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/dao/GoServiceDAOFunctionsGenerator.scala
@@ -137,7 +137,7 @@ object GoServiceDAOFunctionsGenerator {
         "err, ok := err.(*pq.Error); ok",
         genIf(
           "err.Code.Name() == psqlUniqueViolation",
-          genReturn("nil", s"ErrDuplicate${block.name}(${doubleQuote("")})"),
+          genReturn("nil", s"ErrDuplicate${block.name}(err.Detail)"),
         ),
       ),
     )

--- a/src/main/scala/temple/generate/server/go/service/dao/GoServiceDAOFunctionsGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/dao/GoServiceDAOFunctionsGenerator.scala
@@ -1,8 +1,9 @@
 package temple.generate.server.go.service.dao
 
+import temple.ast.Annotation.Unique
 import temple.ast.Metadata.Readable
 import temple.generate.CRUD._
-import temple.generate.server.go.common.GoCommonGenerator._
+import temple.generate.server.go.common.GoCommonGenerator.{genReturn, _}
 import temple.generate.server.go.service.dao.GoServiceDAOGenerator.generateDAOFunctionName
 import temple.generate.server.go.service.dao.GoServiceDAOInterfaceGenerator.generateInterfaceFunction
 import temple.generate.server.{AttributesRoot, CreatedByAttribute}
@@ -129,29 +130,48 @@ object GoServiceDAOFunctionsGenerator {
       genCheckAndReturnError("nil"),
     )
 
+  private def checkPQUniqueError(block: AttributesRoot): String =
+    mkCode.lines(
+      "// pq specific error",
+      genIf(
+        "err, ok := err.(*pq.Error); ok",
+        genIf(
+          "err.Code.Name() == psqlUniqueViolation",
+          genReturn("nil", s"ErrDuplicate${block.name}(${doubleQuote("")})"),
+        ),
+      ),
+    )
+
   private def generateCreateScanBlock(block: AttributesRoot, scanFunctionCall: String): String =
     mkCode.lines(
       genVar(block.decapitalizedName, block.name),
       genDeclareAndAssign(s"row.$scanFunctionCall", "err"),
-      genCheckAndReturnError("nil"),
+      genIfErr(
+        mkCode.doubleLines(
+          when(block.contains(Unique)) { checkPQUniqueError(block) },
+          genReturn("nil", "err"),
+        ),
+      ),
     )
 
-  private def generateReadUpdateScanBlock(block: AttributesRoot, scanFunctionCall: String): String =
+  private def generateReadUpdateScanBlock(block: AttributesRoot, scanFunctionCall: String, operation: CRUD): String =
     mkCode.lines(
       genVar(block.decapitalizedName, block.name),
       genDeclareAndAssign(s"row.$scanFunctionCall", "err"),
       mkCode(
-        "if err != nil",
-        CodeWrap.curly.tabbed(
-          genSwitch(
-            "err",
-            ListMap(
-              "sql.ErrNoRows" -> genReturn(
-                "nil",
-                s"Err${block.name}NotFound(input.${block.idAttribute.name.toUpperCase}.String())",
+        genIfErr(
+          mkCode.doubleLines(
+            when(block.contains(Unique) && operation == Update) { checkPQUniqueError(block) },
+            genSwitch(
+              "err",
+              ListMap(
+                "sql.ErrNoRows" -> genReturn(
+                  "nil",
+                  s"Err${block.name}NotFound(input.${block.idAttribute.name.toUpperCase}.String())",
+                ),
               ),
+              genReturn("nil", "err"),
             ),
-            genReturn("nil", "err"),
           ),
         ),
       ),
@@ -162,7 +182,7 @@ object GoServiceDAOFunctionsGenerator {
     operation match {
       case List                     => Some(generateListScanBlock(block, scanFunctionCall))
       case Create                   => Some(generateCreateScanBlock(block, scanFunctionCall))
-      case Read | Update | Identify => Some(generateReadUpdateScanBlock(block, scanFunctionCall))
+      case Read | Update | Identify => Some(generateReadUpdateScanBlock(block, scanFunctionCall, operation))
       case Delete                   => None
     }
   }

--- a/src/main/scala/temple/generate/server/go/service/dao/GoServiceDAOFunctionsGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/dao/GoServiceDAOFunctionsGenerator.scala
@@ -3,7 +3,7 @@ package temple.generate.server.go.service.dao
 import temple.ast.Annotation.Unique
 import temple.ast.Metadata.Readable
 import temple.generate.CRUD._
-import temple.generate.server.go.common.GoCommonGenerator.{genReturn, _}
+import temple.generate.server.go.common.GoCommonGenerator._
 import temple.generate.server.go.service.dao.GoServiceDAOGenerator.generateDAOFunctionName
 import temple.generate.server.go.service.dao.GoServiceDAOInterfaceGenerator.generateInterfaceFunction
 import temple.generate.server.{AttributesRoot, CreatedByAttribute}

--- a/src/main/scala/temple/generate/server/go/service/dao/GoServiceDAOGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/dao/GoServiceDAOGenerator.scala
@@ -92,7 +92,7 @@ object GoServiceDAOGenerator {
               "Error",
               Seq(),
               Some("string"),
-              genReturn(doubleQuote(s"Duplicate ${block.name} found")),
+              genReturn("string(e)"),
             ),
           ),
         )

--- a/src/main/scala/temple/generate/server/go/service/main/GoServiceMainCreateHandlerGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/main/GoServiceMainCreateHandlerGenerator.scala
@@ -4,7 +4,7 @@ import temple.ast.Annotation.Unique
 import temple.generate.CRUD.Create
 import temple.generate.server.AttributesRoot.ServiceRoot
 import temple.generate.server.go.GoHTTPStatus.{StatusForbidden, StatusInternalServerError}
-import temple.generate.server.go.common.GoCommonGenerator.{genReturn, _}
+import temple.generate.server.go.common.GoCommonGenerator._
 import temple.generate.server.go.common.GoCommonMainGenerator._
 import temple.generate.server.go.service.main.GoServiceMainHandlersGenerator._
 import temple.generate.utils.CodeTerm.{CodeWrap, mkCode}

--- a/src/main/scala/temple/generate/server/go/service/main/GoServiceMainHandlersGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/main/GoServiceMainHandlersGenerator.scala
@@ -347,7 +347,7 @@ object GoServiceMainHandlersGenerator {
         )
     }
 
-  /** Generate DAO call block error handling for Read, Update and Delete */
+  /** Generate DAO call block error handling for Read and Delete */
   private[main] def generateDAOCallErrorBlock(root: ServiceRoot, metricSuffix: Option[String]): String =
     genIfErr(
       genSwitchReturn(


### PR DESCRIPTION
Currently if we used an `@unique` attribute, the error returned would be code 500, with response:
```
{"error":"Something went wrong: pq: duplicate key value violates unique constraint \"example_service_bar_key\""}
```

This isn't ideal, since it's not an internal server error. Now we detect if this is present and return an appropriate error and code.

Closes #387.

### Test Plan
Consider the tutorial templefile:

```
ExampleProject: project {
  #provider(dockerCompose);
}

ExampleService: service {
  foo: string;
  bar: int @unique;
}
```

Let's spin it up and make some requests:

```bash
# Make a new entity
❯❯❯ curl $KONG_ENTRY/api/example-service -d '{"foo": "abcd", "bar": 123}'
{"id":"2c0d13f0-8723-11ea-90d0-0242ac1c0002","foo":"abcd","bar":123}

# Repeat Request
❯❯❯ curl $KONG_ENTRY/api/example-service -d '{"foo": "abcd", "bar": 123}'
{"error":"Duplicate ExampleService found"}
```
```bash
# Make a new entity
❯❯❯ curl $KONG_ENTRY/api/example-service -d '{"foo": "abcd", "bar": 12356}'
{"id":"35ef8443-8723-11ea-90d0-0242ac1c0002","foo":"abcd","bar":12356}

# Update the second entity with value of bar that matches the first
❯❯❯ curl -X PUT $KONG_ENTRY/api/example-service/35ef8443-8723-11ea-90d0-0242ac1c0002 -d '{"foo": "abcd", "bar": 123}'
{"error":"Duplicate ExampleService found"}
```