### PR TITLE
[openapi-gen] Remove 401 error code if auth isn't used

### DIFF
--- a/src/e2e/resources/attributes-temple-expected/api/attributes.openapi.yaml
+++ b/src/e2e/resources/attributes-temple-expected/api/attributes.openapi.yaml
@@ -31,8 +31,6 @@ paths:
                     type: boolean
         '400':
           $ref: '#/components/responses/Error400'
-        '401':
-          $ref: '#/components/responses/Error401'
         '500':
           $ref: '#/components/responses/Error500'
   /example/{id}:
@@ -63,8 +61,6 @@ paths:
                     type: boolean
         '400':
           $ref: '#/components/responses/Error400'
-        '401':
-          $ref: '#/components/responses/Error401'
         '404':
           $ref: '#/components/responses/Error404'
         '500':
@@ -96,8 +92,6 @@ paths:
                     type: boolean
         '400':
           $ref: '#/components/responses/Error400'
-        '401':
-          $ref: '#/components/responses/Error401'
         '404':
           $ref: '#/components/responses/Error404'
         '500':
@@ -116,8 +110,6 @@ paths:
                 properties: {}
         '400':
           $ref: '#/components/responses/Error400'
-        '401':
-          $ref: '#/components/responses/Error401'
         '404':
           $ref: '#/components/responses/Error404'
         '500':
@@ -134,16 +126,6 @@ components:
               error:
                 type: string
                 example: 'Invalid request parameters: name'
-    Error401:
-      description: Valid request but forbidden by server
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              error:
-                type: string
-                example: Not authorised to create this object
     Error404:
       description: ID not found
       content:

--- a/src/e2e/resources/simple-temple-expected/api/simple-temple-test.openapi.yaml
+++ b/src/e2e/resources/simple-temple-expected/api/simple-temple-test.openapi.yaml
@@ -152,6 +152,8 @@ paths:
                 be found
               schema:
                 type: string
+        '401':
+          $ref: '#/components/responses/Error401'
         '404':
           $ref: '#/components/responses/Error404'
         '500':

