### PR TITLE
[metrics] Give unique ID to struct rows

### DIFF
--- a/src/e2e/resources/simple-temple-expected/grafana/provisioning/dashboards/simple-temple-test-user.json
+++ b/src/e2e/resources/simple-temple-expected/grafana/provisioning/dashboards/simple-temple-test-user.json
@@ -1077,7 +1077,7 @@
         "y" : 25
       },
       "hiddenSeries" : false,
-      "id" : 0,
+      "id" : 10,
       "legend" : {
         "avg" : false,
         "current" : false,
@@ -1177,7 +1177,7 @@
         "y" : 25
       },
       "hiddenSeries" : false,
-      "id" : 1,
+      "id" : 11,
       "legend" : {
         "avg" : false,
         "current" : false,
@@ -1287,7 +1287,7 @@
         "y" : 30
       },
       "hiddenSeries" : false,
-      "id" : 2,
+      "id" : 12,
       "legend" : {
         "avg" : false,
         "current" : false,
@@ -1387,7 +1387,7 @@
         "y" : 30
       },
       "hiddenSeries" : false,
-      "id" : 3,
+      "id" : 13,
       "legend" : {
         "avg" : false,
         "current" : false,
@@ -1497,7 +1497,7 @@
         "y" : 35
       },
       "hiddenSeries" : false,
-      "id" : 4,
+      "id" : 14,
       "legend" : {
         "avg" : false,
         "current" : false,
@@ -1597,7 +1597,7 @@
         "y" : 35
       },
       "hiddenSeries" : false,
-      "id" : 5,
+      "id" : 15,
       "legend" : {
         "avg" : false,
         "current" : false,
@@ -1707,7 +1707,7 @@
         "y" : 40
       },
       "hiddenSeries" : false,
-      "id" : 6,
+      "id" : 16,
       "legend" : {
         "avg" : false,
         "current" : false,
@@ -1807,7 +1807,7 @@
         "y" : 40
       },
       "hiddenSeries" : false,
-      "id" : 7,
+      "id" : 17,
       "legend" : {
         "avg" : false,
         "current" : false,
@@ -1917,7 +1917,7 @@
         "y" : 45
       },
       "hiddenSeries" : false,
-      "id" : 8,
+      "id" : 18,
       "legend" : {
         "avg" : false,
         "current" : false,
@@ -2017,7 +2017,7 @@
         "y" : 45
       },
       "hiddenSeries" : false,
-      "id" : 9,
+      "id" : 19,
       "legend" : {
         "avg" : false,
         "current" : false,

--- a/src/main/scala/temple/builder/MetricsBuilder.scala
+++ b/src/main/scala/temple/builder/MetricsBuilder.scala
@@ -69,12 +69,13 @@ object MetricsBuilder {
     datasource: Datasource,
     endpoints: SortedSet[CRUD],
     structName: Option[String] = None,
+    indexOffset: Int = 0,
   ): Seq[Row] =
     endpoints.toSeq.zipWithIndex.map {
       case (endpoint, index) =>
         Row(
           Metric(
-            index * 2,
+            (index + indexOffset) * 2,
             s"$endpoint ${structName.getOrElse(serviceName)} Requests",
             datasource,
             "QPS",
@@ -84,7 +85,7 @@ object MetricsBuilder {
             ),
           ),
           Metric(
-            index * 2 + 1,
+            (index + indexOffset) * 2 + 1,
             s"DB $endpoint ${structName.fold("Queries")(name => s"$name Queries")}",
             datasource,
             "Time (seconds)",

--- a/src/test/resources/project-builder-complex/grafana/provisioning/dashboards/complex-user.json
+++ b/src/test/resources/project-builder-complex/grafana/provisioning/dashboards/complex-user.json
@@ -1077,7 +1077,7 @@
         "y" : 25
       },
       "hiddenSeries" : false,
-      "id" : 0,
+      "id" : 10,
       "legend" : {
         "avg" : false,
         "current" : false,
@@ -1177,7 +1177,7 @@
         "y" : 25
       },
       "hiddenSeries" : false,
-      "id" : 1,
+      "id" : 11,
       "legend" : {
         "avg" : false,
         "current" : false,
@@ -1287,7 +1287,7 @@
         "y" : 30
       },
       "hiddenSeries" : false,
-      "id" : 2,
+      "id" : 12,
       "legend" : {
         "avg" : false,
         "current" : false,
@@ -1387,7 +1387,7 @@
         "y" : 30
       },
       "hiddenSeries" : false,
-      "id" : 3,
+      "id" : 13,
       "legend" : {
         "avg" : false,
         "current" : false,
@@ -1497,7 +1497,7 @@
         "y" : 35
       },
       "hiddenSeries" : false,
-      "id" : 4,
+      "id" : 14,
       "legend" : {
         "avg" : false,
         "current" : false,
@@ -1597,7 +1597,7 @@
         "y" : 35
       },
       "hiddenSeries" : false,
-      "id" : 5,
+      "id" : 15,
       "legend" : {
         "avg" : false,
         "current" : false,
@@ -1707,7 +1707,7 @@
         "y" : 40
       },
       "hiddenSeries" : false,
-      "id" : 6,
+      "id" : 16,
       "legend" : {
         "avg" : false,
         "current" : false,
@@ -1807,7 +1807,7 @@
         "y" : 40
       },
       "hiddenSeries" : false,
-      "id" : 7,
+      "id" : 17,
       "legend" : {
         "avg" : false,
         "current" : false,


### PR DESCRIPTION
Every panel we generate in Grafana needs to have a unique ID.

In the current implementation, we were assigning multiple panels the same ID, because we used the index. Rather, we need to use the index, offset by the number of panels we have already generated.