### PR TITLE
[Go-gen] Refactor Go handler generation code to prepare for structs

### DIFF
--- a/src/main/scala/temple/generate/server/go/service/GoServiceGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/GoServiceGenerator.scala
@@ -34,12 +34,6 @@ object GoServiceGenerator extends ServiceGenerator {
     // Whether or not the service uses metrics
     val usesMetrics = root.metrics.isDefined
 
-    // Whether or not this service is enumerating by creator
-    lazy val enumeratingByCreator = root.readable match {
-      case Readable.All  => false
-      case Readable.This => true
-    }
-
     (Map(
       File(s"${root.kebabName}", "go.mod") -> GoCommonGenerator.generateMod(root.module),
       File(root.kebabName, s"${root.kebabName}.go") -> mkCode.doubleLines(
@@ -64,7 +58,7 @@ object GoServiceGenerator extends ServiceGenerator {
           GoServiceMainGenerator.generateCheckAuthorization(root)
         },
         GoCommonMainGenerator.generateRespondWithErrorFunc(usesMetrics),
-        GoServiceMainHandlersGenerator.generateHandlers(root, usesComms, enumeratingByCreator, usesMetrics),
+        GoServiceMainHandlersGenerator.generateHandlers(root, usesComms, usesMetrics),
       ),
       File(root.kebabName, "setup.go") -> mkCode.doubleLines(
         GoCommonGenerator.generatePackage("main"),

--- a/src/main/scala/temple/generate/server/go/service/GoServiceHookGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/GoServiceHookGenerator.scala
@@ -13,9 +13,6 @@ import scala.Option.when
 
 object GoServiceHookGenerator {
 
-  private[service] def hookSuffix(block: AttributesRoot): String =
-    if (block.isStruct) block.name else ""
-
   private[service] def generateImports(root: ServiceRoot): String = {
     val daoImport = s"${doubleQuote(root.module + "/dao")}"
     if (root.projectUsesAuth)
@@ -62,13 +59,13 @@ object GoServiceHookGenerator {
   private[service] def generateHookStruct(root: ServiceRoot): String = {
     val beforeCreate = root.blockIterator.map { block =>
       block.operations.toSeq.map { op =>
-        s"before${op.toString}${hookSuffix(block)}Hooks" -> s"[]*${generateBeforeHookType(block, op)}"
+        s"before${op.toString}${block.structName}Hooks" -> s"[]*${generateBeforeHookType(block, op)}"
       }
     }
 
     val afterCreate = root.blockIterator.map { block =>
       block.operations.toSeq.map { op =>
-        s"after${op.toString}${hookSuffix(block)}Hooks" -> s"[]*${generateAfterHookType(block, op)}"
+        s"after${op.toString}${block.structName}Hooks" -> s"[]*${generateAfterHookType(block, op)}"
       }
     }
 
@@ -104,13 +101,13 @@ object GoServiceHookGenerator {
   private[service] def generateAddHookMethods(root: ServiceRoot): String = {
     val beforeHooks = root.blockIterator.flatMap { block =>
       block.operations.toSeq.map { op =>
-        generateAddHookMethod("before", generateBeforeHookType(block, op), op, hookSuffix(block))
+        generateAddHookMethod("before", generateBeforeHookType(block, op), op, block.structName)
       }
     }
 
     val afterHooks = root.blockIterator.flatMap { block =>
       block.operations.toSeq.map { op =>
-        generateAddHookMethod("after", generateAfterHookType(block, op), op, hookSuffix(block))
+        generateAddHookMethod("after", generateAfterHookType(block, op), op, block.structName)
       }
     }
 

--- a/src/main/scala/temple/generate/server/go/service/main/GoServiceMainDeleteHandlerGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/main/GoServiceMainDeleteHandlerGenerator.scala
@@ -2,7 +2,7 @@ package temple.generate.server.go.service.main
 
 import temple.ast.Metadata.Writable
 import temple.generate.CRUD.Delete
-import temple.generate.server.AttributesRoot.ServiceRoot
+import temple.generate.server.AttributesRoot
 import temple.generate.server.go.common.GoCommonGenerator._
 import temple.generate.server.go.common.GoCommonMainGenerator._
 import temple.generate.server.go.service.main.GoServiceMainHandlersGenerator._
@@ -13,43 +13,43 @@ import scala.collection.immutable.ListMap
 
 object GoServiceMainDeleteHandlerGenerator {
 
-  private def generateDAOInput(root: ServiceRoot): String =
+  private def generateDAOInput(block: AttributesRoot): String =
     genDeclareAndAssign(
-      genPopulateStruct(s"dao.Delete${root.name}Input", ListMap("ID" -> s"${root.decapitalizedName}ID")),
+      genPopulateStruct(s"dao.Delete${block.name}Input", ListMap("ID" -> s"${block.decapitalizedName}ID")),
       "input",
     )
 
-  private def generateDAOCallBlock(root: ServiceRoot, usesMetrics: Boolean, metricSuffix: Option[String]): String =
+  private def generateDAOCallBlock(block: AttributesRoot, metricSuffix: Option[String]): String =
     mkCode.lines(
-      when(usesMetrics) { generateMetricTimerDecl(Delete.toString) },
+      metricSuffix.map(generateMetricTimerDecl),
       genAssign(
         genMethodCall(
           "env.dao",
-          s"Delete${root.name}",
+          s"Delete${block.name}",
           "input",
         ),
         "err",
       ),
-      when(usesMetrics) { generateMetricTimerObservation() },
-      generateDAOCallErrorBlock(root, metricSuffix),
+      metricSuffix.map(_ => generateMetricTimerObservation()),
+      generateDAOCallErrorBlock(block, metricSuffix),
     )
 
   /** Generate the delete handler function */
-  private[main] def generateDeleteHandler(root: ServiceRoot, usesMetrics: Boolean): String = {
+  private[main] def generateDeleteHandler(block: AttributesRoot, usesMetrics: Boolean): String = {
     val metricSuffix = when(usesMetrics) { Delete.toString }
     mkCode(
-      generateHandlerDecl(root, Delete),
+      generateHandlerDecl(block, Delete),
       CodeWrap.curly.tabbed(
         mkCode.doubleLines(
-          when(root.projectUsesAuth) { generateExtractAuthBlock(metricSuffix) },
-          generateExtractIDBlock(root.decapitalizedName, metricSuffix),
-          when(root.writable == Writable.This) { generateCheckAuthorizationBlock(root, metricSuffix) },
-          generateDAOInput(root),
-          generateInvokeBeforeHookBlock(root, Delete, metricSuffix),
-          generateDAOCallBlock(root, usesMetrics, metricSuffix),
-          generateInvokeAfterHookBlock(root, Delete, metricSuffix),
+          when(block.projectUsesAuth) { generateExtractAuthBlock(metricSuffix) },
+          generateExtractIDBlock(block.decapitalizedName, metricSuffix),
+          when(block.writable == Writable.This) { generateCheckAuthorizationBlock(block, metricSuffix) },
+          generateDAOInput(block),
+          generateInvokeBeforeHookBlock(block, Delete, metricSuffix),
+          generateDAOCallBlock(block, metricSuffix),
+          generateInvokeAfterHookBlock(block, Delete, metricSuffix),
           genMethodCall(genMethodCall("json", "NewEncoder", "w"), "Encode", "struct{}{}"),
-          when(usesMetrics) { generateMetricSuccess(Delete.toString) },
+          metricSuffix.map(metricSuffix => generateMetricSuccess(metricSuffix)),
         ),
       ),
     )

--- a/src/main/scala/temple/generate/server/go/service/main/GoServiceMainGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/main/GoServiceMainGenerator.scala
@@ -1,6 +1,7 @@
 package temple.generate.server.go.service.main
 
 import temple.generate.CRUD._
+import temple.generate.server.AttributesRoot
 import temple.generate.server.AttributesRoot.ServiceRoot
 import temple.generate.server.go.common.GoCommonGenerator._
 import temple.generate.utils.CodeTerm.{CodeWrap, mkCode}
@@ -79,20 +80,20 @@ object GoServiceMainGenerator {
     )
   }
 
-  private[main] def generateDAOReadInput(root: ServiceRoot): String =
+  private[main] def generateDAOReadInput(block: AttributesRoot): String =
     genDeclareAndAssign(
-      genPopulateStruct(s"dao.Read${root.name}Input", ListMap("ID" -> s"${root.decapitalizedName}ID")),
+      genPopulateStruct(s"dao.Read${block.name}Input", ListMap("ID" -> s"${block.decapitalizedName}ID")),
       "input",
     )
 
-  private[main] def generateDAOReadCall(root: ServiceRoot): String =
+  private[main] def generateDAOReadCall(block: AttributesRoot): String =
     genDeclareAndAssign(
       genMethodCall(
         "env.dao",
-        s"Read${root.name}",
+        s"Read${block.name}",
         "input",
       ),
-      root.decapitalizedName,
+      block.decapitalizedName,
       "err",
     )
 

--- a/src/main/scala/temple/generate/server/go/service/main/GoServiceMainHandlersGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/main/GoServiceMainHandlersGenerator.scala
@@ -5,10 +5,9 @@ import temple.ast.AttributeType.{BlobType, DateTimeType, DateType, TimeType}
 import temple.ast.Metadata.Readable
 import temple.ast.{AbstractAttribute, AttributeType}
 import temple.generate.CRUD._
-import temple.generate.server.AttributesRoot.ServiceRoot
+import temple.generate.server.AttributesRoot
 import temple.generate.server.go.GoHTTPStatus._
 import temple.generate.server.go.common.GoCommonGenerator._
-import temple.generate.server.go.service.GoServiceHookGenerator.hookSuffix
 import temple.generate.server.go.service.main.GoServiceMainCreateHandlerGenerator.generateCreateHandler
 import temple.generate.server.go.service.main.GoServiceMainDeleteHandlerGenerator.generateDeleteHandler
 import temple.generate.server.go.service.main.GoServiceMainIdentifyHandlerGenerator.generateIdentifyHandler
@@ -23,7 +22,7 @@ import scala.collection.immutable.ListMap
 
 object GoServiceMainHandlersGenerator {
 
-  private def generateResponseMapFormat(root: ServiceRoot, name: String, attributeType: AttributeType): String = {
+  private def generateResponseMapFormat(root: AttributesRoot, name: String, attributeType: AttributeType): String = {
     val responseFieldName = s"${root.decapitalizedName}.${name.capitalize}"
     attributeType match {
       case DateType =>
@@ -39,17 +38,17 @@ object GoServiceMainHandlersGenerator {
   }
 
   /** Generate a map for converting the fields of the DAO response to the JSON response */
-  private def generateResponseMap(root: ServiceRoot): ListMap[String, String] =
+  private def generateResponseMap(block: AttributesRoot): ListMap[String, String] =
     // Includes ID attribute and all attributes without the @server or @client annotation
-    ListMap(root.idAttribute.name.toUpperCase -> s"${root.decapitalizedName}.${root.idAttribute.name.toUpperCase}") ++
-    root.attributes.collect {
+    ListMap(block.idAttribute.name.toUpperCase -> s"${block.decapitalizedName}.${block.idAttribute.name.toUpperCase}") ++
+    block.attributes.collect {
       case name -> attribute if attribute.inResponse =>
-        name.capitalize -> generateResponseMapFormat(root, name, attribute.attributeType)
+        name.capitalize -> generateResponseMapFormat(block, name, attribute.attributeType)
     }
 
   /** Generate a handler method declaration */
-  private[main] def generateHandlerDecl(root: ServiceRoot, operation: CRUD): String =
-    s"func (env *env) ${operation.toString.toLowerCase}${root.name}Handler(w http.ResponseWriter, r *http.Request)"
+  private[main] def generateHandlerDecl(block: AttributesRoot, operation: CRUD): String =
+    s"func (env *env) ${operation.toString.toLowerCase}${block.name}Handler(w http.ResponseWriter, r *http.Request)"
 
   /** Generate a respond with error call */
   private[main] def generateRespondWithError(
@@ -100,7 +99,7 @@ object GoServiceMainHandlersGenerator {
       ),
     )
 
-  /** Generate the block for extracting and ID from the request URL */
+  /** Generate the block for extracting the ID from the request URL */
   private[main] def generateExtractIDBlock(varPrefix: String, metricSuffix: Option[String]): String =
     mkCode.lines(
       genDeclareAndAssign(
@@ -114,19 +113,19 @@ object GoServiceMainHandlersGenerator {
     )
 
   /** Generate the block for checking if a request is authorized to perform operation  */
-  private[main] def generateCheckAuthorizationBlock(root: ServiceRoot, metricSuffix: Option[String]): String =
+  private[main] def generateCheckAuthorizationBlock(block: AttributesRoot, metricSuffix: Option[String]): String =
     // If the service has an auth block, we can simply check the AuthID is the same as the resource ID being requested
-    if (root.hasAuthBlock) {
+    if (block.hasAuthBlock) {
       mkCode.lines(
         genIf(
-          s"auth.ID != ${root.decapitalizedName}ID",
+          s"auth.ID != ${block.decapitalizedName}ID",
           generateRespondWithErrorReturn(genHTTPEnum(StatusUnauthorized), metricSuffix, doubleQuote("Unauthorized")),
         ),
       )
     } else {
       mkCode.lines(
         genDeclareAndAssign(
-          genFunctionCall("checkAuthorization", "env", s"${root.decapitalizedName}ID", "auth"),
+          genFunctionCall("checkAuthorization", "env", s"${block.decapitalizedName}ID", "auth"),
           "authorized",
           "err",
         ),
@@ -134,7 +133,7 @@ object GoServiceMainHandlersGenerator {
           genSwitchReturn(
             "err.(type)",
             ListMap(
-              s"dao.Err${root.name}NotFound" -> generateRespondWithError(
+              s"dao.Err${block.name}NotFound" -> generateRespondWithError(
                 genHTTPEnum(StatusUnauthorized),
                 metricSuffix,
                 doubleQuote("Unauthorized"),
@@ -157,7 +156,7 @@ object GoServiceMainHandlersGenerator {
 
   /** Generate the block for decoding an incoming request JSON into a request object */
   private[main] def generateDecodeRequestBlock(
-    root: ServiceRoot,
+    block: AttributesRoot,
     op: CRUD,
     typePrefix: String,
     metricSuffix: Option[String],
@@ -165,7 +164,7 @@ object GoServiceMainHandlersGenerator {
     val jsonDecodeCall = genMethodCall(genMethodCall("json", "NewDecoder", "r.Body"), "Decode", "&req")
     mkCode.lines(
       genVar("req", s"${typePrefix}Request"),
-      if (!root.projectUsesAuth && op == Create) genDeclareAndAssign(jsonDecodeCall, "err")
+      if (!block.projectUsesAuth && op == Create) genDeclareAndAssign(jsonDecodeCall, "err")
       else {
         genAssign(jsonDecodeCall, "err")
       },
@@ -209,7 +208,7 @@ object GoServiceMainHandlersGenerator {
     )
 
   private def generateForeignKeyCheckBlock(
-    root: ServiceRoot,
+    block: AttributesRoot,
     name: String,
     reference: String,
     metricSuffix: Option[String],
@@ -220,7 +219,7 @@ object GoServiceMainHandlersGenerator {
           "env.comm",
           s"Check$reference",
           s"*req.${name.capitalize}",
-          when(root.projectUsesAuth) { genMethodCall("r.Header", "Get", doubleQuote("Authorization")) },
+          when(block.projectUsesAuth) { genMethodCall("r.Header", "Get", doubleQuote("Authorization")) },
         ),
         s"${name}Valid",
         "err",
@@ -245,13 +244,13 @@ object GoServiceMainHandlersGenerator {
     )
 
   /** Generate the blocks for checking foreign keys against other services */
-  private[main] def generateForeignKeyCheckBlocks(root: ServiceRoot, metricSuffix: Option[String]): String =
+  private[main] def generateForeignKeyCheckBlocks(block: AttributesRoot, metricSuffix: Option[String]): String =
     mkCode.doubleLines(
-      root.requestAttributes.map {
+      block.requestAttributes.map {
         case name -> attribute =>
           attribute.attributeType match {
             case AttributeType.ForeignKey(reference) =>
-              generateForeignKeyCheckBlock(root, name, reference, metricSuffix)
+              generateForeignKeyCheckBlock(block, name, reference, metricSuffix)
             case _ => ""
           }
       },
@@ -348,12 +347,12 @@ object GoServiceMainHandlersGenerator {
     }
 
   /** Generate DAO call block error handling for Read and Delete */
-  private[main] def generateDAOCallErrorBlock(root: ServiceRoot, metricSuffix: Option[String]): String =
+  private[main] def generateDAOCallErrorBlock(block: AttributesRoot, metricSuffix: Option[String]): String =
     genIfErr(
       genSwitchReturn(
         "err.(type)",
         ListMap(
-          s"dao.Err${root.name}NotFound" -> generateRespondWithError(
+          s"dao.Err${block.name}NotFound" -> generateRespondWithError(
             genHTTPEnum(StatusNotFound),
             metricSuffix,
             genMethodCall("err", "Error"),
@@ -369,24 +368,24 @@ object GoServiceMainHandlersGenerator {
     )
 
   private[main] def generateInvokeBeforeHookBlock(
-    root: ServiceRoot,
+    block: AttributesRoot,
     operation: CRUD,
     metricSuffix: Option[String],
   ): String = {
     val hookArguments: Seq[String] = (operation match {
         case List =>
-          root.readable match {
+          block.readable match {
             case Readable.This => Seq("env", "&input")
             case Readable.All  => Seq("env")
           }
         case Create | Update =>
-          if (root.requestAttributes.isEmpty) Seq("env", "&input") else Seq("env", "req", "&input")
+          if (block.requestAttributes.isEmpty) Seq("env", "&input") else Seq("env", "req", "&input")
         case Read | Delete | Identify =>
           Seq("env", "&input")
-      }) ++ when(root.projectUsesAuth) { "auth" }
+      }) ++ when(block.projectUsesAuth) { "auth" }
 
     genForLoop(
-      genDeclareAndAssign(s"range env.hook.before${operation.toString}${hookSuffix(root)}Hooks", "_", "hook"),
+      genDeclareAndAssign(s"range env.hook.before${operation.toString}${block.structName}Hooks", "_", "hook"),
       mkCode.lines(
         genDeclareAndAssign(
           genFunctionCall("(*hook)", hookArguments),
@@ -398,21 +397,21 @@ object GoServiceMainHandlersGenerator {
   }
 
   private[main] def generateInvokeAfterHookBlock(
-    root: ServiceRoot,
+    block: AttributesRoot,
     operation: CRUD,
     metricSuffix: Option[String],
   ): String = {
     val hookArguments = (operation match {
         case List =>
-          Seq("env", s"${root.decapitalizedName}List")
+          Seq("env", s"${block.decapitalizedName}List")
         case Create | Read | Update | Identify =>
-          Seq("env", root.decapitalizedName)
+          Seq("env", block.decapitalizedName)
         case Delete =>
           Seq("env")
-      }) ++ when(root.projectUsesAuth) { "auth" }
+      }) ++ when(block.projectUsesAuth) { "auth" }
 
     genForLoop(
-      genDeclareAndAssign(s"range env.hook.after${operation.toString}${hookSuffix(root)}Hooks", "_", "hook"),
+      genDeclareAndAssign(s"range env.hook.after${operation.toString}${block.structName}Hooks", "_", "hook"),
       mkCode.lines(
         genDeclareAndAssign(
           genFunctionCall("(*hook)", hookArguments),
@@ -433,35 +432,34 @@ object GoServiceMainHandlersGenerator {
 
   /** Generate the env handler functions */
   private[service] def generateHandlers(
-    root: ServiceRoot,
+    block: AttributesRoot,
     usesComms: Boolean,
-    enumeratingByCreator: Boolean,
     usesMetrics: Boolean,
   ): String = {
-    val responseMap = generateResponseMap(root)
+    val responseMap = generateResponseMap(block)
 
     // Whether or not the client attributes contain attributes of type date, time or datetime
     val clientUsesTime = Set[AttributeType](AttributeType.DateType, AttributeType.TimeType, AttributeType.DateTimeType)
-      .intersect(root.requestAttributes.values.map(_.attributeType).toSet)
+      .intersect(block.requestAttributes.values.map(_.attributeType).toSet)
       .nonEmpty
 
     // Whether or not the client attributes contain attributes of type blob
-    val clientUsesBase64 = root.requestAttributes.values.exists(_.attributeType.isInstanceOf[AttributeType.BlobType])
+    val clientUsesBase64 = block.requestAttributes.values.exists(_.attributeType.isInstanceOf[AttributeType.BlobType])
 
     mkCode.doubleLines(
-      root.operations.toSeq.map {
+      block.operations.toSeq.map {
         case List =>
-          generateListHandler(root, responseMap, enumeratingByCreator, usesMetrics)
+          generateListHandler(block, responseMap, usesMetrics)
         case Create =>
-          generateCreateHandler(root, usesComms, responseMap, clientUsesTime, clientUsesBase64, usesMetrics)
+          generateCreateHandler(block, usesComms, responseMap, clientUsesTime, clientUsesBase64, usesMetrics)
         case Read =>
-          generateReadHandler(root, responseMap, usesMetrics)
+          generateReadHandler(block, responseMap, usesMetrics)
         case Update =>
-          generateUpdateHandler(root, usesComms, responseMap, clientUsesTime, clientUsesBase64, usesMetrics)
+          generateUpdateHandler(block, usesComms, responseMap, clientUsesTime, clientUsesBase64, usesMetrics)
         case Delete =>
-          generateDeleteHandler(root, usesMetrics)
+          generateDeleteHandler(block, usesMetrics)
         case Identify =>
-          generateIdentifyHandler(root, usesMetrics)
+          generateIdentifyHandler(block, usesMetrics)
       },
     )
   }

--- a/src/main/scala/temple/generate/server/go/service/main/GoServiceMainIdentifyHandlerGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/main/GoServiceMainIdentifyHandlerGenerator.scala
@@ -1,50 +1,50 @@
 package temple.generate.server.go.service.main
 
 import temple.generate.CRUD.Identify
-import temple.generate.server.AttributesRoot.ServiceRoot
+import temple.generate.server.AttributesRoot
 import temple.generate.server.go.common.GoCommonGenerator._
 import temple.generate.server.go.common.GoCommonMainGenerator._
 import temple.generate.server.go.service.main.GoServiceMainHandlersGenerator._
 import temple.generate.utils.CodeTerm.{CodeWrap, mkCode}
 import temple.utils.StringUtils.doubleQuote
 
-import Option.when
+import scala.Option.when
 import scala.collection.immutable.ListMap
 
 object GoServiceMainIdentifyHandlerGenerator {
 
-  private def generateDAOInput(root: ServiceRoot): String =
+  private def generateDAOInput(block: AttributesRoot): String =
     genDeclareAndAssign(
-      genPopulateStruct(s"dao.Identify${root.name}Input", ListMap("ID" -> s"auth.ID")),
+      genPopulateStruct(s"dao.Identify${block.name}Input", ListMap("ID" -> s"auth.ID")),
       "input",
     )
 
-  private def generateDAOCall(root: ServiceRoot): String =
+  private def generateDAOCall(block: AttributesRoot): String =
     genDeclareAndAssign(
       genMethodCall(
         "env.dao",
-        s"Identify${root.name}",
+        s"Identify${block.name}",
         "input",
       ),
-      root.decapitalizedName,
+      block.decapitalizedName,
       "err",
     )
 
-  private def generateDAOCallBlock(root: ServiceRoot, usesMetrics: Boolean, metricSuffix: Option[String]): String =
+  private def generateDAOCallBlock(block: AttributesRoot, metricSuffix: Option[String]): String =
     mkCode.doubleLines(
-      generateDAOInput(root),
-      generateInvokeBeforeHookBlock(root, Identify, metricSuffix),
+      generateDAOInput(block),
+      generateInvokeBeforeHookBlock(block, Identify, metricSuffix),
       mkCode.lines(
-        when(usesMetrics) { generateMetricTimerDecl(Identify.toString) },
-        generateDAOCall(root),
-        when(usesMetrics) { generateMetricTimerObservation() },
-        generateDAOCallErrorBlock(root, metricSuffix),
+        metricSuffix.map(generateMetricTimerDecl),
+        generateDAOCall(block),
+        metricSuffix.map(_ => generateMetricTimerObservation()),
+        generateDAOCallErrorBlock(block, metricSuffix),
       ),
-      generateInvokeAfterHookBlock(root, Identify, metricSuffix),
+      generateInvokeAfterHookBlock(block, Identify, metricSuffix),
     )
 
   // The headers used here are defined by Kong: https://docs.konghq.com/2.0.x/proxy/#3-proxying--upstream-timeouts
-  private def generateRedirectResponse(root: ServiceRoot): String = mkCode.lines(
+  private def generateRedirectResponse(block: AttributesRoot): String = mkCode.lines(
     genDeclareAndAssign(
       genMethodCall(
         "fmt",
@@ -53,7 +53,7 @@ object GoServiceMainIdentifyHandlerGenerator {
         genMethodCall("r.Header", "Get", doubleQuote("X-Forwarded-Host")),
         genMethodCall("r.Header", "Get", doubleQuote("X-Forwarded-Port")),
         "r.URL.Path",
-        s"${root.decapitalizedName}.ID",
+        s"${block.decapitalizedName}.ID",
       ),
       "url",
     ),
@@ -62,17 +62,17 @@ object GoServiceMainIdentifyHandlerGenerator {
   )
 
   /** Generate the identify handler function */
-  private[main] def generateIdentifyHandler(root: ServiceRoot, usesMetrics: Boolean): String = {
+  private[main] def generateIdentifyHandler(block: AttributesRoot, usesMetrics: Boolean): String = {
     val metricSuffix = when(usesMetrics) { Identify.toString }
 
     mkCode(
-      generateHandlerDecl(root, Identify),
+      generateHandlerDecl(block, Identify),
       CodeWrap.curly.tabbed(
         mkCode.doubleLines(
           generateExtractAuthBlock(metricSuffix),
-          generateDAOCallBlock(root, usesMetrics, metricSuffix),
-          generateRedirectResponse(root),
-          when(usesMetrics) { generateMetricSuccess(Identify.toString) },
+          generateDAOCallBlock(block, metricSuffix),
+          generateRedirectResponse(block),
+          metricSuffix.map(generateMetricSuccess),
         ),
       ),
     )

--- a/src/main/scala/temple/generate/server/go/service/main/GoServiceMainReadHandlerGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/main/GoServiceMainReadHandlerGenerator.scala
@@ -2,7 +2,7 @@ package temple.generate.server.go.service.main
 
 import temple.ast.Metadata.Readable
 import temple.generate.CRUD.Read
-import temple.generate.server.AttributesRoot.ServiceRoot
+import temple.generate.server.AttributesRoot
 import temple.generate.server.go.common.GoCommonMainGenerator._
 import temple.generate.server.go.service.main.GoServiceMainGenerator.{generateDAOReadCall, generateDAOReadInput}
 import temple.generate.server.go.service.main.GoServiceMainHandlersGenerator._
@@ -13,36 +13,36 @@ import scala.collection.immutable.ListMap
 
 object GoServiceMainReadHandlerGenerator {
 
-  private def generateDAOCallBlock(root: ServiceRoot, usesMetrics: Boolean, metricSuffix: Option[String]): String =
+  private def generateDAOCallBlock(block: AttributesRoot, metricSuffix: Option[String]): String =
     mkCode.doubleLines(
-      generateDAOReadInput(root),
-      generateInvokeBeforeHookBlock(root, Read, metricSuffix),
+      generateDAOReadInput(block),
+      generateInvokeBeforeHookBlock(block, Read, metricSuffix),
       mkCode.lines(
-        when(usesMetrics) { generateMetricTimerDecl(Read.toString) },
-        generateDAOReadCall(root),
-        when(usesMetrics) { generateMetricTimerObservation() },
-        generateDAOCallErrorBlock(root, metricSuffix),
+        metricSuffix.map(generateMetricTimerDecl),
+        generateDAOReadCall(block),
+        metricSuffix.map(_ => generateMetricTimerObservation()),
+        generateDAOCallErrorBlock(block, metricSuffix),
       ),
-      generateInvokeAfterHookBlock(root, Read, metricSuffix),
+      generateInvokeAfterHookBlock(block, Read, metricSuffix),
     )
 
   /** Generate the read handler function */
   private[main] def generateReadHandler(
-    root: ServiceRoot,
+    block: AttributesRoot,
     responseMap: ListMap[String, String],
     usesMetrics: Boolean,
   ): String = {
     val metricSuffix = when(usesMetrics) { Read.toString }
     mkCode(
-      generateHandlerDecl(root, Read),
+      generateHandlerDecl(block, Read),
       CodeWrap.curly.tabbed(
         mkCode.doubleLines(
-          when(root.projectUsesAuth) { generateExtractAuthBlock(metricSuffix) },
-          generateExtractIDBlock(root.decapitalizedName, metricSuffix),
-          when(root.readable == Readable.This) { generateCheckAuthorizationBlock(root, metricSuffix) },
-          generateDAOCallBlock(root, usesMetrics, metricSuffix),
-          generateJSONResponse(s"read${root.name}", responseMap),
-          when(usesMetrics) { generateMetricSuccess(Read.toString) },
+          when(block.projectUsesAuth) { generateExtractAuthBlock(metricSuffix) },
+          generateExtractIDBlock(block.decapitalizedName, metricSuffix),
+          when(block.readable == Readable.This) { generateCheckAuthorizationBlock(block, metricSuffix) },
+          generateDAOCallBlock(block, metricSuffix),
+          generateJSONResponse(s"read${block.name}", responseMap),
+          metricSuffix.map(generateMetricSuccess),
         ),
       ),
     )


### PR DESCRIPTION
- Generalise a lot of handler functions from ServiceRoot to AttributesRoot
- Use the new `structName` method (returns the name of the struct block, or blank for services) for calculating suffixes, instead of a local `hookSuffix` function
- Remove `enumeratingByCreator`, as it can be calculated from the block, as was already being done in several places
- Remove `usesMetrics` when it can exactly be inferred from the presence/absence of the option `metricSuffix`

N.b. this has no effect on the code output, which will be coming in the next PR.