--- a/src/main/scala/temple/generate/target/openapi/OpenAPIGenerator.scala
+++ b/src/main/scala/temple/generate/target/openapi/OpenAPIGenerator.scala
@@ -113,13 +113,12 @@ private class OpenAPIGenerator private (
             tags = tags,
             security = securitySchemeName,
             responses = Seq(
-              200 -> ResponseObject(
-                s"$capitalizedName list successfully fetched",
-                Some(jsonContent(MediaTypeObject(OpenAPIArray(generateItemType(service.attributes))))),
-              ),
-              401 -> Response.Ref(useError(401)),
-              500 -> Response.Ref(useError(500)),
-            ),
+                200 -> ResponseObject(
+                  s"$capitalizedName list successfully fetched",
+                  Some(jsonContent(MediaTypeObject(OpenAPIArray(generateItemType(service.attributes))))),
+                ),
+                500 -> Response.Ref(useError(500)),
+              ) ++ securityScheme.map(_ => 401 -> Response.Ref(useError(401))),
           )
       case Create =>
         path(s"$prefix", lowerName) += HTTPVerb.Post -> Handler(
@@ -129,14 +128,13 @@ private class OpenAPIGenerator private (
             requestBody =
               Some(RequestBodyObject(jsonContent(MediaTypeObject(generateItemInputType(service.attributes))))),
             responses = Seq(
-              200 -> ResponseObject(
-                s"$capitalizedName successfully created",
-                Some(jsonContent(MediaTypeObject(generateItemType(service.attributes)))),
-              ),
-              400 -> Response.Ref(useError(400)),
-              401 -> Response.Ref(useError(401)),
-              500 -> Response.Ref(useError(500)),
-            ),
+                200 -> ResponseObject(
+                  s"$capitalizedName successfully created",
+                  Some(jsonContent(MediaTypeObject(generateItemType(service.attributes)))),
+                ),
+                400 -> Response.Ref(useError(400)),
+                500 -> Response.Ref(useError(500)),
+              ) ++ securityScheme.map(_ => 401 -> Response.Ref(useError(401))),
           )
       case Read =>
         path(s"$prefix/{id}", lowerName) += HTTPVerb.Get -> Handler(
@@ -144,15 +142,14 @@ private class OpenAPIGenerator private (
             tags = tags,
             security = securitySchemeName,
             responses = Seq(
-              200 -> ResponseObject(
-                s"$capitalizedName details",
-                Some(jsonContent(MediaTypeObject(generateItemType(service.attributes)))),
-              ),
-              400 -> Response.Ref(useError(400)),
-              401 -> Response.Ref(useError(401)),
-              404 -> Response.Ref(useError(404)),
-              500 -> Response.Ref(useError(500)),
-            ),
+                200 -> ResponseObject(
+                  s"$capitalizedName details",
+                  Some(jsonContent(MediaTypeObject(generateItemType(service.attributes)))),
+                ),
+                400 -> Response.Ref(useError(400)),
+                404 -> Response.Ref(useError(404)),
+                500 -> Response.Ref(useError(500)),
+              ) ++ securityScheme.map(_ => 401 -> Response.Ref(useError(401))),
           )
       case Update =>
         path(s"$prefix/{id}", lowerName) += HTTPVerb.Put -> Handler(
@@ -162,15 +159,14 @@ private class OpenAPIGenerator private (
             requestBody =
               Some(RequestBodyObject(jsonContent(MediaTypeObject(generateItemInputType(service.attributes))))),
             responses = Seq(
-              200 -> ResponseObject(
-                s"$capitalizedName successfully updated",
-                Some(jsonContent(MediaTypeObject(generateItemType(service.attributes)))),
-              ),
-              400 -> Response.Ref(useError(400)),
-              401 -> Response.Ref(useError(401)),
-              404 -> Response.Ref(useError(404)),
-              500 -> Response.Ref(useError(500)),
-            ),
+                200 -> ResponseObject(
+                  s"$capitalizedName successfully updated",
+                  Some(jsonContent(MediaTypeObject(generateItemType(service.attributes)))),
+                ),
+                400 -> Response.Ref(useError(400)),
+                404 -> Response.Ref(useError(404)),
+                500 -> Response.Ref(useError(500)),
+              ) ++ securityScheme.map(_ => 401 -> Response.Ref(useError(401))),
           )
       case Delete =>
         path(s"$prefix/{id}", lowerName) += HTTPVerb.Delete -> Handler(
@@ -178,15 +174,14 @@ private class OpenAPIGenerator private (
             tags = tags,
             security = securitySchemeName,
             responses = Seq(
-              200 -> ResponseObject(
-                s"$capitalizedName successfully deleted",
-                Some(jsonContent(MediaTypeObject(OpenAPIObject(Map())))),
-              ),
-              400 -> Response.Ref(useError(400)),
-              401 -> Response.Ref(useError(401)),
-              404 -> Response.Ref(useError(404)),
-              500 -> Response.Ref(useError(500)),
-            ),
+                200 -> ResponseObject(
+                  s"$capitalizedName successfully deleted",
+                  Some(jsonContent(MediaTypeObject(OpenAPIObject(Map())))),
+                ),
+                400 -> Response.Ref(useError(400)),
+                404 -> Response.Ref(useError(404)),
+                500 -> Response.Ref(useError(500)),
+              ) ++ securityScheme.map(_ => 401 -> Response.Ref(useError(401))),
           )
       case Identify =>
         path(s"$prefix", lowerName) += HTTPVerb.Get -> Handler(
@@ -206,6 +201,7 @@ private class OpenAPIGenerator private (
                   ),
                 ),
               ),
+              401 -> Response.Ref(useError(401)),
               404 -> Response.Ref(useError(404)),
               500 -> Response.Ref(useError(500)),
             ),

--- a/src/main/scala/temple/generate/target/openapi/ast/Handler.scala
+++ b/src/main/scala/temple/generate/target/openapi/ast/Handler.scala
@@ -38,5 +38,5 @@ object Handler {
     tags: Seq[String] = Nil,
     requestBody: Option[RequestBody] = None,
     responses: Seq[(Int, Response)] = Seq(),
-  ): Handler = Handler(summary, description, security, tags, requestBody, responses.to(ListMap))
+  ): Handler = Handler(summary, description, security, tags, requestBody, responses.sortBy(_._1).to(ListMap))
 }

--- a/src/test/resources/project-builder-complex/api/sample-complex-project.openapi.yaml
+++ b/src/test/resources/project-builder-complex/api/sample-complex-project.openapi.yaml
@@ -137,6 +137,8 @@ paths:
               description: The location where the single complexuser can be found
               schema:
                 type: string
