### PR TITLE
[project-test] Support structs in temple test

### DIFF
--- a/src/main/scala/temple/test/ProjectTester.scala
+++ b/src/main/scala/temple/test/ProjectTester.scala
@@ -141,7 +141,7 @@ object ProjectTester {
   }
 
   /** Execute the tests on each generated service */
-  private def performTests(templefile: Templefile, generatedPath: String, url: String): Unit = {
+  private def performTests(templefile: Templefile, url: String): Unit = {
     val authMethod = templefile.lookupMetadata[AuthMethod]
     var anyFailed  = false
     authMethod.foreach { auth =>
@@ -169,7 +169,7 @@ object ProjectTester {
     try {
       // Check we can actually connect to the URL
       Http(s"http://${config.baseIP}").asString
-      performTests(templefile, generatedPath, config.baseIP)
+      performTests(templefile, config.baseIP)
     } catch {
       case e: ConnectException =>
         println(s"😢 Could not connect to ${config.baseIP}, is the project running?")
@@ -186,7 +186,7 @@ object ProjectTester {
   def test(templefile: Templefile, generatedPath: String): Unit =
     try {
       val config = performSetup(templefile, generatedPath)
-      performTests(templefile, generatedPath, config.baseIP)
+      performTests(templefile, config.baseIP)
     } finally {
       performShutdown(templefile, generatedPath)
     }

--- a/src/main/scala/temple/test/internal/CRUDServiceTest.scala
+++ b/src/main/scala/temple/test/internal/CRUDServiceTest.scala
@@ -3,17 +3,18 @@ package temple.test.internal
 import scalaj.http.Http
 import temple.ast.AbstractServiceBlock.ServiceBlock
 import temple.test.internal.ServiceTestUtils._
-import temple.ast.Metadata
+import temple.ast.{Metadata, StructBlock}
 import temple.builder.project.ProjectBuilder
 import temple.generate.CRUD
+import temple.utils.StringUtils.kebabCase
 
 class CRUDServiceTest(
-  name: String,
+  serviceName: String,
   service: ServiceBlock,
   allServices: Map[String, ServiceBlock],
   baseURL: String,
   usesAuth: Boolean,
-) extends ServiceTest(name, baseURL, usesAuth) {
+) extends ServiceTest(serviceName, baseURL, usesAuth) {
 
   private def testCreateEndpoint(): Unit =
     testEndpoint("create") { (test, accessToken) =>
@@ -24,14 +25,14 @@ class CRUDServiceTest(
 
   private def testReadEndpoint(): Unit =
     testEndpoint("read") { (test, accessToken) =>
-      val id      = create(test, name, allServices, baseURL, accessToken)
+      val id      = create(test, serviceName, allServices, baseURL, accessToken)
       val getJSON = getRequest(test, s"$serviceURL/$id", accessToken)
       test.validateResponseBody(None, getJSON, service.attributes)
     }
 
   private def testUpdateEndpoint(): Unit =
     testEndpoint("update") { (test, accessToken) =>
-      val id          = create(test, name, allServices, baseURL, accessToken)
+      val id          = create(test, serviceName, allServices, baseURL, accessToken)
       val requestBody = constructRequestBody(test, service.attributes, allServices, baseURL, accessToken)
       val updateJSON  = putRequest(test, s"$serviceURL/$id", requestBody, accessToken)
       test.validateResponseBody(requestBody.asObject, updateJSON, service.attributes)
@@ -39,18 +40,18 @@ class CRUDServiceTest(
 
   private def testDeleteEndpoint(): Unit =
     testEndpoint("delete") { (test, accessToken) =>
-      val id         = create(test, name, allServices, baseURL, accessToken)
+      val id         = create(test, serviceName, allServices, baseURL, accessToken)
       val deleteJSON = deleteRequest(test, s"$serviceURL/$id", accessToken)
       test.assert(deleteJSON.isEmpty, "delete response was not empty")
     }
 
   private def testListEndpoint(): Unit =
     testEndpoint("list") { (test, accessToken) =>
-      val _ = create(test, name, allServices, baseURL, accessToken)
+      val _ = create(test, serviceName, allServices, baseURL, accessToken)
       val listJSON = getRequest(test, s"$serviceURL/all", accessToken)
-        .apply(s"${name}List")
+        .apply(s"${serviceName}List")
         .flatMap(_.asArray)
-        .getOrElse(test.fail(s"response did not contain key ${name}List"))
+        .getOrElse(test.fail(s"response did not contain key ${serviceName}List"))
 
       // Ensure the correct number of items were returned
       // For `this`, only 1 item has been created for this access token...
@@ -90,6 +91,64 @@ class CRUDServiceTest(
       test.validateResponseBody(requestBody.asObject, response, service.attributes)
     }
 
+  def testCreateStructEndpoint(structName: String, struct: StructBlock): Unit =
+    testEndpoint("create", Some(structName)) { (test, accessToken) =>
+      val parentID    = create(test, serviceName, allServices, baseURL, accessToken)
+      val requestBody = constructRequestBody(test, struct.attributes, allServices, baseURL, accessToken)
+      val createJSON  = postRequest(test, s"$serviceURL/$parentID/${kebabCase(structName)}", requestBody, accessToken)
+      test.validateResponseBody(requestBody.asObject, createJSON, struct.attributes)
+    }
+
+  def testReadStructEndpoint(structName: String, struct: StructBlock): Unit =
+    testEndpoint("read", Some(structName)) { (test, accessToken) =>
+      val parentID = create(test, serviceName, allServices, baseURL, accessToken)
+      val structID = createStruct(test, parentID, structName, serviceName, allServices, baseURL, accessToken)
+      val getJSON  = getRequest(test, s"$serviceURL/$parentID/${kebabCase(structName)}/$structID", accessToken)
+      test.validateResponseBody(None, getJSON, struct.attributes)
+    }
+
+  def testUpdateStructEndpoint(structName: String, struct: StructBlock): Unit =
+    testEndpoint("update", Some(structName)) { (test, accessToken) =>
+      val parentID    = create(test, serviceName, allServices, baseURL, accessToken)
+      val structID    = createStruct(test, parentID, structName, serviceName, allServices, baseURL, accessToken)
+      val requestBody = constructRequestBody(test, struct.attributes, allServices, baseURL, accessToken)
+      val updateJSON =
+        putRequest(test, s"$serviceURL/$parentID/${kebabCase(structName)}/$structID", requestBody, accessToken)
+      test.validateResponseBody(requestBody.asObject, updateJSON, struct.attributes)
+
+      // A subsequent GET should match the updated values
+      val getJSON = getRequest(test, s"$serviceURL/$parentID/${kebabCase(structName)}/$structID", accessToken)
+      test.validateResponseBody(requestBody.asObject, getJSON, struct.attributes)
+    }
+
+  def testDeleteStructEndpoint(structName: String, struct: StructBlock): Unit =
+    testEndpoint("delete", Some(structName)) { (test, accessToken) =>
+      val parentID   = create(test, serviceName, allServices, baseURL, accessToken)
+      val structID   = createStruct(test, parentID, structName, serviceName, allServices, baseURL, accessToken)
+      val deleteJSON = deleteRequest(test, s"$serviceURL/$parentID/${kebabCase(structName)}/$structID", accessToken)
+      test.assert(deleteJSON.isEmpty, "delete response was not empty")
+
+      // A subsequent GET should fail
+      val code = executeRequest(test, s"$serviceURL/$parentID/${kebabCase(structName)}/$structID", accessToken)
+      test.assertEqual(404, code, "entity should have been deleted")
+    }
+
+  def testListStructEndpoint(structName: String, struct: StructBlock): Unit =
+    testEndpoint("list", Some(structName)) { (test, accessToken) =>
+      val parentID = create(test, serviceName, allServices, baseURL, accessToken)
+      val _        = createStruct(test, parentID, structName, serviceName, allServices, baseURL, accessToken)
+      val listJSON = getRequest(test, s"$serviceURL/$parentID/${kebabCase(structName)}/all", accessToken)
+        .apply(s"${structName}List")
+        .flatMap(_.asArray)
+        .getOrElse(test.fail(s"response did not contain key ${structName}List"))
+      test.assertEqual(1, listJSON.size, "expected list response to contain 1 item only")
+
+      listJSON.foreach { listItem =>
+        val listObject = listItem.asObject.getOrElse(test.fail("list item was not a JSON object"))
+        test.validateResponseBody(None, listObject, struct.attributes)
+      }
+    }
+
   // Test each type of endpoint that is present in the service
   def test(): Boolean = {
     ProjectBuilder.endpoints(service).foreach {
@@ -100,6 +159,19 @@ class CRUDServiceTest(
       case CRUD.Delete   => testDeleteEndpoint()
       case CRUD.Identify => testIdentifyEndpoint()
     }
+
+    service.structs.foreach {
+      case (name, struct) =>
+        ProjectBuilder.endpoints(struct).foreach {
+          case CRUD.List     => testListStructEndpoint(name, struct)
+          case CRUD.Create   => testCreateStructEndpoint(name, struct)
+          case CRUD.Read     => testReadStructEndpoint(name, struct)
+          case CRUD.Update   => testUpdateStructEndpoint(name, struct)
+          case CRUD.Delete   => testDeleteStructEndpoint(name, struct)
+          case CRUD.Identify => throw new RuntimeException("A struct cannot have an identify endpoint")
+        }
+    }
+
     anyTestFailed
   }
 }

--- a/src/main/scala/temple/test/internal/EndpointTest.scala
+++ b/src/main/scala/temple/test/internal/EndpointTest.scala
@@ -9,7 +9,7 @@ import temple.utils.StringUtils
 
 class TestFailedException(msg: String) extends RuntimeException(msg)
 
-private[internal] class EndpointTest(service: String, endpointName: String) {
+private[internal] class EndpointTest(service: String, endpointName: String, struct: Option[String]) {
 
   // Validate that the response JSON for the provided key matches the Attribute
   private def validateResponseType(
@@ -163,8 +163,8 @@ private[internal] class EndpointTest(service: String, endpointName: String) {
     if (!value) fail(failMsg)
 
   def pass(): Unit =
-    println(StringUtils.indent(s"✅ $service $endpointName", 4))
+    println(StringUtils.indent(s"✅ ${struct.getOrElse(service)} $endpointName", 4))
 
   def fail(message: String): Nothing =
-    throw new TestFailedException(StringUtils.indent(s"❌ $service $endpointName: $message", 4))
+    throw new TestFailedException(StringUtils.indent(s"❌ ${struct.getOrElse(service)} $endpointName: $message", 4))
 }

--- a/src/main/scala/temple/test/internal/ServiceTest.scala
+++ b/src/main/scala/temple/test/internal/ServiceTest.scala
@@ -7,8 +7,10 @@ abstract class ServiceTest(service: String, baseURL: String, usesAuth: Boolean) 
   protected val serviceURL    = s"http://$baseURL/api/${StringUtils.kebabCase(service)}"
   println(s"🧪 Testing $service service")
 
-  def testEndpoint(endpointName: String)(testFn: (EndpointTest, String) => Unit): Unit = {
-    val endpointTest = new EndpointTest(service, endpointName)
+  def testEndpoint(endpointName: String, structName: Option[String] = None)(
+    testFn: (EndpointTest, String) => Unit,
+  ): Unit = {
+    val endpointTest = new EndpointTest(service, endpointName, structName)
     try {
       val token = if (usesAuth) ServiceTestUtils.getAuthTokenWithEmail(service, baseURL) else ""
       testFn(endpointTest, token)


### PR DESCRIPTION
Wahay! Let's support structs in `temple test`!

- Add support for CRUDL endpoints
- Adapts a couple of the utility methods to also use structs