### PR TITLE
[go-gen] Add ParentID to scan call

### DIFF
--- a/src/e2e/resources/simple-temple-expected/simple-temple-test-user/dao/dao.go
+++ b/src/e2e/resources/simple-temple-expected/simple-temple-test-user/dao/dao.go
@@ -275,7 +275,7 @@ func (dao *DAO) ListFred(input ListFredInput) (*[]Fred, error) {
 	fredList := make([]Fred, 0)
 	for rows.Next() {
 		var fred Fred
-		err = rows.Scan(&fred.ID, &fred.Field, &fred.Friend, &fred.Image)
+		err = rows.Scan(&fred.ID, &fred.ParentID, &fred.Field, &fred.Friend, &fred.Image)
 		if err != nil {
 			return nil, err
 		}
@@ -294,7 +294,7 @@ func (dao *DAO) CreateFred(input CreateFredInput) (*Fred, error) {
 	row := executeQueryWithRowResponse(dao.DB, "INSERT INTO fred (id, parent_id, field, friend, image) VALUES ($1, $2, $3, $4, $5) RETURNING id, parent_id, field, friend, image;", input.ID, input.ParentID, input.Field, input.Friend, input.Image)
 
 	var fred Fred
-	err := row.Scan(&fred.ID, &fred.Field, &fred.Friend, &fred.Image)
+	err := row.Scan(&fred.ID, &fred.ParentID, &fred.Field, &fred.Friend, &fred.Image)
 	if err != nil {
 		return nil, err
 	}
@@ -307,7 +307,7 @@ func (dao *DAO) ReadFred(input ReadFredInput) (*Fred, error) {
 	row := executeQueryWithRowResponse(dao.DB, "SELECT id, parent_id, field, friend, image FROM fred WHERE id = $1;", input.ID)
 
 	var fred Fred
-	err := row.Scan(&fred.ID, &fred.Field, &fred.Friend, &fred.Image)
+	err := row.Scan(&fred.ID, &fred.ParentID, &fred.Field, &fred.Friend, &fred.Image)
 	if err != nil {
 		switch err {
 		case sql.ErrNoRows:
@@ -325,7 +325,7 @@ func (dao *DAO) UpdateFred(input UpdateFredInput) (*Fred, error) {
 	row := executeQueryWithRowResponse(dao.DB, "UPDATE fred SET parent_id = $1, field = $2, friend = $3, image = $4 WHERE id = $5 RETURNING id, parent_id, field, friend, image;", input.Field, input.Friend, input.Image, input.ID)
 
 	var fred Fred
-	err := row.Scan(&fred.ID, &fred.Field, &fred.Friend, &fred.Image)
+	err := row.Scan(&fred.ID, &fred.ParentID, &fred.Field, &fred.Friend, &fred.Image)
 	if err != nil {
 		switch err {
 		case sql.ErrNoRows:

--- a/src/main/scala/temple/generate/server/go/service/dao/GoServiceDAOFunctionsGenerator.scala
+++ b/src/main/scala/temple/generate/server/go/service/dao/GoServiceDAOFunctionsGenerator.scala
@@ -108,6 +108,9 @@ object GoServiceDAOFunctionsGenerator {
         block.createdByAttribute.map { enumerating =>
           Some(s"&${block.decapitalizedName}.${enumerating.name.capitalize}")
         },
+        block.parentAttribute.map { parent =>
+          Some(s"&${block.decapitalizedName}.${parent.name.capitalize}")
+        },
         block.storedAttributes.map { case (name, _) => s"&${block.decapitalizedName}.${name.capitalize}" },
       )
 

--- a/src/test/resources/project-builder-complex/complex-user/dao/dao.go
+++ b/src/test/resources/project-builder-complex/complex-user/dao/dao.go
@@ -256,7 +256,7 @@ func (dao *DAO) CreateTempleUser(input CreateTempleUserInput) (*TempleUser, erro
 	row := executeQueryWithRowResponse(dao.DB, "INSERT INTO temple_user (id, parent_id, int_field, double_field, string_field, bool_field, date_field, time_field, date_time_field, blob_field) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) RETURNING id, parent_id, int_field, double_field, string_field, bool_field, date_field, time_field, date_time_field, blob_field;", input.ID, input.ParentID, input.IntField, input.DoubleField, input.StringField, input.BoolField, input.DateField, input.TimeField, input.DateTimeField, input.BlobField)
 
 	var templeUser TempleUser
-	err := row.Scan(&templeUser.ID, &templeUser.IntField, &templeUser.DoubleField, &templeUser.StringField, &templeUser.BoolField, &templeUser.DateField, &templeUser.TimeField, &templeUser.DateTimeField, &templeUser.BlobField)
+	err := row.Scan(&templeUser.ID, &templeUser.ParentID, &templeUser.IntField, &templeUser.DoubleField, &templeUser.StringField, &templeUser.BoolField, &templeUser.DateField, &templeUser.TimeField, &templeUser.DateTimeField, &templeUser.BlobField)
 	if err != nil {
 		return nil, err
 	}
@@ -269,7 +269,7 @@ func (dao *DAO) ReadTempleUser(input ReadTempleUserInput) (*TempleUser, error) {
 	row := executeQueryWithRowResponse(dao.DB, "SELECT id, parent_id, int_field, double_field, string_field, bool_field, date_field, time_field, date_time_field, blob_field FROM temple_user WHERE id = $1;", input.ID)
 
 	var templeUser TempleUser
-	err := row.Scan(&templeUser.ID, &templeUser.IntField, &templeUser.DoubleField, &templeUser.StringField, &templeUser.BoolField, &templeUser.DateField, &templeUser.TimeField, &templeUser.DateTimeField, &templeUser.BlobField)
+	err := row.Scan(&templeUser.ID, &templeUser.ParentID, &templeUser.IntField, &templeUser.DoubleField, &templeUser.StringField, &templeUser.BoolField, &templeUser.DateField, &templeUser.TimeField, &templeUser.DateTimeField, &templeUser.BlobField)
 	if err != nil {
 		switch err {
 		case sql.ErrNoRows:
@@ -287,7 +287,7 @@ func (dao *DAO) UpdateTempleUser(input UpdateTempleUserInput) (*TempleUser, erro
 	row := executeQueryWithRowResponse(dao.DB, "UPDATE temple_user SET parent_id = $1, int_field = $2, double_field = $3, string_field = $4, bool_field = $5, date_field = $6, time_field = $7, date_time_field = $8, blob_field = $9 WHERE id = $10 RETURNING id, parent_id, int_field, double_field, string_field, bool_field, date_field, time_field, date_time_field, blob_field;", input.IntField, input.DoubleField, input.StringField, input.BoolField, input.DateField, input.TimeField, input.DateTimeField, input.BlobField, input.ID)
 
 	var templeUser TempleUser
-	err := row.Scan(&templeUser.ID, &templeUser.IntField, &templeUser.DoubleField, &templeUser.StringField, &templeUser.BoolField, &templeUser.DateField, &templeUser.TimeField, &templeUser.DateTimeField, &templeUser.BlobField)
+	err := row.Scan(&templeUser.ID, &templeUser.ParentID, &templeUser.IntField, &templeUser.DoubleField, &templeUser.StringField, &templeUser.BoolField, &templeUser.DateField, &templeUser.TimeField, &templeUser.DateTimeField, &templeUser.BlobField)
 	if err != nil {
 		switch err {
 		case sql.ErrNoRows:


### PR DESCRIPTION
Add `ParentID` to the call for scanning into structs.

As per the [Go `sql` documentation](https://golang.org/pkg/database/sql/#Rows.Scan): 

> Scan copies the columns in the current row into the values pointed at by dest. The number of values in dest must be the same as the number of columns in Rows.