+        '401':
+          $ref: '#/components/responses/Error401'
         '404':
           $ref: '#/components/responses/Error404'
         '500':

--- a/src/test/resources/project-builder-simple/api/sample-project.openapi.yaml
+++ b/src/test/resources/project-builder-simple/api/sample-project.openapi.yaml
@@ -69,8 +69,6 @@ paths:
                     type: string
         '400':
           $ref: '#/components/responses/Error400'
-        '401':
-          $ref: '#/components/responses/Error401'
         '500':
           $ref: '#/components/responses/Error500'
   /temple-user/{id}:
@@ -120,8 +118,6 @@ paths:
                     type: string
         '400':
           $ref: '#/components/responses/Error400'
-        '401':
-          $ref: '#/components/responses/Error401'
         '404':
           $ref: '#/components/responses/Error404'
         '500':
@@ -191,8 +187,6 @@ paths:
                     type: string
         '400':
           $ref: '#/components/responses/Error400'
-        '401':
-          $ref: '#/components/responses/Error401'
         '404':
           $ref: '#/components/responses/Error404'
         '500':
@@ -211,8 +205,6 @@ paths:
                 properties: {}
         '400':
           $ref: '#/components/responses/Error400'
-        '401':
-          $ref: '#/components/responses/Error401'
         '404':
           $ref: '#/components/responses/Error404'
         '500':
@@ -229,16 +221,6 @@ components:
               error:
                 type: string
                 example: 'Invalid request parameters: name'
-    Error401:
-      description: Valid request but forbidden by server
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              error:
-                type: string
-                example: Not authorised to create this object
     Error404:
       description: ID not found
       content:

--- a/src/test/scala/temple/generate/target/openapi/OpenAPIGeneratorTest.scala
+++ b/src/test/scala/temple/generate/target/openapi/OpenAPIGeneratorTest.scala
@@ -102,8 +102,6 @@ class OpenAPIGeneratorTest extends FlatSpec with Matchers {
         |                      type: number
         |                      format: int32
         |                      description: Reference to User ID
-        |        '401':
-        |          $ref: '#/components/responses/Error401'
         |        '500':
         |          $ref: '#/components/responses/Error500'
         |  /match:
@@ -173,8 +171,6 @@ class OpenAPIGeneratorTest extends FlatSpec with Matchers {
         |                    description: Reference to User ID
         |        '400':
         |          $ref: '#/components/responses/Error400'
-        |        '401':
-        |          $ref: '#/components/responses/Error401'
         |        '500':
         |          $ref: '#/components/responses/Error500'
         |    get:
@@ -189,6 +185,8 @@ class OpenAPIGeneratorTest extends FlatSpec with Matchers {
         |              description: The location where the single match can be found
         |              schema:
         |                type: string
+        |        '401':
+        |          $ref: '#/components/responses/Error401'
         |        '404':
         |          $ref: '#/components/responses/Error404'
         |        '500':
@@ -239,8 +237,6 @@ class OpenAPIGeneratorTest extends FlatSpec with Matchers {
         |                    description: Reference to User ID
         |        '400':
         |          $ref: '#/components/responses/Error400'
-        |        '401':
-        |          $ref: '#/components/responses/Error401'
         |        '404':
         |          $ref: '#/components/responses/Error404'
         |        '500':
@@ -311,8 +307,6 @@ class OpenAPIGeneratorTest extends FlatSpec with Matchers {
         |                    description: Reference to User ID
         |        '400':
         |          $ref: '#/components/responses/Error400'
-        |        '401':
-        |          $ref: '#/components/responses/Error401'
         |        '404':
         |          $ref: '#/components/responses/Error404'
         |        '500':
@@ -331,8 +325,6 @@ class OpenAPIGeneratorTest extends FlatSpec with Matchers {
         |                properties: {}
         |        '400':
         |          $ref: '#/components/responses/Error400'
-        |        '401':
-        |          $ref: '#/components/responses/Error401'
         |        '404':
         |          $ref: '#/components/responses/Error404'
         |        '500':


### PR DESCRIPTION
We don't need to include a 401 error unless there is a security scheme being used (which is indicative of an auth block in the project) - so.. let's do that!